### PR TITLE
docs: enforce required dev gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4618,6 +4618,7 @@ jobs:
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
               tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
+              tldw_Server_API/tests/Services/test_notes_graph_suggestions_workers.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -5897,6 +5898,7 @@ jobs:
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
               tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
+              tldw_Server_API/tests/Services/test_notes_graph_suggestions_workers.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -7182,6 +7184,7 @@ jobs:
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
               tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
+              tldw_Server_API/tests/Services/test_notes_graph_suggestions_workers.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py

--- a/Docs/Development/CI_REQUIRED_GATES.md
+++ b/Docs/Development/CI_REQUIRED_GATES.md
@@ -1,19 +1,39 @@
 # CI Required Gates
 
-This document defines the required pull-request gate contract during the phased CI rollout.
+This document defines the required pull-request gate contract for `dev`.
 
 ## Required Check Names
 
-Configure branch protection to require these checks:
+The active `dev-core-required-gates` repository ruleset requires these checks:
 
 1. `backend-required`
 2. `security-required`
 3. `coverage-required`
 4. `frontend-required`
 5. `e2e-required`
-6. `container-build-check` *(pending branch protection configuration)*
+6. `container-build-check`
 
-These check names are stable and should remain unchanged once branch protection is configured.
+These check names are stable and must remain unchanged. Each status is bound to
+GitHub Actions integration `15368`.
+
+## Live `dev` Enforcement
+
+GitHub aggregates two active, `dev`-only repository rulesets:
+
+- `dev-core-required-gates` (ID `21824526`) requires all six checks above,
+  uses strict/current-base enforcement, and has no bypass actors.
+- `frontend-license-gate-dev` (ID `19362594`) retains the pull-request rule
+  and requires `frontend-license-policy/trusted/dev` from integration `15368`.
+
+The effective pull-request rule sets the required approving-review count to
+zero, dismisses stale reviews after a push, and requires extra approval for
+unattributed changes.
+Neither ruleset grants an administrative bypass; GitHub reports
+`current_user_can_bypass: never` for both.
+
+If the additive core ruleset malfunctions, disable ruleset `21824526` without
+deleting it or modifying ruleset `19362594`, then record the before/after API
+responses in TASK-13013.2.
 
 ### Container Build Check Details
 
@@ -46,13 +66,18 @@ Examples:
 
 Expired allowlist entries are ignored by the gate.
 
-## Rollout Phases (2-4 Weeks)
+## Rollout Status
 
 1. Introduce required lanes and deterministic no-op semantics.
 2. Tighten blocking behavior across required lanes.
 3. Refine path coupling and flake handling in `e2e-required`.
-4. Finalize branch protection to required lane names above.
-5. Add `container-build-check` to branch protection required statuses.
+4. Enforce the required lane names on `dev` with strict/current-base checks.
+5. Enforce `container-build-check` with the other required statuses.
+
+The required-status enforcement described in phases 4 and 5 is complete for
+`dev` as of 2026-08-29. The controlled TASK-13013.2 proof PR recorded a
+failing `coverage-required` check from integration `15368` and GitHub reported
+the ready pull request as `BLOCKED`.
 
 ## Legacy CI Workflow
 

--- a/Docs/superpowers/evidence/TASK-13013.2/README.md
+++ b/Docs/superpowers/evidence/TASK-13013.2/README.md
@@ -1,0 +1,50 @@
+# TASK-13013.2 Dev Required-Gate Evidence
+
+TASK-13013.2 activated the additive `dev-core-required-gates` repository
+ruleset and proved that a source-bound failing required check blocks a ready
+pull request to `dev`.
+
+## Result
+
+- Ruleset `21824526` is active and targets only `refs/heads/dev`.
+- It requires `backend-required`, `security-required`, `coverage-required`,
+  `frontend-required`, `e2e-required`, and `container-build-check`.
+- Every context is bound to GitHub Actions integration `15368`.
+- `strict_required_status_checks_policy` is `true`.
+- `bypass_actors` is empty and GitHub reports
+  `current_user_can_bypass: never`.
+- Existing ruleset `19362594` remained normalized-policy identical to its
+  pre-change snapshot.
+
+## Controlled Failure Proof
+
+Temporary PR [#2835](https://github.com/rmusser01/tldw_server/pull/2835)
+used exact head `6475cef3c03ef7c39bfe84f7f49030d568881e95`, a mechanical revert of
+the known AuthNZ fixture correction. Five canonical required gates passed;
+`coverage-required` failed from integration `15368` at
+[Actions job 99167420781](https://github.com/rmusser01/tldw_server/actions/runs/33277727573/job/99167420781).
+After the PR was marked ready, GitHub reported `mergeStateStatus: BLOCKED`.
+Both applicable rulesets reported no bypass capability. The PR was then closed
+unmerged and the remote proof branch was deleted.
+
+## Evidence Files
+
+- `dev-required-gates-before.json`
+  - SHA-256 `cb96daac66afbd0b90e5e5a0703a44f7c6e255098eae3dff3a1e4c38868254fc`
+- `dev-core-required-gates-payload.json`
+  - SHA-256 `88be53a4d825bf6994b9f9cfceb43a33aacc2e3e313b8f1613e1e57306b0f2c3`
+- `dev-required-gates-after.json`
+  - SHA-256 `c03acd795035512e4592c39f2b5a4aabb35bb320c9584e5bdb66b9c8733b1775`
+- `failing-check-proof.json`
+  - SHA-256 `6283f107d2939d685ec4126baa4d063effd13a83da6a492d258927301ad30d4c`
+
+All JSON files passed `python3 -m json.tool`. Live normalized comparisons
+verified the new payload, preserved ruleset `19362594`, and the effective
+seven-status `dev` policy.
+
+## Rollback
+
+If the canonical gate layer malfunctions, disable ruleset `21824526` without
+deleting it. Do not modify or delete ruleset `19362594`. Capture the disabling
+API response and the effective `dev` rules in this evidence directory and
+reopen TASK-13013.2 before any replacement policy is activated.

--- a/Docs/superpowers/evidence/TASK-13013.2/dev-core-required-gates-payload.json
+++ b/Docs/superpowers/evidence/TASK-13013.2/dev-core-required-gates-payload.json
@@ -1,0 +1,49 @@
+{
+  "name": "dev-core-required-gates",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/dev"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "backend-required",
+            "integration_id": 15368
+          },
+          {
+            "context": "security-required",
+            "integration_id": 15368
+          },
+          {
+            "context": "coverage-required",
+            "integration_id": 15368
+          },
+          {
+            "context": "frontend-required",
+            "integration_id": 15368
+          },
+          {
+            "context": "e2e-required",
+            "integration_id": 15368
+          },
+          {
+            "context": "container-build-check",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-after.json
+++ b/Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-after.json
@@ -1,0 +1,118 @@
+{
+  "ruleset_created_at": "2026-08-29T22:03:22.739Z",
+  "repository": "rmusser01/tldw_server",
+  "dev_head": "41bd5dda336c70259595ebf3ce3fb4a6a5b549db",
+  "created_ruleset": {
+    "id": 21824526,
+    "name": "dev-core-required-gates",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "current_user_can_bypass": "never",
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": [
+          "refs/heads/dev"
+        ]
+      }
+    },
+    "rules": [
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "strict_required_status_checks_policy": true,
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            {
+              "context": "backend-required",
+              "integration_id": 15368
+            },
+            {
+              "context": "security-required",
+              "integration_id": 15368
+            },
+            {
+              "context": "coverage-required",
+              "integration_id": 15368
+            },
+            {
+              "context": "frontend-required",
+              "integration_id": 15368
+            },
+            {
+              "context": "e2e-required",
+              "integration_id": 15368
+            },
+            {
+              "context": "container-build-check",
+              "integration_id": 15368
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "preserved_ruleset": {
+    "id": 19362594,
+    "name": "frontend-license-gate-dev",
+    "normalized_policy_matches_before": true
+  },
+  "effective_dev_rules": [
+    {
+      "type": "required_status_checks",
+      "ruleset_id": 21824526,
+      "strict_required_status_checks_policy": true,
+      "required_status_checks": [
+        {
+          "context": "backend-required",
+          "integration_id": 15368
+        },
+        {
+          "context": "security-required",
+          "integration_id": 15368
+        },
+        {
+          "context": "coverage-required",
+          "integration_id": 15368
+        },
+        {
+          "context": "frontend-required",
+          "integration_id": 15368
+        },
+        {
+          "context": "e2e-required",
+          "integration_id": 15368
+        },
+        {
+          "context": "container-build-check",
+          "integration_id": 15368
+        }
+      ]
+    },
+    {
+      "type": "pull_request",
+      "ruleset_id": 19362594,
+      "required_approving_review_count": 0,
+      "dismiss_stale_reviews_on_push": true,
+      "require_extra_approval_for_unattributed_changes": true
+    },
+    {
+      "type": "required_status_checks",
+      "ruleset_id": 19362594,
+      "strict_required_status_checks_policy": false,
+      "required_status_checks": [
+        {
+          "context": "frontend-license-policy/trusted/dev",
+          "integration_id": 15368
+        }
+      ]
+    }
+  ],
+  "rollback": {
+    "action": "disable_only",
+    "ruleset_id": 21824526,
+    "existing_ruleset_id": 19362594,
+    "existing_ruleset_must_remain_unchanged": true
+  }
+}

--- a/Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-before.json
+++ b/Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-before.json
@@ -1,0 +1,131 @@
+{
+  "repository": "rmusser01/tldw_server",
+  "dev_head": "41bd5dda336c70259595ebf3ce3fb4a6a5b549db",
+  "merged_baseline_pr": {
+    "number": 2831,
+    "url": "https://github.com/rmusser01/tldw_server/pull/2831",
+    "head": "c336469210016866a9bb877d5ac473916180c47e",
+    "merge_commit": "41bd5dda336c70259595ebf3ce3fb4a6a5b549db"
+  },
+  "rulesets": [
+    {
+      "id": 19362594,
+      "name": "frontend-license-gate-dev",
+      "target": "branch",
+      "enforcement": "active"
+    },
+    {
+      "id": 5653432,
+      "name": "safee",
+      "target": "branch",
+      "enforcement": "active"
+    }
+  ],
+  "dev_ruleset": {
+    "id": 19362594,
+    "name": "frontend-license-gate-dev",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "current_user_can_bypass": "never",
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": [
+          "refs/heads/dev"
+        ]
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 0,
+          "dismiss_stale_reviews_on_push": true,
+          "required_reviewers": [],
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_review_thread_resolution": false,
+          "require_extra_approval_for_unattributed_changes": true,
+          "allowed_merge_methods": [
+            "merge"
+          ]
+        }
+      },
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "strict_required_status_checks_policy": false,
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            {
+              "context": "frontend-license-policy/trusted/dev",
+              "integration_id": 15368
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "effective_dev_rules": [
+    {
+      "type": "pull_request",
+      "ruleset_id": 19362594
+    },
+    {
+      "type": "required_status_checks",
+      "ruleset_id": 19362594,
+      "strict_required_status_checks_policy": false,
+      "required_status_checks": [
+        {
+          "context": "frontend-license-policy/trusted/dev",
+          "integration_id": 15368
+        }
+      ]
+    }
+  ],
+  "canonical_check_runs": [
+    {
+      "name": "backend-required",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516900/job/99060572535"
+    },
+    {
+      "name": "container-build-check",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516843/job/99057626986"
+    },
+    {
+      "name": "coverage-required",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516862/job/99057205527"
+    },
+    {
+      "name": "e2e-required",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516919/job/99055542157"
+    },
+    {
+      "name": "frontend-required",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516897/job/99083416438"
+    },
+    {
+      "name": "security-required",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33231516847/job/99056445805"
+    }
+  ]
+}

--- a/Docs/superpowers/evidence/TASK-13013.2/failing-check-proof.json
+++ b/Docs/superpowers/evidence/TASK-13013.2/failing-check-proof.json
@@ -1,0 +1,90 @@
+{
+  "captured_at": "2026-08-29T22:25:49Z",
+  "repository": "rmusser01/tldw_server",
+  "proof_pr": {
+    "number": 2835,
+    "url": "https://github.com/rmusser01/tldw_server/pull/2835",
+    "base": "dev",
+    "head": "6475cef3c03ef7c39bfe84f7f49030d568881e95",
+    "source_change": "mechanical revert of c336469210016866a9bb877d5ac473916180c47e",
+    "ready_state": {
+      "is_draft": false,
+      "state": "OPEN",
+      "mergeable": "MERGEABLE",
+      "merge_state_status": "BLOCKED"
+    },
+    "cleanup_state": {
+      "state": "CLOSED",
+      "closed_at": "2026-08-29T22:25:24Z",
+      "merged_at": null,
+      "remote_branch_deleted": true
+    }
+  },
+  "canonical_check_runs": [
+    {
+      "name": "backend-required",
+      "status": "completed",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727560/job/99167372736"
+    },
+    {
+      "name": "container-build-check",
+      "status": "completed",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727565/job/99167893831"
+    },
+    {
+      "name": "coverage-required",
+      "status": "completed",
+      "conclusion": "failure",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727573/job/99167420781"
+    },
+    {
+      "name": "e2e-required",
+      "status": "completed",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727651/job/99167401701"
+    },
+    {
+      "name": "frontend-required",
+      "status": "completed",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727756/job/99167451044"
+    },
+    {
+      "name": "security-required",
+      "status": "completed",
+      "conclusion": "success",
+      "app_id": 15368,
+      "app_slug": "github-actions",
+      "details_url": "https://github.com/rmusser01/tldw_server/actions/runs/33277727661/job/99167532189"
+    }
+  ],
+  "enforcement": {
+    "failing_required_check": "coverage-required",
+    "failing_check_source_integration_id": 15368,
+    "ready_pr_merge_state_status": "BLOCKED",
+    "additive_ruleset": {
+      "id": 21824526,
+      "name": "dev-core-required-gates",
+      "current_user_can_bypass": "never",
+      "bypass_actors": []
+    },
+    "preserved_ruleset": {
+      "id": 19362594,
+      "name": "frontend-license-gate-dev",
+      "current_user_can_bypass": "never",
+      "bypass_actors": []
+    }
+  }
+}

--- a/Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
+++ b/Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
@@ -122,7 +122,7 @@
 - [x] Replace the stale pending-enforcement prose with the exact active ruleset name/ID, strict policy, integration binding, no-bypass policy, and retained frontend-license layer.
 - [x] Document that the effective approval policy remains the existing dev pull-request rule: zero required approving reviews, stale reviews dismissed, extra approval required for unattributed changes, and no ruleset bypass actors.
 - [x] Summarize the before/after and controlled proof in the evidence README without credentials or transient API tokens.
-- [ ] Mark all TASK-13013.2 acceptance criteria and Definition of Done items complete; record Bandit as not applicable because only Markdown/Backlog records changed.
+- [x] Mark all TASK-13013.2 acceptance criteria and Definition of Done items complete; record Bandit as not applicable because only Markdown/Backlog records changed.
 
 ### Task 5: Verify and publish the closeout branch
 
@@ -133,9 +133,9 @@
 - Consumes: committed documentation/evidence/task changes and the active live policy.
 - Produces: one reviewable closeout PR based on current `dev`.
 
-- [ ] Validate every evidence JSON file with `python3 -m json.tool` without installing dependencies.
-- [ ] Re-run the live normalized ruleset comparisons and effective `dev` rule assertions.
-- [ ] Run `git diff --check` and scan the changed files for credentials or private infrastructure details.
-- [ ] Commit the exact documentation, evidence, and Backlog scope.
-- [ ] Push `codex/task-13013-2-required-gates` and open a PR to `dev` with the ruleset/proof evidence.
-- [ ] Verify the PR head, base, changed paths, and hosted required-gate status; do not merge without a separate user decision.
+- [x] Validate every evidence JSON file with `python3 -m json.tool` without installing dependencies.
+- [x] Re-run the live normalized ruleset comparisons and effective `dev` rule assertions.
+- [x] Run `git diff --check` and scan the changed files for credentials or private infrastructure details.
+- [x] Commit the exact documentation, evidence, and Backlog scope.
+- [x] Push `codex/task-13013-2-required-gates` and open PR #2836 to `dev` with the ruleset/proof evidence.
+- [x] Verify PR #2836 head, base, nine changed paths, and attached hosted required-gate status; do not merge without a separate user decision.

--- a/Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
+++ b/Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
@@ -1,0 +1,141 @@
+# TASK-13013.2 Required Dev Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every canonical required CI gate strict and non-bypassable on `dev`, with live evidence that a known failing required check blocks a pull request.
+
+**Architecture:** Preserve the existing `frontend-license-gate-dev` ruleset byte-for-byte and add one independent `dev-core-required-gates` layer. GitHub aggregates the two layers: the existing layer continues to require a pull request and the trusted frontend-license status, while the new layer requires the six canonical GitHub Actions checks with strict/current-base enforcement and no bypass actors.
+
+**Tech Stack:** GitHub repository rulesets REST API through `gh`, GitHub Actions check runs, Backlog.md CLI, Markdown evidence, Git.
+
+**Spec:** `Docs/superpowers/specs/2026-08-21-core-release-readiness-program-design.md`
+
+## Global Constraints
+
+- The authoritative base is merged `origin/dev` commit `41bd5dda336c70259595ebf3ce3fb4a6a5b549db` or a later descendant verified immediately before the live change.
+- Never update or delete ruleset `19362594`; its normalized JSON must remain unchanged.
+- The additive ruleset targets only `refs/heads/dev`, has no bypass actors, and contains only the required-status-check rule.
+- Each required context is bound to GitHub Actions integration `15368`; never fall back to an unbound source.
+- Stop without mutation when the audited live state, check source, branch, or same-named ruleset differs from this plan.
+- A failed verification disables, but does not delete, only the new additive ruleset.
+- The proof branch and pull request are temporary and must never merge. Keep the PR draft until a required check fails; mark it ready only long enough to capture ruleset-derived `BLOCKED`, then close it.
+- Do not install software or modify system files.
+
+---
+
+### Task 1: Freeze the live pre-change authority
+
+**Files:**
+- Create: `Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-before.json`
+- Modify: `backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md`
+
+**Interfaces:**
+- Consumes: live repository rulesets, effective `dev` rules, canonical check names, merged PR #2831 check runs.
+- Produces: exact normalized pre-change evidence and a fail-closed authorization decision.
+
+- [x] Capture ruleset `19362594`, the ruleset list, and effective `dev` rules with `gh api`.
+- [x] Verify ruleset `19362594` is active, targets only `dev`, has no bypass actors, requires a pull request, and requires only `frontend-license-policy/trusted/dev` from integration `15368`.
+- [x] Verify the six canonical checks on PR #2831 head `c336469210016866a9bb877d5ac473916180c47e` all concluded `success` and each came from integration `15368`.
+- [x] Verify no ruleset named `dev-core-required-gates` exists; if one exists, require exact normalized policy equality or stop.
+- [x] Record the complete pre-change JSON and SHA-256 digest in the evidence file.
+
+### Task 2: Create the additive strict ruleset
+
+**Files:**
+- Create: `Docs/superpowers/evidence/TASK-13013.2/dev-core-required-gates-payload.json`
+- Create: `Docs/superpowers/evidence/TASK-13013.2/dev-required-gates-after.json`
+
+**Interfaces:**
+- Consumes: the frozen Task 1 evidence.
+- Produces: one active, dev-only, strict, no-bypass six-check ruleset.
+
+- [x] Materialize this exact normalized payload:
+
+```json
+{
+  "name": "dev-core-required-gates",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/dev"]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {"context": "backend-required", "integration_id": 15368},
+          {"context": "security-required", "integration_id": 15368},
+          {"context": "coverage-required", "integration_id": 15368},
+          {"context": "frontend-required", "integration_id": 15368},
+          {"context": "e2e-required", "integration_id": 15368},
+          {"context": "container-build-check", "integration_id": 15368}
+        ]
+      }
+    }
+  ]
+}
+```
+
+- [x] POST the payload once with `gh api --method POST repos/rmusser01/tldw_server/rulesets --input <payload>`.
+- [x] Read the created ruleset back and require normalized equality with the payload.
+- [x] Re-read ruleset `19362594` and require byte-for-byte normalized equality with the Task 1 snapshot.
+- [x] Read effective `dev` rules and require all seven statuses: the trusted frontend-license status plus the six canonical gates, with the canonical layer strict.
+- [x] On any mismatch, PUT only the new ruleset to `enforcement: disabled`, record the response, and stop. No mismatch occurred.
+
+### Task 3: Prove a failing required gate blocks merge
+
+**Files:**
+- Create: `Docs/superpowers/evidence/TASK-13013.2/failing-check-proof.json`
+
+**Interfaces:**
+- Consumes: the active additive ruleset, known failing pre-fix commit `237ea28e3d01dd79252013df0012ddd3734c8ace`, and its focused correction commit `c336469210016866a9bb877d5ac473916180c47e`.
+- Produces: a temporary draft PR whose required failure and blocked merge state are captured without merging.
+
+- [x] Verify commit `237ea28e3d01dd79252013df0012ddd3734c8ace` is the parent of correction commit `c336469210016866a9bb877d5ac473916180c47e` and its hosted `coverage-required` check failed from integration `15368`.
+- [x] Create temporary branch `codex/task-13013-2-ruleset-proof` from current `dev` and revert only correction commit `c336469210016866a9bb877d5ac473916180c47e`; this preserves the repaired workflow admission while reproducing the known AuthNZ coverage failure.
+- [x] Verify the proof branch differs from `dev` only by that mechanical revert, then push its exact head.
+- [x] Open a draft PR to `dev` titled `test: prove required dev gate enforcement` and label its body as non-mergeable temporary proof.
+- [x] Wait only for one canonical required check to conclude failure; do not rerun or repair it.
+- [x] Verify the exact PR head remains fixed, mark it ready after the failure, then require `mergeStateStatus: BLOCKED`, integration `15368`, and no bypass on either applicable ruleset.
+- [x] Capture PR URL, head SHA, failing check, Actions URL, applicable rules, merge state, and bypass state.
+- [x] Close the proof PR and delete only `codex/task-13013-2-ruleset-proof` from the remote.
+- [x] Verify the PR is closed/unmerged and the proof branch no longer exists.
+
+### Task 4: Publish the canonical policy and close the task
+
+**Files:**
+- Modify: `Docs/Development/CI_REQUIRED_GATES.md`
+- Create: `Docs/superpowers/evidence/TASK-13013.2/README.md`
+- Modify: `backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 evidence.
+- Produces: current canonical documentation, auditable ruleset identifiers, rollback instructions, and a complete task record.
+
+- [x] Replace the stale pending-enforcement prose with the exact active ruleset name/ID, strict policy, integration binding, no-bypass policy, and retained frontend-license layer.
+- [x] Document that the effective approval policy remains the existing dev pull-request rule: zero required approving reviews, stale reviews dismissed, extra approval required for unattributed changes, and no ruleset bypass actors.
+- [x] Summarize the before/after and controlled proof in the evidence README without credentials or transient API tokens.
+- [ ] Mark all TASK-13013.2 acceptance criteria and Definition of Done items complete; record Bandit as not applicable because only Markdown/Backlog records changed.
+
+### Task 5: Verify and publish the closeout branch
+
+**Files:**
+- Test: all files changed by Tasks 1-4.
+
+**Interfaces:**
+- Consumes: committed documentation/evidence/task changes and the active live policy.
+- Produces: one reviewable closeout PR based on current `dev`.
+
+- [ ] Validate every evidence JSON file with `python3 -m json.tool` without installing dependencies.
+- [ ] Re-run the live normalized ruleset comparisons and effective `dev` rule assertions.
+- [ ] Run `git diff --check` and scan the changed files for credentials or private infrastructure details.
+- [ ] Commit the exact documentation, evidence, and Backlog scope.
+- [ ] Push `codex/task-13013-2-required-gates` and open a PR to `dev` with the ruleset/proof evidence.
+- [ ] Verify the PR head, base, changed paths, and hosted required-gate status; do not merge without a separate user decision.

--- a/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
+++ b/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13013.1
 title: Restore all required CI gates to green on the current dev release line
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-29 03:28'
+updated_date: '2026-08-29 22:00'
 labels:
   - release-readiness
   - ci
@@ -23,9 +23,9 @@ Diagnose and repair the required-gate failure present at the audited dev head, b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Checked-in OpenAPI schemas and fingerprints match the runtime API for the exact verified commit.
-- [ ] #2 Every documented required backend, security, coverage, frontend, end-to-end, and container gate passes on one exact candidate.
-- [ ] #3 The root cause, verification commands, workflow run links, and any baseline-only skips are recorded.
+- [x] #1 Checked-in OpenAPI schemas and fingerprints match the runtime API for the exact verified commit.
+- [x] #2 Every documented required backend, security, coverage, frontend, end-to-end, and container gate passes on one exact candidate.
+- [x] #3 The root cause, verification commands, workflow run links, and any baseline-only skips are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -44,14 +44,22 @@ Draft PR: https://github.com/rmusser01/tldw_server/pull/2831. Branch pushed from
 2026-08-28 hosted coverage correction: migrated stale AuthNZ_SQLite user setup to the production guarded/versioned write path, bound the SQLite API-key repository tests to SQLite instead of the PostgreSQL fixture, modeled BYOK absence with a physical fixture delete, and updated guard-boundary expectations. Production AuthNZ code is unchanged. Exact hosted-equivalent coverage command is GREEN: 215 passed in 267.64s, total coverage 40.93% against 35% floor. Required/license-first workflow contracts: 56 passed. Ruff: new helper fully clean; all touched tests clean for E9/F63/F7/F82. Bandit medium/high: none. git diff --check: clean. No installs or system-file changes.
 
 Final-byte verification before commit: hosted-equivalent AuthNZ coverage gate passed 215/215 in 263.95s with 40.87% coverage (35% floor). The earlier 40.93% figure was the preceding successful run; both exceeded the gate. Final git diff --check clean and production app diff empty.
+
+2026-08-29 final hosted evidence: PR #2831 exact head c336469210016866a9bb877d5ac473916180c47e passed backend-required, security-required, coverage-required, frontend-required, e2e-required, every container-build-check job including the aggregate, and onboarding-docs-gate. PR merged to dev as merge commit 41bd5dda336c70259595ebf3ce3fb4a6a5b549db. PR: https://github.com/rmusser01/tldw_server/pull/2831
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Restored the required CI baseline on the current dev release line. Corrected direct-PR gate admission, refreshed the runtime OpenAPI fingerprint, published ADR-041, fixed stale AuthNZ test fixtures without relaxing production safeguards, and added regression coverage. All required hosted gates passed on exact head c336469210016866a9bb877d5ac473916180c47e; PR #2831 merged to dev as 41bd5dda336c70259595ebf3ce3fb4a6a5b549db. No known blockers or skipped required checks remain.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
+++ b/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13013.2
 title: Enforce the documented required gates on dev
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
+updated_date: '2026-08-29 22:30'
 labels:
   - release-readiness
   - ci
@@ -26,6 +27,24 @@ Align the live GitHub ruleset with the repository's documented required-gate pol
 - [ ] #2 Required checks are strict or otherwise prove that the reviewed head is current before merge.
 - [ ] #3 The approval policy and administrative bypass policy are explicit and a controlled failing-check proof demonstrates enforcement.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-08-29 approved design: preserve live ruleset 19362594 byte-for-byte; add one dev-only strict no-bypass ruleset requiring the six canonical GitHub Actions checks from integration 15368; prove enforcement with a temporary controlled failing-check draft PR; disable the additive layer and stop if validation fails. Read-only audit confirmed current dev effective rules contain only frontend-license-policy/trusted/dev and strict=false.
+
+2026-08-29 live enforcement: created additive ruleset dev-core-required-gates ID 21824526, active only on refs/heads/dev, strict=true, no bypass actors, current_user_can_bypass=never, and exactly six required contexts bound to GitHub Actions integration 15368. Existing ruleset 19362594 remained normalized-policy identical.
+
+Controlled proof: temporary PR #2835 exact head 6475cef3c03ef7c39bfe84f7f49030d568881e95 mechanically reverted only the known AuthNZ fixture correction. backend, security, frontend, e2e, and container aggregate passed; coverage-required failed from integration 15368 at https://github.com/rmusser01/tldw_server/actions/runs/33277727573/job/99167420781. After marking the PR ready, GitHub reported BLOCKED and both rulesets reported no bypass. PR closed unmerged; remote proof branch deleted.
+
+Verification: live payload/effective-policy/preserved-ruleset comparisons PASS; proof cleanup PASS; four evidence JSON files passed python3 -m json.tool; required-workflow and release-helper modules passed 85 tests in 10.63s; git diff --check PASS. Bandit is not applicable because TASK-13013.2 changes only Markdown, JSON evidence, and Backlog records. No known blocker or skipped required verification.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
+++ b/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
@@ -4,7 +4,7 @@ title: Enforce the documented required gates on dev
 status: Done
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-29 22:33'
+updated_date: '2026-08-30 01:00'
 labels:
   - release-readiness
   - ci
@@ -46,12 +46,18 @@ Controlled proof: temporary PR #2835 exact head 6475cef3c03ef7c39bfe84f7f49030d5
 Verification: live payload/effective-policy/preserved-ruleset comparisons PASS; proof cleanup PASS; four evidence JSON files passed python3 -m json.tool; required-workflow and release-helper modules passed 85 tests in 10.63s; git diff --check PASS. Bandit is not applicable because TASK-13013.2 changes only Markdown, JSON evidence, and Backlog records. No known blocker or skipped required verification.
 
 Closeout PR: https://github.com/rmusser01/tldw_server/pull/2836. Initial exact head 78068ff8a191f993f5e395e0ea9346718072a29c, base dev, nine expected documentation/evidence/Backlog paths, merge state BLOCKED while the newly enforced required checks run. No merge is authorized without a separate user decision.
+
+2026-08-29 latest-dev delivery refresh: rebasing the two patch-identical closeout commits onto dev 00c900cfc7 exposed a current-dev shard-coverage regression introduced after the original PR base. Existing contract test_full_suite_splits_slow_chat_and_retrieval_shards failed 1/85 because test_notes_graph_suggestions_workers.py is assigned in only two of five repeated full-suite matrices. The PR will remain unpushed until the existing RED is closed with the minimal repeated-matrix metadata correction and the full required verification is green.
+
+2026-08-29 current-dev shard correction: root cause was TASK-13138 commit 9ccccea369 assigning test_notes_graph_suggestions_workers.py to only Linux 3.12 and Linux 3.13 while the workflow contract requires identical platform-service coverage across macOS 3.12, Windows 3.12, and release OS/Python 3.13 matrices. Added the same exact test path to those three existing platform-services-core lists; no application code, new shard, ignore, baseline expansion, dependency, or system change. Existing RED was 1 failed/84 passed. GREEN: exact regression 1 passed; required-workflow plus release-helper modules 85 passed in 9.33s; shard authority PASS with 789 shards, 4460 test files, baseline 130, and new_uncovered=0. Bandit remains not applicable because the correction changes workflow YAML and Backlog metadata only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Enforced the documented dev CI policy with additive ruleset 21824526: six canonical checks, GitHub Actions integration 15368, strict/current-base policy, no bypass actors. Preserved existing pull-request/license ruleset 19362594 unchanged. Controlled PR #2835 proved failing coverage-required blocks a ready PR and was closed unmerged with its branch deleted. Published audited before/after/proof evidence and rollback instructions in PR #2836. Verification includes 85 passing focused tests, valid evidence JSON/hashes, clean diff/credential scan, and fresh live-policy comparisons. No known blockers or skipped required verification; Bandit is not applicable to the documentation/evidence-only change.
+
+During latest-dev delivery refresh, closed one inherited CI coverage hole by assigning the Notes graph suggestion worker test to the three repeated full-suite matrices that omitted it. The existing contract and shard authority now pass without weakening coverage.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
+++ b/backlog/tasks/task-13013.2 - Enforce-the-documented-required-gates-on-dev.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13013.2
 title: Enforce the documented required gates on dev
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-29 22:30'
+updated_date: '2026-08-29 22:33'
 labels:
   - release-readiness
   - ci
@@ -23,9 +23,9 @@ Align the live GitHub ruleset with the repository's documented required-gate pol
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The dev ruleset requires every check named by the canonical required-gates documentation.
-- [ ] #2 Required checks are strict or otherwise prove that the reviewed head is current before merge.
-- [ ] #3 The approval policy and administrative bypass policy are explicit and a controlled failing-check proof demonstrates enforcement.
+- [x] #1 The dev ruleset requires every check named by the canonical required-gates documentation.
+- [x] #2 Required checks are strict or otherwise prove that the reviewed head is current before merge.
+- [x] #3 The approval policy and administrative bypass policy are explicit and a controlled failing-check proof demonstrates enforcement.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,14 +44,22 @@ Docs/superpowers/plans/2026-08-29-task-13013-2-required-gates.md
 Controlled proof: temporary PR #2835 exact head 6475cef3c03ef7c39bfe84f7f49030d568881e95 mechanically reverted only the known AuthNZ fixture correction. backend, security, frontend, e2e, and container aggregate passed; coverage-required failed from integration 15368 at https://github.com/rmusser01/tldw_server/actions/runs/33277727573/job/99167420781. After marking the PR ready, GitHub reported BLOCKED and both rulesets reported no bypass. PR closed unmerged; remote proof branch deleted.
 
 Verification: live payload/effective-policy/preserved-ruleset comparisons PASS; proof cleanup PASS; four evidence JSON files passed python3 -m json.tool; required-workflow and release-helper modules passed 85 tests in 10.63s; git diff --check PASS. Bandit is not applicable because TASK-13013.2 changes only Markdown, JSON evidence, and Backlog records. No known blocker or skipped required verification.
+
+Closeout PR: https://github.com/rmusser01/tldw_server/pull/2836. Initial exact head 78068ff8a191f993f5e395e0ea9346718072a29c, base dev, nine expected documentation/evidence/Backlog paths, merge state BLOCKED while the newly enforced required checks run. No merge is authorized without a separate user decision.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Enforced the documented dev CI policy with additive ruleset 21824526: six canonical checks, GitHub Actions integration 15368, strict/current-base policy, no bypass actors. Preserved existing pull-request/license ruleset 19362594 unchanged. Controlled PR #2835 proved failing coverage-required blocks a ready PR and was closed unmerged with its branch deleted. Published audited before/after/proof evidence and rollback instructions in PR #2836. Verification includes 85 passing focused tests, valid evidence JSON/hashes, clean diff/credential scan, and fresh live-policy comparisons. No known blockers or skipped required verification; Bandit is not applicable to the documentation/evidence-only change.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- activate and document strict dev ruleset 21824526 for all six canonical required gates
- preserve frontend-license ruleset 19362594 and record the explicit approval/no-bypass policy
- publish before/after JSON, rollback instructions, and controlled failing-check proof from closed PR #2835
- close TASK-13013.1 after merged PR #2831 and complete TASK-13013.2 evidence

## Verification
- 85 passed: required workflow contracts + release helper tests
- four evidence JSON files pass python3 -m json.tool with recorded SHA-256 digests
- live normalized payload, preserved ruleset, effective dev policy, and proof cleanup checks pass
- git diff --check and credential-pattern scan pass
- Bandit not applicable: Markdown, JSON evidence, and Backlog records only

The live additive ruleset is already active and was proven to block a ready PR with failing coverage-required. This PR records the reviewed policy and evidence; do not merge without the user's separate decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the live `dev` required-gates enforcement and its controlled blocking proof, and fixes a CI coverage hole so the required-gate checks run green on the current dev head.

- Adds a previously missing Notes graph suggestion worker test to the three repeated full-suite CI matrices.
- Documents the `dev-core-required-gates` ruleset, rollback path, before/after snapshots, and controlled proof under TASK-13013.2.
- Closes TASK-13013.1 and TASK-13013.2.

**Rollout action**

- The ruleset is already live; do not merge without a separate user decision.
- Rollback: disable ruleset `21824526` without deleting it; keep ruleset `19362594` untouched.

<sup>Written for commit 8c3ebfe7a815badc09f8e563d88815c7a31e4b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

