### PR TITLE
fix(auth): harden trusted proxy login lockouts

### DIFF
--- a/Docs/Deployment/horizontal-scaling.md
+++ b/Docs/Deployment/horizontal-scaling.md
@@ -227,7 +227,7 @@ volumes:
 - Use **least-connections** or **round-robin** balancing for stateless REST endpoints.
 - Enable **sticky sessions** (IP hash or cookie-based) if clients rely on WebSocket connections or SSE streams, since the event broadcaster is per-instance.
 - Set appropriate health check paths: `GET /api/v1/config/quickstart` or a dedicated `/health` endpoint.
-- Forward the original client IP via `X-Forwarded-For` and configure `RG_CLIENT_IP_HEADER` and `RG_TRUSTED_PROXIES` so the Resource Governor sees real client IPs.
+- Forward the original client IP via `X-Forwarded-For`. Forwarded identity is opt-in and is trusted only when the physical peer is a valid IP in the subsystem's trusted-proxy host/CIDR list.
 
 ### nginx example
 
@@ -263,15 +263,21 @@ server {
 
 ### Trusted proxy configuration
 
-Set these environment variables on each app instance so the Resource Governor resolves client IPs correctly behind a reverse proxy:
+Set these environment variables on each app instance when forwarding is enabled. If both AuthNZ and Resource Governor use forwarded identity, their trusted-proxy sets must be equivalent and their headers compatible so login lockouts and request governance derive the same client identity:
 
 ```bash
-# Header containing the real client IP
+# Resource Governor: header and trusted proxy CIDRs
 RG_CLIENT_IP_HEADER=X-Forwarded-For
-
-# CIDR ranges of trusted proxies (comma-separated)
 RG_TRUSTED_PROXIES=172.16.0.0/12,10.0.0.0/8
+
+# AuthNZ: explicit opt-in and equivalent trusted proxy CIDRs
+AUTH_TRUST_X_FORWARDED_FOR=true
+AUTH_TRUSTED_PROXY_IPS=172.16.0.0/12,10.0.0.0/8
 ```
+
+- `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward (right-to-left); malformed chains fall back to the physical peer. Other `RG_CLIENT_IP_HEADER` values must contain one plain IP literal.
+- Invalid physical peers resolve to the safe `unknown` sentinel. Leaving the AuthNZ opt-in or either RG setting unset uses the physical peer.
+- Rollout no longer consults legacy raw-IP password-login buckets; account-wide lockout and Resource Governor protections remain active.
 
 ## Monitoring
 

--- a/Docs/Operations/Env_Vars.md
+++ b/Docs/Operations/Env_Vars.md
@@ -328,8 +328,9 @@ The Resource Governor (RG) is the **primary enforcement path** for all rate limi
 - `RG_REDIS_FAIL_MODE`: Behavior when Redis is unavailable (`fail_open` | `fail_closed` | `fallback_memory`). Default `fail_open`.
 
 ### Client Identity
-- `RG_TRUSTED_PROXIES`: Comma-separated list of trusted proxy IPs for `X-Forwarded-For` resolution.
-- `RG_CLIENT_IP_HEADER`: Custom header for client IP extraction (e.g., `CF-Connecting-IP`).
+- `RG_TRUSTED_PROXIES`: Comma-separated trusted-proxy host/CIDR list. This is opt-in: forwarding is used only when the physical peer is a valid IP in this list.
+- `RG_CLIENT_IP_HEADER`: Header used with `RG_TRUSTED_PROXIES`; leave either setting unset to use the physical peer. `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward (right-to-left), and malformed chains fall back to the physical peer. Any other header value must contain one plain IP literal.
+- Invalid physical peers resolve to the safe `unknown` sentinel.
 
 ### Per-Module Policy Overrides
 - `RG_CHAT_POLICY_ID`: Override chat policy ID (default `chat.default`).
@@ -374,6 +375,10 @@ The following env vars are retained as **deprecated compatibility knobs** during
 
 ## AuthNZ (Authentication)
 - `AUTH_MODE`: `single_user` | `multi_user`.
+- `AUTH_TRUST_X_FORWARDED_FOR`: Opt in to trusted forwarded identity for AuthNZ (default `false`). Use with `AUTH_TRUSTED_PROXY_IPS`.
+- `AUTH_TRUSTED_PROXY_IPS`: Comma-separated trusted-proxy host/CIDR list. Forwarded identity is used only when the physical peer is a valid IP in this list.
+- When both AuthNZ and Resource Governor forwarding are enabled, configure equivalent trusted-proxy sets and compatible headers so password-login lockouts and request governance derive the same client identity. AuthNZ uses `AUTH_TRUST_X_FORWARDED_FOR=true` plus `AUTH_TRUSTED_PROXY_IPS=<proxy IP/CIDR list>`; Resource Governor uses `RG_CLIENT_IP_HEADER=X-Forwarded-For` plus `RG_TRUSTED_PROXIES=<equivalent proxy IP/CIDR list>`.
+- Rollout no longer consults legacy raw-IP password-login buckets. Account-wide lockout and Resource Governor protections remain active.
 - `DATABASE_URL`: AuthNZ database URL. For production multi-user, use Postgres (e.g., `postgresql://user:pass@host:5432/db`). SQLite supported for dev.
 - `SINGLE_USER_API_KEY`: API key for single-user mode (>=24 chars recommended in production).
 - `JWT_SECRET_KEY`: JWT signing secret (>=32 chars). Required for `multi_user` in production.

--- a/Docs/Published/Deployment/horizontal-scaling.md
+++ b/Docs/Published/Deployment/horizontal-scaling.md
@@ -227,7 +227,7 @@ volumes:
 - Use **least-connections** or **round-robin** balancing for stateless REST endpoints.
 - Enable **sticky sessions** (IP hash or cookie-based) if clients rely on WebSocket connections or SSE streams, since the event broadcaster is per-instance.
 - Set appropriate health check paths: `GET /api/v1/config/quickstart` or a dedicated `/health` endpoint.
-- Forward the original client IP via `X-Forwarded-For` and configure `RG_CLIENT_IP_HEADER` and `RG_TRUSTED_PROXIES` so the Resource Governor sees real client IPs.
+- Forward the original client IP via `X-Forwarded-For`. Forwarded identity is opt-in and is trusted only when the physical peer is a valid IP in the subsystem's trusted-proxy host/CIDR list.
 
 ### nginx example
 
@@ -263,15 +263,21 @@ server {
 
 ### Trusted proxy configuration
 
-Set these environment variables on each app instance so the Resource Governor resolves client IPs correctly behind a reverse proxy:
+Set these environment variables on each app instance when forwarding is enabled. If both AuthNZ and Resource Governor use forwarded identity, their trusted-proxy sets must be equivalent and their headers compatible so login lockouts and request governance derive the same client identity:
 
 ```bash
-# Header containing the real client IP
+# Resource Governor: header and trusted proxy CIDRs
 RG_CLIENT_IP_HEADER=X-Forwarded-For
-
-# CIDR ranges of trusted proxies (comma-separated)
 RG_TRUSTED_PROXIES=172.16.0.0/12,10.0.0.0/8
+
+# AuthNZ: explicit opt-in and equivalent trusted proxy CIDRs
+AUTH_TRUST_X_FORWARDED_FOR=true
+AUTH_TRUSTED_PROXY_IPS=172.16.0.0/12,10.0.0.0/8
 ```
+
+- `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward (right-to-left); malformed chains fall back to the physical peer. Other `RG_CLIENT_IP_HEADER` values must contain one plain IP literal.
+- Invalid physical peers resolve to the safe `unknown` sentinel. Leaving the AuthNZ opt-in or either RG setting unset uses the physical peer.
+- Rollout no longer consults legacy raw-IP password-login buckets; account-wide lockout and Resource Governor protections remain active.
 
 ## Monitoring
 

--- a/Docs/Published/Env_Vars.md
+++ b/Docs/Published/Env_Vars.md
@@ -256,7 +256,7 @@ Notes:
 ## Chat Commands & Weather
 - `CHAT_COMMANDS_ENABLED`: Enable slash-command preprocessing (`true|false`, default `false`).
 - `CHAT_COMMAND_INJECTION_MODE`: Slash-command injection mode (`system|preface|replace`, default `system`).
-- `CHAT_COMMANDS_REQUIRE_PERMISSIONS`: Require per-command RBAC permission checks (`true|false`, default `false`).
+- `CHAT_COMMANDS_REQUIRE_PERMISSIONS`: Deprecated compatibility flag; declared per-command permissions are enforced whenever slash commands are enabled.
 - `CHAT_COMMANDS_RATE_LIMIT_USER`: Per-user, per-command RPM limit (accepts `10` or `10/min`; default `10`).
 - `CHAT_COMMANDS_RATE_LIMIT`: Backward-compatible alias for `CHAT_COMMANDS_RATE_LIMIT_USER`.
 - `CHAT_COMMANDS_RATE_LIMIT_GLOBAL`: Global, per-command RPM limit (accepts `100` or `100/min`; default `100`).
@@ -264,6 +264,7 @@ Notes:
 - `DEFAULT_LOCATION`: Optional fallback location for `/weather` when no argument is supplied.
 - `WEATHER_PROVIDER`: Weather backend (`openweather`, `noop`, `none`, `disabled`; default `openweather`).
 - `OPENWEATHER_API_KEY`: API key for the `openweather` provider.
+- `EGRESS_ALLOWLIST`: Must include `api.openweathermap.org` when the `openweather` provider is enabled; policy denial returns weather as unavailable without making the request.
 - `WEATHER_UNITS`: Unit system for weather summaries (`metric|imperial`, default `metric`).
 - `WEATHER_LANG`: OpenWeather language code for descriptions (default `en`).
 - `WEATHER_TIMEOUT_MS`: OpenWeather HTTP timeout in milliseconds (default `1500`).
@@ -327,8 +328,9 @@ The Resource Governor (RG) is the **primary enforcement path** for all rate limi
 - `RG_REDIS_FAIL_MODE`: Behavior when Redis is unavailable (`fail_open` | `fail_closed` | `fallback_memory`). Default `fail_open`.
 
 ### Client Identity
-- `RG_TRUSTED_PROXIES`: Comma-separated list of trusted proxy IPs for `X-Forwarded-For` resolution.
-- `RG_CLIENT_IP_HEADER`: Custom header for client IP extraction (e.g., `CF-Connecting-IP`).
+- `RG_TRUSTED_PROXIES`: Comma-separated trusted-proxy host/CIDR list. This is opt-in: forwarding is used only when the physical peer is a valid IP in this list.
+- `RG_CLIENT_IP_HEADER`: Header used with `RG_TRUSTED_PROXIES`; leave either setting unset to use the physical peer. `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward (right-to-left), and malformed chains fall back to the physical peer. Any other header value must contain one plain IP literal.
+- Invalid physical peers resolve to the safe `unknown` sentinel.
 
 ### Per-Module Policy Overrides
 - `RG_CHAT_POLICY_ID`: Override chat policy ID (default `chat.default`).
@@ -373,6 +375,10 @@ The following env vars are retained as **deprecated compatibility knobs** during
 
 ## AuthNZ (Authentication)
 - `AUTH_MODE`: `single_user` | `multi_user`.
+- `AUTH_TRUST_X_FORWARDED_FOR`: Opt in to trusted forwarded identity for AuthNZ (default `false`). Use with `AUTH_TRUSTED_PROXY_IPS`.
+- `AUTH_TRUSTED_PROXY_IPS`: Comma-separated trusted-proxy host/CIDR list. Forwarded identity is used only when the physical peer is a valid IP in this list.
+- When both AuthNZ and Resource Governor forwarding are enabled, configure equivalent trusted-proxy sets and compatible headers so password-login lockouts and request governance derive the same client identity. AuthNZ uses `AUTH_TRUST_X_FORWARDED_FOR=true` plus `AUTH_TRUSTED_PROXY_IPS=<proxy IP/CIDR list>`; Resource Governor uses `RG_CLIENT_IP_HEADER=X-Forwarded-For` plus `RG_TRUSTED_PROXIES=<equivalent proxy IP/CIDR list>`.
+- Rollout no longer consults legacy raw-IP password-login buckets. Account-wide lockout and Resource Governor protections remain active.
 - `DATABASE_URL`: AuthNZ database URL. For production multi-user, use Postgres (e.g., `postgresql://user:pass@host:5432/db`). SQLite supported for dev.
 - `SINGLE_USER_API_KEY`: API key for single-user mode (>=24 chars recommended in production).
 - `JWT_SECRET_KEY`: JWT signing secret (>=32 chars). Required for `multi_user` in production.

--- a/Docs/superpowers/plans/2026-08-29-task-13013-5-trusted-proxy-login-lockout.md
+++ b/Docs/superpowers/plans/2026-08-29-task-13013-5-trusted-proxy-login-lockout.md
@@ -1,0 +1,1045 @@
+# TASK-13013.5 Trusted Proxy Identity and Login Lockout Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve client identity safely across trusted proxy chains and isolate password-login lockouts by client/login pair while retaining account-wide and Resource Governor protections.
+
+**Architecture:** Add one pure standard-library trusted-hop resolver under `app/core/Security`, then keep AuthNZ and Resource Governor as thin compatibility wrappers around their existing environment-variable families. Build one versioned deterministic login/client key in the auth endpoint, use it for password-failure checks and records, and carry that opaque key through the existing server-side MFA payload so success resets the original attempt's buckets.
+
+**Tech Stack:** Python 3.11, `ipaddress`, `hashlib`, JSON, FastAPI/Starlette request headers, pytest, Ruff, Bandit, Backlog.md, MkDocs published-doc refresh, Git.
+
+**Spec:** `Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md`
+
+## Global Constraints
+
+- Base all implementation work on `codex/task-13013-5-trusted-proxy-lockout` at design commit `0291c94412` or a direct descendant whose merge base with `origin/dev` remains `f676e23549ea8ed82ef53493260621a05b281863`.
+- Keep `AUTH_TRUST_X_FORWARDED_FOR`, `AUTH_TRUSTED_PROXY_IPS`, `RG_TRUSTED_PROXIES`, and `RG_CLIENT_IP_HEADER` unchanged.
+- Use only Python's standard library for the shared resolver and lockout-key format; add no dependency or dependency-manifest change.
+- Return only canonical compressed IPv4/IPv6 literals or `None` from the shared resolver; never log raw forwarding values or parser exception text.
+- Never rewrite `request.client`; do not change audit, setup, authorization, WebSocket, or unrelated middleware identity behavior.
+- Add no database model, migration, retention sweep, or cleanup heuristic for legacy raw-IP rows.
+- Encode new client/login lockout identifiers exactly as `login-client-v1:<64 lowercase SHA-256 hex>` over compact JSON `[canonical_client_or_unknown, stripped_lower_login_identifier]`.
+- Preserve the existing account-wide bucket keyed by the stored canonical username and the existing Resource Governor controls.
+- Treat `Docs/Published` as generated output: edit canonical source docs, run `Helper_Scripts/refresh_docs_published.sh`, and never hand-edit generated mirrors.
+- Use the existing `../../.venv` tools; install nothing and modify no system file.
+- Keep TASK-13013.5 current through Backlog.md MCP/CLI and keep deferred global middleware work under TASK-13144.
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/Security/trusted_proxy.py`: pure IP/network parsing and trusted-hop selection only.
+- Create `tldw_Server_API/tests/Security/test_trusted_proxy.py`: exhaustive resolver contract with no FastAPI dependency.
+- Modify `tldw_Server_API/app/core/AuthNZ/ip_allowlist.py`: AuthNZ settings/request adapter and existing allowlist helpers.
+- Modify `tldw_Server_API/app/core/Resource_Governance/deps.py`: Resource Governor environment/request adapter; remove the invalid-peer-to-loopback shortcut.
+- Modify `tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py`: AuthNZ precedence, repeated-header, sentinel, and compatibility coverage.
+- Modify `tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py`: Resource Governor XFF/custom-header and invalid-peer coverage.
+- Modify `tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py`: middleware-level identity regression coverage.
+- Modify `tldw_Server_API/app/api/v1/endpoints/auth.py`: composite key helpers and password/MFA lockout flow only.
+- Modify `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`: deterministic key and exact password/MFA call-sequence coverage.
+- Modify `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`: HTTP-surface isolation and threshold coverage.
+- Modify `tldw_Server_API/app/core/Resource_Governance/README.md`, `Docs/Operations/Env_Vars.md`, and `Docs/Deployment/horizontal-scaling.md`: retained variables, chain semantics, and equivalent-config warning.
+- Regenerate `Docs/Published/Env_Vars.md` and `Docs/Published/Deployment/horizontal-scaling.md` with the existing refresh script.
+- Modify `backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md` only through Backlog.md MCP/CLI.
+
+---
+
+### Task 1: Implement the pure trusted-hop resolver
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Security/trusted_proxy.py`
+- Create: `tldw_Server_API/tests/Security/test_trusted_proxy.py`
+
+**Interfaces:**
+- Consumes: physical peer `str | None`, trusted proxy host/CIDR strings, ordered XFF field values, and an optional strict single-address field.
+- Produces: `resolve_trusted_client_ip(physical_peer, trusted_proxy_entries, *, forwarded_for_values=(), single_forwarded_value=None) -> str | None` and `is_trusted_proxy_peer(physical_peer, trusted_proxy_entries) -> bool`.
+
+- [ ] **Step 1: Write the direct-peer and trust-boundary tests**
+
+Create the test module with literal expectations for canonicalization, disabled forwarding, untrusted spoofing, invalid trusted entries, and invalid peers:
+
+```python
+import pytest
+
+from tldw_Server_API.app.core.Security.trusted_proxy import (
+    is_trusted_proxy_peer,
+    resolve_trusted_client_ip,
+)
+
+
+@pytest.mark.parametrize(
+    ("peer", "expected"),
+    [
+        ("203.0.113.7", "203.0.113.7"),
+        ("2001:0db8:0:0::7", "2001:db8::7"),
+        (None, None),
+        ("testclient", None),
+        ("127.0.0.1:8000", None),
+    ],
+)
+def test_direct_peer_is_canonical_or_absent(peer, expected):
+    assert resolve_trusted_client_ip(peer, ()) == expected
+
+
+def test_untrusted_peer_cannot_select_forwarded_identity():
+    assert resolve_trusted_client_ip(
+        "198.51.100.8",
+        ("10.0.0.0/8", "not-a-network"),
+        forwarded_for_values=("203.0.113.9",),
+        single_forwarded_value="192.0.2.4",
+    ) == "198.51.100.8"
+
+
+def test_trusted_peer_predicate_accepts_hosts_and_cidrs():
+    entries = ("192.0.2.10", "2001:db8:abcd::/48", "invalid")
+    assert is_trusted_proxy_peer("192.0.2.10", entries) is True
+    assert is_trusted_proxy_peer("2001:db8:abcd::4", entries) is True
+    assert is_trusted_proxy_peer("203.0.113.4", entries) is False
+```
+
+- [ ] **Step 2: Write the XFF and strict-single-field matrix**
+
+Add explicit tests for overwritten/appended XFF, repeated fields in wire order, attacker-prepended values, multi-proxy chains, all-trusted fallback, malformed/empty/decorated tokens, IPv6, and strict single values:
+
+```python
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (("203.0.113.9",), "203.0.113.9"),
+        (("198.51.100.99, 203.0.113.9, 10.0.0.2",), "203.0.113.9"),
+        (("198.51.100.99", "203.0.113.9, 10.0.0.2"), "203.0.113.9"),
+        (("2001:db8:ffff::9, 2001:db8:abcd::2",), "2001:db8:ffff::9"),
+        (("10.0.0.2, 10.0.0.3",), "10.0.0.1"),
+        (("203.0.113.9,,10.0.0.2",), "10.0.0.1"),
+        (("203.0.113.9:443,10.0.0.2",), "10.0.0.1"),
+        (("[2001:db8::9],10.0.0.2",), "10.0.0.1"),
+        (("for=203.0.113.9,10.0.0.2",), "10.0.0.1"),
+        (("fe80::1%eth0,10.0.0.2",), "10.0.0.1"),
+    ],
+)
+def test_xff_is_scanned_from_trusted_edge(values, expected):
+    assert resolve_trusted_client_ip(
+        "10.0.0.1",
+        ("10.0.0.0/8", "2001:db8:abcd::/48"),
+        forwarded_for_values=values,
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("203.0.113.9", "203.0.113.9"),
+        ("2001:0db8::9", "2001:db8::9"),
+        ("203.0.113.9, 10.0.0.2", "10.0.0.1"),
+        ("", "10.0.0.1"),
+        ("[2001:db8::9]", "10.0.0.1"),
+    ],
+)
+def test_single_forwarded_field_accepts_exactly_one_plain_ip(value, expected):
+    assert resolve_trusted_client_ip(
+        "10.0.0.1",
+        ("10.0.0.0/8",),
+        single_forwarded_value=value,
+    ) == expected
+```
+
+- [ ] **Step 3: Run the resolver tests and preserve the RED result**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/Security/test_trusted_proxy.py -q
+```
+
+Expected: collection fails because `Security.trusted_proxy` does not exist.
+
+- [ ] **Step 4: Implement the minimal pure resolver**
+
+Create the module with no logging, environment, FastAPI, or request imports:
+
+```python
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Iterable
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+def _parse_ip(value: str | None) -> IPAddress | None:
+    if not isinstance(value, str):
+        return None
+    token = value.strip()
+    if not token:
+        return None
+    try:
+        return ipaddress.ip_address(token)
+    except ValueError:
+        return None
+
+
+def _parse_networks(entries: Iterable[str]) -> tuple[IPNetwork, ...]:
+    networks: list[IPNetwork] = []
+    for entry in entries:
+        token = str(entry).strip()
+        if not token:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(token, strict=False))
+        except ValueError:
+            continue
+    return tuple(networks)
+
+
+def _address_is_trusted(address: IPAddress, networks: tuple[IPNetwork, ...]) -> bool:
+    return any(address.version == network.version and address in network for network in networks)
+
+
+def is_trusted_proxy_peer(
+    physical_peer: str | None,
+    trusted_proxy_entries: Iterable[str],
+) -> bool:
+    peer = _parse_ip(physical_peer)
+    return peer is not None and _address_is_trusted(peer, _parse_networks(trusted_proxy_entries))
+
+
+def resolve_trusted_client_ip(
+    physical_peer: str | None,
+    trusted_proxy_entries: Iterable[str],
+    *,
+    forwarded_for_values: Iterable[str] = (),
+    single_forwarded_value: str | None = None,
+) -> str | None:
+    peer = _parse_ip(physical_peer)
+    if peer is None:
+        return None
+    networks = _parse_networks(trusted_proxy_entries)
+    if not _address_is_trusted(peer, networks):
+        return peer.compressed
+
+    xff_values = tuple(str(value) for value in forwarded_for_values)
+    if xff_values:
+        parsed_chain: list[IPAddress] = []
+        for token in ",".join(xff_values).split(","):
+            parsed = _parse_ip(token)
+            if parsed is None:
+                return peer.compressed
+            parsed_chain.append(parsed)
+        for address in reversed(parsed_chain):
+            if not _address_is_trusted(address, networks):
+                return address.compressed
+        return peer.compressed
+
+    if single_forwarded_value is not None:
+        forwarded = _parse_ip(single_forwarded_value)
+        return forwarded.compressed if forwarded is not None else peer.compressed
+    return peer.compressed
+```
+
+- [ ] **Step 5: Run the focused resolver suite and static checks**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/Security/test_trusted_proxy.py -q
+../../.venv/bin/ruff check tldw_Server_API/app/core/Security/trusted_proxy.py tldw_Server_API/tests/Security/test_trusted_proxy.py
+../../.venv/bin/python -m py_compile tldw_Server_API/app/core/Security/trusted_proxy.py tldw_Server_API/tests/Security/test_trusted_proxy.py
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 6: Commit the pure resolver**
+
+```bash
+git add tldw_Server_API/app/core/Security/trusted_proxy.py tldw_Server_API/tests/Security/test_trusted_proxy.py
+git commit -m "fix: resolve trusted proxy chains safely"
+```
+
+---
+
+### Task 2: Delegate AuthNZ and Resource Governor wrappers to the resolver
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/AuthNZ/ip_allowlist.py:1-102`
+- Modify: `tldw_Server_API/app/core/Resource_Governance/deps.py:15-119`
+- Modify: `tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py`
+- Modify: `tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py`
+- Modify: `tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py`
+
+**Interfaces:**
+- Consumes: Task 1 `resolve_trusted_client_ip()` and `is_trusted_proxy_peer()`.
+- Produces: unchanged public wrappers `resolve_client_ip(request, settings=None) -> str | None` and `derive_client_ip(request) -> str`, with safe chain semantics and existing configuration names.
+
+- [ ] **Step 1: Add AuthNZ wrapper RED tests**
+
+Use a Starlette `Headers` object constructed with `raw=` so repeated XFF field occurrences are real and ordered. Assert XFF precedence, malformed-primary fallback, canonical output, invalid-peer `None`, disabled-header behavior, and strict X-Real-IP behavior:
+
+```python
+from types import SimpleNamespace
+
+from starlette.datastructures import Headers
+
+
+def _request(peer, raw_headers):
+    return SimpleNamespace(client=SimpleNamespace(host=peer), headers=Headers(raw=raw_headers))
+
+
+def _proxy_settings(enabled=True):
+    return SimpleNamespace(
+        AUTH_TRUST_X_FORWARDED_FOR=enabled,
+        AUTH_TRUSTED_PROXY_IPS=["10.0.0.0/8"],
+    )
+
+
+def test_resolve_client_ip_combines_repeated_xff_and_ignores_attacker_prefix():
+    request = _request(
+        "10.0.0.1",
+        [(b"x-forwarded-for", b"198.51.100.99"),
+         (b"x-forwarded-for", b"203.0.113.9, 10.0.0.2")],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "203.0.113.9"
+
+
+def test_resolve_client_ip_ignores_forwarding_when_disabled():
+    request = _request("10.0.0.1", [(b"x-forwarded-for", b"203.0.113.9")])
+    assert resolve_client_ip(request, _proxy_settings(enabled=False)) == "10.0.0.1"
+
+
+def test_xff_takes_precedence_over_x_real_ip():
+    request = _request(
+        "10.0.0.1",
+        [(b"x-forwarded-for", b"203.0.113.9"), (b"x-real-ip", b"198.51.100.4")],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "203.0.113.9"
+
+
+def test_malformed_xff_does_not_fall_through_to_x_real_ip():
+    request = _request(
+        "10.0.0.1",
+        [(b"x-forwarded-for", b"bad, 10.0.0.2"), (b"x-real-ip", b"203.0.113.4")],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "10.0.0.1"
+
+
+def test_repeated_x_real_ip_is_not_treated_as_a_single_address():
+    request = _request(
+        "10.0.0.1",
+        [(b"x-real-ip", b"203.0.113.4"), (b"x-real-ip", b"198.51.100.4")],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "10.0.0.1"
+
+
+def test_invalid_physical_peer_never_authorizes_forwarded_headers():
+    request = _request("testclient", [(b"x-forwarded-for", b"203.0.113.4")])
+    assert resolve_client_ip(request, _proxy_settings()) is None
+```
+
+- [ ] **Step 2: Add Resource Governor wrapper and middleware RED tests**
+
+Expand the existing request helper to support raw repeated headers, then assert right-to-left XFF, case-insensitive configured XFF, strict custom headers, invalid peer `unknown`, and middleware state propagation:
+
+```python
+@pytest.mark.asyncio
+async def test_xff_uses_first_untrusted_hop_from_the_right(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "x-FoRwArDeD-fOr")
+    request = _make_request(
+        peer="10.0.0.1",
+        raw_headers=[(b"x-forwarded-for", b"198.51.100.99, 203.0.113.9, 10.0.0.2")],
+    )
+    assert derive_client_ip(request) == "203.0.113.9"
+
+
+@pytest.mark.asyncio
+async def test_custom_header_is_single_ip_only(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "CF-Connecting-IP")
+    request = _make_request(
+        peer="10.0.0.1",
+        raw_headers=[(b"cf-connecting-ip", b"203.0.113.9, 10.0.0.2")],
+    )
+    assert derive_client_ip(request) == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_repeated_custom_header_is_not_treated_as_a_single_address(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "CF-Connecting-IP")
+    request = _make_request(
+        peer="10.0.0.1",
+        raw_headers=[(b"cf-connecting-ip", b"203.0.113.9"),
+                     (b"cf-connecting-ip", b"198.51.100.9")],
+    )
+    assert derive_client_ip(request) == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_peer_is_unknown_not_loopback(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "127.0.0.1")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "X-Forwarded-For")
+    request = _make_request(peer="testclient", raw_headers=[(b"x-forwarded-for", b"203.0.113.9")])
+    assert derive_client_ip(request) == "unknown"
+```
+
+- [ ] **Step 3: Run the wrapper matrix and preserve the RED result**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py -q
+```
+
+Expected: new tests fail because the wrappers still select the leftmost value and Resource Governor still converts invalid peers to loopback.
+
+- [ ] **Step 4: Replace AuthNZ's forwarding parser with a thin adapter**
+
+Import the Task 1 functions. Keep `_ip_in_allowlist()` for non-proxy allowlist behavior, but make `is_trusted_proxy_ip()` call `is_trusted_proxy_peer()`. Add a private header extractor that preserves repeated occurrences and use XFF before X-Real-IP:
+
+```python
+def _header_values(request: Any, name: str) -> tuple[str, ...]:
+    try:
+        headers = request.headers
+        getlist = getattr(headers, "getlist", None)
+        if callable(getlist):
+            return tuple(str(value) for value in getlist(name))
+        value = headers.get(name)
+        return (str(value),) if value is not None else ()
+    except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
+        return ()
+
+
+def is_trusted_proxy_ip(ip: str | None, settings: Settings | None = None) -> bool:
+    resolved_settings = settings or get_settings()
+    entries = _normalize_entries(
+        getattr(resolved_settings, "AUTH_TRUSTED_PROXY_IPS", None) or []
+    )
+    return is_trusted_proxy_peer(ip, entries)
+
+
+def resolve_client_ip(request: Any, settings: Settings | None = None) -> str | None:
+    if request is None:
+        return None
+    try:
+        resolved_settings = settings or get_settings()
+    except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
+        resolved_settings = settings
+    try:
+        peer = getattr(getattr(request, "client", None), "host", None)
+    except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
+        peer = None
+    trusted = _normalize_entries(
+        getattr(resolved_settings, "AUTH_TRUSTED_PROXY_IPS", None) or []
+    ) if resolved_settings is not None else []
+    if not bool(getattr(resolved_settings, "AUTH_TRUST_X_FORWARDED_FOR", False)):
+        trusted = []
+    xff = _header_values(request, "x-forwarded-for")
+    real_ip_values = () if xff else _header_values(request, "x-real-ip")
+    real_ip = real_ip_values[0] if len(real_ip_values) == 1 else None
+    return resolve_trusted_client_ip(
+        peer,
+        trusted,
+        forwarded_for_values=xff,
+        single_forwarded_value=real_ip,
+    )
+```
+
+- [ ] **Step 5: Replace Resource Governor's duplicated parser with a thin adapter**
+
+Delete `_parse_trusted_proxies()`, `_is_trusted_proxy()`, and the `testclient`-to-loopback shortcut. Split `RG_TRUSTED_PROXIES` into raw entries, distinguish XFF case-insensitively, and map the shared resolver's `None` to `unknown`:
+
+```python
+def derive_client_ip(request: Request) -> str:
+    try:
+        peer = request.client.host if request.client and request.client.host else None
+    except _RG_DEPS_NONCRITICAL_EXCEPTIONS:
+        peer = None
+    trusted = tuple(
+        part.strip()
+        for part in (os.getenv("RG_TRUSTED_PROXIES") or "").split(",")
+        if part.strip()
+    )
+    header_name = (os.getenv("RG_CLIENT_IP_HEADER") or "").strip()
+    xff_values: tuple[str, ...] = ()
+    single_value = None
+    if header_name:
+        if header_name.lower() == "x-forwarded-for":
+            xff_values = tuple(request.headers.getlist(header_name))
+        else:
+            header_values = tuple(request.headers.getlist(header_name))
+            single_value = header_values[0] if len(header_values) == 1 else None
+    resolved = resolve_trusted_client_ip(
+        peer,
+        trusted,
+        forwarded_for_values=xff_values,
+        single_forwarded_value=single_value,
+    )
+    return resolved or "unknown"
+```
+
+- [ ] **Step 6: Run focused and neighboring regression suites**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Security/test_trusted_proxy.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py -q
+../../.venv/bin/ruff check \
+  tldw_Server_API/app/core/Security/trusted_proxy.py \
+  tldw_Server_API/app/core/AuthNZ/ip_allowlist.py \
+  tldw_Server_API/app/core/Resource_Governance/deps.py \
+  tldw_Server_API/tests/Security/test_trusted_proxy.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
+git diff --check
+```
+
+Expected: every command exits 0; the pre-existing baseline of 15 wrapper/middleware tests remains green alongside the new matrix.
+
+- [ ] **Step 7: Commit the compatibility wrappers**
+
+```bash
+git add \
+  tldw_Server_API/app/core/AuthNZ/ip_allowlist.py \
+  tldw_Server_API/app/core/Resource_Governance/deps.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
+git commit -m "fix: share trusted proxy identity resolution"
+```
+
+---
+
+### Task 3: Introduce the stable client/login lockout key
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/auth.py:1-140, 966-990`
+- Modify: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+
+**Interfaces:**
+- Consumes: Task 2 canonical `_auth_request_client_ip()` output or `unknown`, plus the attempted identifier.
+- Produces: `_login_client_lockout_key(client_ip, login_identifier) -> str` and `_validated_login_client_lockout_key(value) -> str | None`.
+
+- [ ] **Step 1: Add exact key-format and validation RED tests**
+
+Add a known vector, normalization equivalence, alias distinction, unknown-client behavior, and malformed-key rejection:
+
+```python
+def test_login_client_lockout_key_has_stable_known_vector():
+    assert auth._login_client_lockout_key("203.0.113.9", " Alice@Example.COM ") == (
+        "login-client-v1:5573603ba3e0013f1788b2e3e4b7d67553500401252965ad3f2189a1a352b014"
+    )
+
+
+def test_login_client_lockout_key_normalizes_identifier_but_preserves_aliases():
+    by_email = auth._login_client_lockout_key("2001:db8::9", " USER@example.com ")
+    assert by_email == auth._login_client_lockout_key("2001:db8::9", "user@example.com")
+    assert by_email != auth._login_client_lockout_key("2001:db8::9", "user")
+    assert auth._login_client_lockout_key(None, "user").startswith("login-client-v1:")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "login-client-v1:", "login-client-v1:" + "A" * 64,
+     "login-client-v2:" + "a" * 64, "login-client-v1:" + "a" * 63,
+     "login-client-v1:" + "g" * 64],
+)
+def test_validated_login_client_lockout_key_rejects_noncanonical_values(value):
+    assert auth._validated_login_client_lockout_key(value) is None
+```
+
+- [ ] **Step 2: Add the invalid-physical-peer mapping RED test**
+
+Construct a request whose physical peer is `testclient` and whose XFF is spoofed. Assert `_auth_request_client_ip(request) == "unknown"`; this freezes removal of the current raw-peer fallback.
+
+- [ ] **Step 3: Run the helper selection and preserve the RED result**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q \
+  -k "login_client_lockout_key or invalid_physical_peer"
+```
+
+Expected: failures because the helpers do not exist and invalid peers still leak the raw placeholder.
+
+- [ ] **Step 4: Implement the versioned key and safe client sentinel**
+
+Import `hashlib`, add a compiled exact-key expression, and implement the helpers near `_auth_request_client_ip()`:
+
+```python
+_LOGIN_CLIENT_LOCKOUT_KEY_RE = re.compile(r"login-client-v1:[0-9a-f]{64}\Z")
+
+
+def _auth_request_client_ip(request: Request) -> str:
+    try:
+        settings = get_settings()
+    except _AUTH_NONCRITICAL_EXCEPTIONS:
+        settings = None
+    try:
+        return resolve_client_ip(request, settings) or "unknown"
+    except _AUTH_NONCRITICAL_EXCEPTIONS:
+        return "unknown"
+
+
+def _login_client_lockout_key(client_ip: str | None, login_identifier: str) -> str:
+    payload = json.dumps(
+        [client_ip or "unknown", login_identifier.strip().lower()],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"login-client-v1:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _validated_login_client_lockout_key(value: object) -> str | None:
+    return value if isinstance(value, str) and _LOGIN_CLIENT_LOCKOUT_KEY_RE.fullmatch(value) else None
+```
+
+- [ ] **Step 5: Run the helper tests and static checks**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q \
+  -k "login_client_lockout_key or invalid_physical_peer"
+../../.venv/bin/ruff check tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+../../.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/auth.py
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 6: Commit the stable-key contract**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+git commit -m "fix: add stable login client lockout keys"
+```
+
+---
+
+### Task 4: Isolate password-login failures without weakening account lockout
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/auth.py:1520-1930`
+- Modify: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- Modify: `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`
+
+**Interfaces:**
+- Consumes: Task 3 `_login_client_lockout_key()`, existing `AuthGovernor.check_lockout()` / `record_auth_failure()`, and `RateLimiter.reset_failed_attempts()`.
+- Produces: pre-fetch composite checking; composite-only unknown-user recording; composite-plus-account known-user recording; exact composite/account success reset.
+
+- [ ] **Step 1: Write unit tests for the exact password-login call order**
+
+Use recording stubs for `check_lockout`, `record_auth_failure`, and `reset_failed_attempts`. Cover these literal expectations:
+
+```python
+assert checked == [(composite_key, "login")]
+assert recorded_unknown == [(composite_key, "login")]
+assert recorded_bad_password == [
+    (composite_key, "login"),
+    ("stored_username", "login"),
+]
+assert reset_on_success == [
+    (composite_key, "login"),
+    ("stored_username", "login"),
+]
+```
+
+Add separate cases proving:
+
+```python
+assert auth._login_client_lockout_key("203.0.113.9", "alice") != \
+       auth._login_client_lockout_key("203.0.113.9", "bob")
+assert checked_for_email[1] == ("stored_username", "login")
+assert checked_for_username[1] == ("stored_username", "login")
+```
+
+The first assertion freezes shared-IP isolation; the latter two freeze username/email alias convergence on the account bucket.
+
+- [ ] **Step 2: Add HTTP-surface threshold and isolation tests**
+
+In the existing Postgres-backed integration module, teach `_StubLimiter` to record checked/failed/reset identifiers. Keep the existing same-client/same-login threshold test and add a case that submits three failures for `lockout_user` (the third reaches its 429 threshold), then a failure for `other_identifier`; assert the latter remains 401 rather than inheriting the first composite bucket's lockout. Assert every client-side recorded identifier matches `^login-client-v1:[0-9a-f]{64}$` and no raw physical IP is stored.
+
+- [ ] **Step 3: Run the password-login tests and preserve the RED result**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q \
+  -k "lockout or login_client"
+```
+
+Expected: new call-sequence and isolation assertions fail because the endpoint still checks, records, and resets raw client IP.
+
+- [ ] **Step 4: Compute the composite before the pre-fetch check**
+
+At login entry, normalize once with the same operation as `fetch_user_by_login_identifier()` and use the composite for the first check:
+
+```python
+client_ip = _auth_request_client_ip(request)
+login_identifier = form_data.username.strip().lower()
+client_login_lockout_key = _login_client_lockout_key(client_ip, login_identifier)
+
+if getattr(rate_limiter, "enabled", False):
+    is_locked, lockout_expires = await auth_gov.check_lockout(
+        client_login_lockout_key,
+        attempt_type="login",
+        rate_limiter=rate_limiter,
+    )
+```
+
+Keep the same sanitized 429 response and expiry calculation, but change internal counter names from IP-specific to client/login-specific language; do not include the opaque key in log messages.
+
+- [ ] **Step 5: Route failure and ordinary-success mutations to exact buckets**
+
+Replace the three raw-IP mutations:
+
+```python
+# Unknown user
+await auth_gov.record_auth_failure(
+    identifier=client_login_lockout_key,
+    attempt_type="login",
+    rate_limiter=rate_limiter,
+)
+
+# Invalid password
+client_result = await auth_gov.record_auth_failure(
+    identifier=client_login_lockout_key,
+    attempt_type="login",
+    rate_limiter=rate_limiter,
+)
+account_result = await auth_gov.record_auth_failure(
+    identifier=user["username"],
+    attempt_type="login",
+    rate_limiter=rate_limiter,
+)
+
+# Successful non-MFA login
+await rate_limiter.reset_failed_attempts(client_login_lockout_key, "login")
+await rate_limiter.reset_failed_attempts(user["username"], "login")
+```
+
+Keep the stored-username account lockout check before password verification. Determine the 429 response from either failure result exactly as the current endpoint does; merely rename `ip_result` to `client_result`.
+
+- [ ] **Step 6: Run unit and integration password-login gates**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q \
+  -k "lockout or login_client"
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q
+git diff --check
+```
+
+Expected: all selected unit tests and the complete HTTP integration module pass.
+
+- [ ] **Step 7: Commit password-login isolation**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/auth.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+git commit -m "fix: isolate password login lockouts"
+```
+
+---
+
+### Task 5: Carry the original composite key through MFA success
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/auth.py:1838-1883, 3442-3602`
+- Modify: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py:650-880, 1075-1135`
+
+**Interfaces:**
+- Consumes: Task 4 `client_login_lockout_key` and Task 3 `_validated_login_client_lockout_key()`.
+- Produces: MFA ephemeral JSON `{user_id, session_id, login_lockout_key}` and exact original-composite/account reset after successful MFA.
+
+- [ ] **Step 1: Add MFA payload and different-network RED tests**
+
+Extend the existing MFA challenge test to decode the stored ephemeral JSON and assert exact fields:
+
+```python
+cached = json.loads(session_manager.stored_value)
+assert cached == {
+    "user_id": 7,
+    "session_id": 41,
+    "login_lockout_key": auth._login_client_lockout_key("203.0.113.9", "mfa_user"),
+}
+assert "203.0.113.9" not in session_manager.stored_value
+assert "mfa_user" not in session_manager.stored_value
+```
+
+Extend the MFA completion test so the current request uses `198.51.100.44` while the cached payload contains a valid original key. Assert reset calls are exactly:
+
+```python
+assert reset_calls == [
+    (original_login_lockout_key, "login"),
+    ("mfa_user", "login"),
+]
+assert all(identifier != "198.51.100.44" for identifier, _ in reset_calls)
+```
+
+- [ ] **Step 2: Add malformed/missing cached-key RED tests**
+
+Parameterize payloads with a missing key, raw IP, wrong version, uppercase digest, short digest, and non-string value. Invoke `mfa_login()` and assert HTTP 400 with existing detail `MFA session expired or invalid`; assert no limiter reset, no token update, and no user-selected identifier reaches a limiter call.
+
+- [ ] **Step 3: Run the MFA selection and preserve the RED result**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q -k "mfa and (login or lockout)"
+```
+
+Expected: challenge payload lacks `login_lockout_key`, completion resets the current request IP, and malformed-key cases do not reject early.
+
+- [ ] **Step 4: Store the opaque key in the challenge payload**
+
+Change only the existing server-side ephemeral value:
+
+```python
+payload = {
+    "user_id": int(user["id"]),
+    "session_id": int(session_id),
+    "login_lockout_key": client_login_lockout_key,
+}
+```
+
+Do not expose the key in the response, token claims, logs, cookies, or audit payload.
+
+- [ ] **Step 5: Validate and use the original key on MFA completion**
+
+Validate the cached key alongside `user_id` and `session_id` before Resource Governor reservation or user lookup:
+
+```python
+session_id = payload.get("session_id")
+user_id = payload.get("user_id")
+login_lockout_key = _validated_login_client_lockout_key(payload.get("login_lockout_key"))
+if not session_id or not user_id or login_lockout_key is None:
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="MFA session expired or invalid",
+    )
+```
+
+After successful MFA, keep the current request IP for audit/session observability but reset only:
+
+```python
+await rate_limiter.reset_failed_attempts(login_lockout_key, "login")
+await rate_limiter.reset_failed_attempts(user.get("username", ""), "login")
+```
+
+- [ ] **Step 6: Run the complete AuthNZ endpoint unit module**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q
+../../.venv/bin/ruff check tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+../../.venv/bin/python -m py_compile tldw_Server_API/app/api/v1/endpoints/auth.py
+git diff --check
+```
+
+Expected: the complete module and every static command pass.
+
+- [ ] **Step 7: Commit MFA reset propagation**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+git commit -m "fix: reset original login lockout after mfa"
+```
+
+---
+
+### Task 6: Document the retained proxy configuration and rollout boundary
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Resource_Governance/README.md:115-130`
+- Modify: `Docs/Operations/Env_Vars.md:320-340`
+- Modify: `Docs/Deployment/horizontal-scaling.md:225-295`
+- Regenerate: `Docs/Published/Env_Vars.md`
+- Regenerate: `Docs/Published/Deployment/horizontal-scaling.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-5 final behavior and existing publishing script.
+- Produces: operator-facing configuration, equivalence warning, rollout behavior, and deterministic published mirrors.
+
+- [ ] **Step 1: Update canonical operator docs with exact semantics**
+
+Add the four retained variables and these concrete rules:
+
+```markdown
+- Forwarding headers are trusted only when the physical peer is a valid IP in the subsystem's configured trusted-proxy host/CIDR list.
+- `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward; malformed chains fall back to the physical peer.
+- Other `RG_CLIENT_IP_HEADER` values must contain one plain IP literal.
+- If both AuthNZ and Resource Governor forwarding are enabled, configure equivalent trusted-proxy sets and compatible headers so login lockouts and request governance derive the same client identity.
+- AuthNZ: `AUTH_TRUST_X_FORWARDED_FOR=true` plus `AUTH_TRUSTED_PROXY_IPS=<proxy IP/CIDR list>`.
+- Resource Governor: `RG_CLIENT_IP_HEADER=X-Forwarded-For` plus `RG_TRUSTED_PROXIES=<equivalent proxy IP/CIDR list>`.
+```
+
+Document that invalid physical peers resolve to the subsystem's safe unknown sentinel, the feature remains opt-in, and rollout stops checking legacy raw-IP password-login buckets while account-wide lockout and Resource Governor protection remain active.
+
+- [ ] **Step 2: Refresh generated documentation once**
+
+Run:
+
+```bash
+bash Helper_Scripts/refresh_docs_published.sh
+git diff -- Docs/Published/Env_Vars.md Docs/Published/Deployment/horizontal-scaling.md
+git status --short Docs/Published
+```
+
+Expected: the two named generated mirrors contain the canonical edits. If the refresh exposes unrelated generated drift, do not edit generated files by hand; preserve only output attributable to the three canonical source-doc changes and record the unrelated drift in TASK-13013.5.
+
+- [ ] **Step 3: Prove the generated mirrors match their canonical sources**
+
+Run:
+
+```bash
+cmp Docs/Operations/Env_Vars.md Docs/Published/Env_Vars.md
+cmp Docs/Deployment/horizontal-scaling.md Docs/Published/Deployment/horizontal-scaling.md
+python3 Helper_Scripts/docs/check_public_private_boundary.py
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 4: Commit canonical and generated docs**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Resource_Governance/README.md \
+  Docs/Operations/Env_Vars.md \
+  Docs/Deployment/horizontal-scaling.md \
+  Docs/Published/Env_Vars.md \
+  Docs/Published/Deployment/horizontal-scaling.md
+git commit -m "docs: explain trusted proxy chain configuration"
+```
+
+---
+
+### Task 7: Run completion gates and close the implementation record
+
+**Files:**
+- Test: all production, test, and documentation files changed in Tasks 1-6.
+- Modify: `backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md` through Backlog.md MCP/CLI only.
+
+**Interfaces:**
+- Consumes: committed Tasks 1-6 and the approved design.
+- Produces: fresh verification evidence, updated Backlog acceptance/DoD state, and one review-ready exact branch head.
+
+- [ ] **Step 1: Re-run the complete focused security and wrapper matrix**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Security/test_trusted_proxy.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q
+```
+
+Expected: every selected test passes.
+
+- [ ] **Step 2: Run the complete login lockout integration module**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q
+```
+
+Expected: every test passes against the repository's configured isolated Postgres fixture. A missing configured Postgres service is an environment blocker to record, not permission to skip or weaken the gate.
+
+- [ ] **Step 3: Run Python compilation and Ruff on every touched Python path**
+
+Run:
+
+```bash
+../../.venv/bin/python -m py_compile \
+  tldw_Server_API/app/core/Security/trusted_proxy.py \
+  tldw_Server_API/app/core/AuthNZ/ip_allowlist.py \
+  tldw_Server_API/app/core/Resource_Governance/deps.py \
+  tldw_Server_API/app/api/v1/endpoints/auth.py \
+  tldw_Server_API/tests/Security/test_trusted_proxy.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+../../.venv/bin/ruff check \
+  tldw_Server_API/app/core/Security/trusted_proxy.py \
+  tldw_Server_API/app/core/AuthNZ/ip_allowlist.py \
+  tldw_Server_API/app/core/Resource_Governance/deps.py \
+  tldw_Server_API/app/api/v1/endpoints/auth.py \
+  tldw_Server_API/tests/Security/test_trusted_proxy.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py \
+  tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py \
+  tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Run Bandit on touched production Python**
+
+Run:
+
+```bash
+../../.venv/bin/bandit -q -ll \
+  tldw_Server_API/app/core/Security/trusted_proxy.py \
+  tldw_Server_API/app/core/AuthNZ/ip_allowlist.py \
+  tldw_Server_API/app/core/Resource_Governance/deps.py \
+  tldw_Server_API/app/api/v1/endpoints/auth.py
+```
+
+Expected: exit 0 with no Medium/High-severity finding introduced by this change.
+
+- [ ] **Step 5: Verify docs, scope, and absence of forbidden changes**
+
+Run:
+
+```bash
+cmp Docs/Operations/Env_Vars.md Docs/Published/Env_Vars.md
+cmp Docs/Deployment/horizontal-scaling.md Docs/Published/Deployment/horizontal-scaling.md
+python3 Helper_Scripts/docs/check_public_private_boundary.py
+git diff --check origin/dev...HEAD
+git diff --name-only origin/dev...HEAD
+git diff --name-only origin/dev...HEAD | rg '(^|/)(alembic|migrations)(/|$)|(^|/)(requirements[^/]*|pyproject\.toml|package-lock\.json|bun\.lockb?)$|(^|/)tldw_Server_API/app/core/Security/middleware\.py$|websocket' && exit 1 || true
+```
+
+Expected: source/generated docs compare equal; the boundary and whitespace checks pass; the exact changed-path review contains only planned code, tests, docs, plan/spec, and Backlog records; the forbidden-path scan prints nothing.
+
+- [ ] **Step 6: Update TASK-13013.5 through Backlog.md**
+
+Append the exact commit SHAs and command results, check each acceptance criterion/Definition of Done item supported by evidence, link this plan and the approved spec, keep TASK-13144 as the deferred global rewrite, and move TASK-13013.5 to `Done` only after all local gates and independent review pass.
+
+- [ ] **Step 7: Commit the final task record and verify the branch**
+
+```bash
+git add 'backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md'
+git commit -m "chore: record trusted proxy lockout verification"
+git status --short --branch
+git log --oneline --decorate origin/dev..HEAD
+git diff --check origin/dev...HEAD
+```
+
+Expected: clean worktree, reviewable small commits, and no untracked/generated residue.
+
+- [ ] **Step 8: Require independent review and hosted gates before merge**
+
+Request correctness/security review against the exact branch head. Resolve every Critical or Important finding with a test-first follow-up and rerun affected gates. Push only after local review is green, then require the repository's `backend-required`, `security-required`, and `coverage-required` checks to succeed on the unchanged PR head; do not bypass protection or merge without a separate user decision.

--- a/Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
+++ b/Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
@@ -1,0 +1,332 @@
+# Trusted Proxy Identity and Login Lockout Isolation Design
+
+**Status:** Draft for written-spec review
+
+**Tracking task:** TASK-13013.5
+
+**Deferred architecture task:** TASK-13144
+
+**Baseline:** `origin/dev` at `f676e23549ea8ed82ef53493260621a05b281863`
+
+## Purpose
+
+Harden the public server's client-IP and password-login lockout boundaries so
+trusted reverse proxies cannot accidentally expose spoofable identity and one
+attacker behind a shared proxy or NAT cannot lock unrelated users out of the
+application.
+
+This is a release-readiness repair, not a global request-identity rewrite. It
+introduces one small pure resolver that AuthNZ and Resource Governor call from
+their existing integration points. Their existing environment-variable
+families remain supported.
+
+## Current Problems
+
+Two independent client-IP implementations currently trust forwarding headers
+only when the physical peer is configured as trusted, but both select the
+leftmost forwarded value. A proxy that appends to an inbound
+`X-Forwarded-For` header therefore leaves an attacker-controlled value in the
+selected position. The implementations can also drift because AuthNZ and
+Resource Governor parse the same security boundary separately.
+
+Password login separately checks and records a raw client-IP lockout bucket.
+All users behind one correctly resolved proxy or NAT therefore share that
+bucket. One attacker can consume it and block unrelated users before their
+credentials are evaluated. Resource Governor already supplies the broader
+IP-scoped request/spray control, so the password-login lockout can be isolated
+to a client-and-login pair while retaining the existing account-wide bucket.
+
+## Goals
+
+- Resolve client identity only from a valid physical peer and explicitly
+  trusted proxy hops.
+- Make direct, single-proxy, multi-proxy, spoofed, malformed, IPv4, and IPv6
+  behavior deterministic.
+- Reuse one pure standard-library resolver from AuthNZ and Resource Governor.
+- Preserve the existing AuthNZ and Resource Governor configuration names.
+- Prevent one shared-IP attacker from consuming another login identifier's
+  client-side password lockout bucket.
+- Preserve the existing account-wide username lockout as a second layer.
+- Reset the exact password-login buckets after ordinary or MFA success.
+- Avoid a database schema migration, a new runtime dependency, and raw
+  client/login pairs in new lockout identifiers.
+
+## Non-Goals
+
+- Rewriting `request.client` globally in middleware.
+- Changing audit, setup, authorization, WebSocket, or unrelated middleware
+  identity semantics.
+- Supporting RFC 7239 `Forwarded`, hostname proxy entries, or non-IP
+  forwarding values.
+- Renaming or consolidating the `AUTH_*` and `RG_*` environment variables.
+- Replacing Resource Governor's IP-wide request controls.
+- Redesigning MFA throttling or the lockout database.
+
+The broader HTTP/WebSocket middleware rewrite is tracked independently by
+TASK-13144. It depends on this task but is outside TASK-13013 and cannot block
+the current release.
+
+## Architecture
+
+### Shared pure resolver
+
+Add a focused module under `tldw_Server_API/app/core/Security/` that depends
+only on Python's `ipaddress` and collection types. Its public operation accepts:
+
+- the physical peer string;
+- trusted proxy IP/CIDR strings;
+- zero or more ordered `X-Forwarded-For` field values; and
+- an optional single-address forwarding field value.
+
+It returns a canonical compressed IP string or `None`. It does not read process
+environment, import FastAPI, inspect `Request`, log header contents, or replace
+`request.client`.
+
+AuthNZ's `resolve_client_ip()` remains the compatibility wrapper for
+`AUTH_TRUST_X_FORWARDED_FOR` and `AUTH_TRUSTED_PROXY_IPS`. Resource Governor's
+`derive_client_ip()` remains the compatibility wrapper for
+`RG_TRUSTED_PROXIES` and `RG_CLIENT_IP_HEADER`. Each wrapper extracts request
+data and delegates the trust decision to the shared operation. AuthNZ returns
+`None` when no canonical IP exists, and its login helper maps that condition to
+`unknown`. Resource Governor returns its existing `unknown` sentinel. The
+current Resource Governor shortcut that treats any non-IP peer as loopback is
+removed from the security path.
+
+### Resolution contract
+
+1. Parse the physical peer as an IP literal. Invalid or missing peers produce
+   no resolved IP and never authorize a forwarding header. Compatibility
+   wrappers map no result to their existing safe sentinel where required.
+2. Canonicalize valid IPv4 and IPv6 values with `ipaddress.ip_address(...).compressed`.
+3. Parse trusted entries as exact hosts or CIDRs. Ignore invalid configured
+   entries. An empty or wholly invalid list trusts no proxy.
+4. If forwarding is disabled or the physical peer is not trusted, ignore every
+   forwarding field and return the canonical physical peer.
+5. When `X-Forwarded-For` is present, join repeated field occurrences in wire
+   order, split the resulting list, and require every token to be a plain valid
+   IP literal. Empty or malformed tokens reject the entire chain and fall back
+   to the physical peer without consulting a secondary header.
+6. Walk the valid chain from right to left. Skip addresses in the configured
+   trusted proxy networks. The first untrusted address is the client. This
+   ignores attacker-prepended values once the actual untrusted client hop is
+   reached. If every forwarded address is trusted, fall back to the physical
+   peer rather than inventing a client identity.
+7. AuthNZ uses `X-Forwarded-For` when present and consults `X-Real-IP` only when
+   `X-Forwarded-For` is absent. A repeated, comma-separated, or invalid
+   `X-Real-IP` value falls back to the physical peer.
+8. Resource Governor treats `RG_CLIENT_IP_HEADER=X-Forwarded-For`
+   case-insensitively as a list header. Other configured header names use the
+   strict single-address rule.
+
+Forwarding values with ports, brackets, zone identifiers, `for=` syntax, or
+other decorations are invalid. Supporting those forms would add ambiguous
+parsing outside the existing contract.
+
+### Compatibility boundaries
+
+The following names and opt-in behavior remain unchanged:
+
+- `AUTH_TRUST_X_FORWARDED_FOR`
+- `AUTH_TRUSTED_PROXY_IPS`
+- `RG_TRUSTED_PROXIES`
+- `RG_CLIENT_IP_HEADER`
+
+Operators that configure both subsystems must use equivalent trusted-proxy
+sets and compatible headers. The documentation will state this directly.
+Equivalent configuration produces the same canonical identity; intentionally
+different configuration remains possible for backward compatibility.
+
+The only intentional behavior change for a valid enabled configuration is
+that `X-Forwarded-For` is evaluated from the trusted edge inward instead of
+accepting its leftmost value. Deployments whose ingress overwrites the header
+continue to resolve the same client. Deployments whose ingress appends gain
+spoof resistance.
+
+## Login Lockout Isolation
+
+### Stable composite key
+
+Add one small login helper that builds a versioned deterministic lockout identifier
+from the resolved client identity and attempted login identifier.
+
+- Normalize the attempted identifier with `strip().lower()`, exactly matching
+  `fetch_user_by_login_identifier()`.
+- Use the canonical resolved IP, or the stable `unknown` sentinel when no IP is
+  available.
+- Encode the two strings as a compact JSON array and hash the UTF-8 bytes with
+  standard-library SHA-256.
+- Store the result as `login-client-v1:<64 lowercase hex characters>`.
+
+The key must not use Resource Governor's `hash_entity()` because that helper's
+configuration and fallback behavior are not the durable cross-process
+identity contract required by the database-backed lockout tracker. A known
+test vector will freeze the composite-key format.
+
+The version prefix prevents collision with existing raw username/IP
+identifiers and allows a later contract change without a schema migration.
+Existing raw-IP rows are no longer checked or extended by this login path. The
+repository has no general failed-attempt retention sweep, so those legacy rows
+may remain inert until explicit database maintenance or a future compatible
+cleanup task; this change does not guess which historical identifiers were IPs
+and which were IP-shaped usernames.
+
+SHA-256 prevents the new pair from being stored as plaintext but is not treated
+as a secrecy boundary. The database already retains the separate account
+identifier, and this task does not introduce or manage another application
+secret merely to key short-lived lockout state.
+
+### Password-login flow
+
+The endpoint computes the normalized attempted identifier and composite key
+before the pre-fetch lockout check.
+
+- Pre-fetch: check the composite client/login bucket.
+- User not found: record only the composite bucket. Resource Governor remains
+  the IP-wide defense against high-cardinality username spraying.
+- User found: also check the existing account-wide bucket keyed by the stored
+  canonical username before password verification.
+- Invalid password: record both the composite bucket and the account bucket.
+- Successful non-MFA login: reset the exact composite bucket used for the
+  attempt and the account bucket.
+- MFA challenge: store the opaque composite key alongside `user_id` and
+  `session_id` in the existing server-side ephemeral value. Do not store the
+  raw IP/login pair there.
+- Successful MFA login: require the cached key to match the exact versioned
+  key shape, then reset it and the account bucket. Do not derive the reset key
+  from the MFA request's potentially different network path.
+
+Alias behavior is deliberate. Login by username and login by email may have
+different composite buckets, while both resolve to the same account-wide
+bucket after user lookup. Case and surrounding whitespace cannot create extra
+buckets. A successful login resets only the exact composite bucket used by
+that flow plus the account bucket; it does not erase unrelated attack history.
+
+MFA token failures continue to use the existing MFA Resource Governor policy.
+This task changes password-login failure isolation, not MFA attempt policy.
+
+## Failure Handling and Privacy
+
+- Untrusted peers never gain header authority.
+- Any malformed forwarded chain fails closed to the physical peer.
+- A malformed primary `X-Forwarded-For` chain cannot fall through to
+  `X-Real-IP`.
+- Invalid physical peers produce no canonical identity rather than being
+  treated as loopback.
+- Raw forwarding-header values and parser exception text are never logged.
+- New lockout rows contain only the versioned digest, not the new raw
+  client/login pair. The existing account bucket remains unchanged.
+- Resolver failures must not bypass the account-wide lockout or Resource
+  Governor controls.
+
+## Expected Files
+
+The implementation plan will confirm exact paths, but the intended scope is:
+
+- one new shared security resolver and its focused tests;
+- thin changes to AuthNZ `ip_allowlist.py` and Resource Governor `deps.py`;
+- login/MFA lockout-key changes in `app/api/v1/endpoints/auth.py`;
+- focused AuthNZ and Resource Governor regression tests;
+- operator documentation for the retained proxy environment variables; and
+- Backlog records for TASK-13013.5, completed TASK-13013.4 metadata, and the
+  deferred TASK-13144 architecture task.
+
+No database model, migration, dependency manifest, global middleware, or
+WebSocket implementation belongs in this change.
+
+## Verification Strategy
+
+### Resolver matrix
+
+- direct valid IPv4 and IPv6 peers;
+- forwarding disabled;
+- untrusted peer with spoofed forwarding fields;
+- one trusted proxy with overwritten and appended XFF;
+- multiple trusted proxies;
+- attacker-prepended XFF values;
+- repeated XFF field occurrences in wire order;
+- all-trusted chains;
+- malformed, empty, decorated, and mixed-validity chains;
+- XFF precedence over X-Real-IP;
+- strict single-address custom headers;
+- invalid trusted entries and invalid physical peers; and
+- canonical IPv4/IPv6 output.
+
+### Login and MFA matrix
+
+- exact stable composite-key vector and prefix validation;
+- case/whitespace normalization parity with database lookup;
+- same proxy plus different attempted users remain isolated;
+- same client/login pair locks at the configured threshold;
+- known-account failures still trigger the account-wide bucket;
+- username/email aliases share the account bucket;
+- unknown-user failures use the composite bucket;
+- spoofed forwarding values cannot select another lockout bucket;
+- ordinary success resets the exact composite and account buckets;
+- MFA challenge carries only the opaque original composite key;
+- MFA success from a different request IP resets the original key; and
+- malformed cached MFA keys are ignored or rejected safely and never reset an
+  attacker-selected identifier.
+
+### Completion gates
+
+- focused shared-resolver, AuthNZ, Resource Governor, login, and MFA tests;
+- existing AuthNZ and Resource Governor regression modules;
+- Python compilation and Ruff on touched Python;
+- Bandit on touched production Python with no new Medium/High findings;
+- `git diff --check`;
+- required backend/security/coverage CI shards; and
+- documentation/config examples checked for the retained environment names.
+
+## Rollout and Rollback
+
+No configuration migration is required. Proxy-header trust remains disabled by
+default for AuthNZ and inactive for Resource Governor unless both its trusted
+proxy set and header name are configured.
+
+The change can be rolled back as one code revision without transforming stored
+data. Older code ignores the versioned composite rows. Its window-reset logic
+handles any legacy failed-attempt rows it consults after rollback, and expired
+legacy lockout rows are pruned when checked.
+
+At rollout, a currently active raw-IP lockout cannot be mapped to a composite
+key because it has no attempted-login component. The new path therefore stops
+consulting that one legacy bucket immediately. The existing account bucket and
+Resource Governor remain active during this transition. Operators should
+validate equivalent AuthNZ and Resource Governor proxy settings in staging
+before production rollout.
+
+## Reviewed Alternatives
+
+### Global `request.client` middleware rewrite
+
+This would provide one conceptual identity everywhere, but it changes audit,
+WebSocket, setup, authorization, and middleware behavior together and risks
+losing the immutable physical peer used to decide whether headers are trusted.
+It is deferred to TASK-13144 with an explicit consumer inventory, separate
+physical-peer storage, staged rollout, observability, and rollback.
+
+### Keep both resolvers and patch each independently
+
+This is a smaller immediate diff but preserves duplicated trust logic and
+future drift. One pure shared resolver with thin compatibility wrappers is the
+smallest durable correction.
+
+### Keep raw IP lockout and add exceptions for proxies
+
+Proxy-specific exceptions weaken brute-force protection and cannot distinguish
+shared clients. The composite bucket plus existing account bucket and Resource
+Governor layers isolates unrelated users without removing controls.
+
+### Keyed HMAC lockout identifiers
+
+HMAC would make offline guessing of the composite more expensive but requires
+a stable key lifecycle and migration contract. The lockout database already
+contains a raw account identifier, and the task adds no raw pair. Versioned
+SHA-256 is deterministic across workers and adequate for this scoped release
+repair.
+
+## Decision
+
+Proceed with the shared pure trusted-hop resolver, thin existing-config
+wrappers, versioned client/login lockout key, and exact MFA reset propagation.
+Keep global request-client rewriting deferred under TASK-13144.

--- a/backlog/tasks/task-13013.4 - Resolve-the-stale-release-blocking-security-pull-requests.md
+++ b/backlog/tasks/task-13013.4 - Resolve-the-stale-release-blocking-security-pull-requests.md
@@ -1,15 +1,15 @@
 ---
 id: TASK-13013.4
 title: Resolve the stale release-blocking security pull requests
-status: In Progress
+status: Done
 assignee: []
-created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 00:23'
+created_date: 2026-08-21 19:50
+updated_date: 2026-08-30 02:51
 labels:
-  - release-readiness
-  - security
-  - privacy
-  - authorization
+- release-readiness
+- security
+- privacy
+- authorization
 dependencies: []
 parent_task_id: TASK-13013
 priority: high
@@ -30,7 +30,7 @@ Rebase, replace, or formally supersede the open security work for RAG query logg
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-08-29: Approved design: replace the five stale PRs from current dev in one reconciliation PR with five isolated security commits; do not rebase or merge obsolete branches. Preserve a test-first cycle for each boundary, record supersession links, and close stale PRs only after the replacement merges.
 
 2026-08-29 implementation evidence:
@@ -72,7 +72,13 @@ Rebase, replace, or formally supersede the open security work for RAG query logg
 - TDD evidence: the new importer interface was RED (2 failures); the exact tenant/fallback matrix is GREEN (4 passed); the focused changed-area suite is 48 passed; the complete 11-module security suite is 128 passed in 13.35s.
 - Static evidence: Ruff on all 8 corrected Python files passed; all 8 compiled in memory; Bandit -ll on the 3 corrected production files reported no Medium/High findings; git diff --check passed.
 - Merge remains gated on pushing this correction, replying inline to all three Qodo threads, and all required CI succeeding.
-<!-- SECTION:NOTES:END -->
+2026-08-30 closure verification: GitHub reports replacement PR #2837 MERGED at head 797f1bc583e551c5b3137dee80eef21952d0f23e with merge commit 00c900cfc7a1f8dc1e8ca9b4351b69962ea5bfb2. Superseded PRs #2610, #2614, #2622, #2623, and #2625 are CLOSED. The task is complete.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed by replacement PR #2837 (https://github.com/rmusser01/tldw_server/pull/2837). GitHub verified the PR merged at head 797f1bc583e551c5b3137dee80eef21952d0f23e with merge commit 00c900cfc7a1f8dc1e8ca9b4351b69962ea5bfb2 on 2026-08-30T00:48:43Z. Superseded PRs #2610, #2614, #2622, #2623, and #2625 were then closed without merging. The task notes contain the focused security, review-correction, Ruff, compile, Bandit, and diff verification evidence; no known release-blocking security issue remains in this task’s scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -80,6 +86,6 @@ Rebase, replace, or formally supersede the open security work for RAG query logg
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -3,22 +3,24 @@ id: TASK-13013.5
 title: Harden trusted proxy client identity and login lockout isolation
 status: In Progress
 assignee: []
-created_date: 2026-08-21 19:50
+created_date: '2026-08-21 19:50'
+updated_date: '2026-08-30 06:51'
 labels:
-- release-readiness
-- security
-- auth
-- proxy
-- rate-limit
+  - release-readiness
+  - security
+  - auth
+  - proxy
+  - rate-limit
 dependencies: []
+references:
+  - TASK-13144
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
+  - >-
+    Docs/superpowers/plans/2026-08-29-task-13013-5-trusted-proxy-login-lockout.md
 parent_task_id: TASK-13013
 priority: high
-references:
-- TASK-13144
-documentation:
-- Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
-- Docs/superpowers/plans/2026-08-29-task-13013-5-trusted-proxy-login-lockout.md
-updated_date: 2026-08-30 05:45
 ---
 
 ## Description
@@ -34,6 +36,30 @@ Provide a production-safe trusted-proxy contract that preserves sanitized client
 - [ ] #3 Direct, single-proxy, multi-proxy, spoofed-header, IPv4, and IPv6 regression cases pass.
 <!-- AC:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-08-29: Approved architectural direction: add one shared pure trusted-hop resolver under app/core/Security while retaining the existing AUTH_* and RG_* environment-variable families through thin wrappers; replace shared raw-IP password-login lockout state with versioned deterministic client-plus-normalized-login buckets plus the existing account bucket; preserve the exact bucket through MFA; do not rewrite request.client globally in this release slice. Final pre-spec review requires canonical IP output only, X-Forwarded-For precedence and right-to-left trusted-hop walking, fail-closed malformed/repeated-header handling, login normalization matching fetch_user_by_login_identifier, versioned SHA-256 keys, and MFA key-shape validation. Global HTTP/WebSocket request.client rewriting is deferred to TASK-13144 and does not block TASK-13013.
+2026-08-29 spec baseline: isolated branch codex/task-13013-5-trusted-proxy-lockout starts from origin/dev f676e23549ea8ed82ef53493260621a05b281863. Existing focused proxy baseline passed with the project virtualenv: 15 passed across AuthNZ IP allowlist plus Resource Governor trusted-proxy dependency/middleware tests. No dependency or system installation was performed. Written design: Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md.
+2026-08-29 implementation planning: approved design decomposed into seven test-first review gates covering the pure trusted-hop resolver, AuthNZ and Resource Governor compatibility wrappers, stable client/login lockout keys, password-login isolation, exact MFA reset propagation, canonical/generated operator docs, and final security/CI verification. The plan explicitly rejects repeated single-address headers, preserves full repeated X-Forwarded-For wire order, adds no schema/dependency/global middleware change, uses only the existing project virtualenv, and keeps the global request.client rewrite deferred to TASK-13144.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-08-29 Task 7 local completion gates (branch head fdaf564a14; base f676e23549ea8ed82ef53493260621a05b281863). Commits: 0291c94412 docs: design trusted proxy lockout isolation; 0986ef1f51 docs: plan trusted proxy lockout hardening; 467dbd2353 fix: resolve trusted proxy chains safely; f5ab70056c fix: share trusted proxy identity resolution; 58168486e7 fix: add stable login client lockout keys; e88a2c1bef fix: isolate password login lockouts; b42f0802c2 fix: reset original login lockout after mfa; fdaf564a14 docs: explain trusted proxy chain configuration.
+
+Exact local commands/results: (1) ../../.venv/bin/python -m pytest tldw_Server_API/tests/Security/test_trusted_proxy.py tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q => 96 passed, 132 warnings, exit 0. (2) ../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q => 3 passed, 10 warnings, exit 0; no Postgres-fixture skip/blocker occurred. (3) ../../.venv/bin/python -m py_compile [the 10 Task 7 brief paths] => exit 0. (4) ../../.venv/bin/ruff check [the same 10 paths] => exit 1 with 10 inherited full-file findings: auth.py I001/F401/B010/B010/B904; test_auth_endpoints_extended.py I001/B017/I001; integration test I001/I001. Base f676e23549ea8ed82ef53493260621a05b281863 comparison had the same auth (5), unit-test (3), and integration-test (2) diagnostics; it additionally had 2 findings each in the two Resource_Governance tests that are now clean. No newly introduced Ruff diagnostic. ../../.venv/bin/ruff check --select E9,F63,F7,F82 [same 10 paths] => All checks passed, exit 0. (5) ../../.venv/bin/bandit -q -ll trusted_proxy.py ip_allowlist.py deps.py auth.py => exit 0; only existing nosec B105 warning in auth.py line 1246. Base/head Bandit: head has no Medium/High findings; stdin base comparison is tool-limited because Bandit trojansource opens <stdin> and reports FileNotFoundError, while preserving exit 0; base auth.py likewise only emitted the pre-existing nosec B105 warning. trusted_proxy.py is new relative to base.
+
+Docs/scope: cmp Docs/Operations/Env_Vars.md Docs/Published/Env_Vars.md => exit 0; cmp Docs/Deployment/horizontal-scaling.md Docs/Published/Deployment/horizontal-scaling.md => exit 0; python3 Helper_Scripts/docs/check_public_private_boundary.py => exit 0 (OK public OSS boundary); git diff --check origin/dev...HEAD => exit 0; forbidden-path scan => no output, exit 0. Changed-path review is limited to planned trusted-proxy/auth code and tests, docs/spec/plan, Resource_Governance README, and Backlog records; no migrations, dependency manifests, global security middleware, or websocket paths. Task 6 mirror-alignment ruling remains accepted; no docs regeneration performed.
+
+Known pending items: do not mark acceptance/DoD complete or task Done until controller task/final review and hosted backend-required, security-required, coverage-required gates pass on the unchanged reviewed head. TASK-13144 remains the deferred global request.client rewrite.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+2026-08-29 local completion-gate evidence recorded at head fdaf564a14. Focused security/wrapper/auth tests: 96 passed; integration lockout module: 3 passed (no fixture skip); compilation, changed-code Ruff safety selection, Bandit Medium/High gate, document mirrors/boundary, whitespace, and forbidden-path checks passed. Full-file Ruff has 10 inherited findings, unchanged/reduced versus base and outside changed code; no unrelated cleanup made. TASK remains In Progress pending controller reviews and hosted required gates; TASK-13144 remains the deferred global rewrite.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
@@ -43,11 +69,3 @@ Provide a production-safe trusted-proxy contract that preserves sanitized client
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Implementation Notes
-
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-2026-08-29: Approved architectural direction: add one shared pure trusted-hop resolver under app/core/Security while retaining the existing AUTH_* and RG_* environment-variable families through thin wrappers; replace shared raw-IP password-login lockout state with versioned deterministic client-plus-normalized-login buckets plus the existing account bucket; preserve the exact bucket through MFA; do not rewrite request.client globally in this release slice. Final pre-spec review requires canonical IP output only, X-Forwarded-For precedence and right-to-left trusted-hop walking, fail-closed malformed/repeated-header handling, login normalization matching fetch_user_by_login_identifier, versioned SHA-256 keys, and MFA key-shape validation. Global HTTP/WebSocket request.client rewriting is deferred to TASK-13144 and does not block TASK-13013.
-2026-08-29 spec baseline: isolated branch codex/task-13013-5-trusted-proxy-lockout starts from origin/dev f676e23549ea8ed82ef53493260621a05b281863. Existing focused proxy baseline passed with the project virtualenv: 15 passed across AuthNZ IP allowlist plus Resource Governor trusted-proxy dependency/middleware tests. No dependency or system installation was performed. Written design: Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md.
-2026-08-29 implementation planning: approved design decomposed into seven test-first review gates covering the pure trusted-hop resolver, AuthNZ and Resource Governor compatibility wrappers, stable client/login lockout keys, password-login isolation, exact MFA reset propagation, canonical/generated operator docs, and final security/CI verification. The plan explicitly rejects repeated single-address headers, preserves full repeated X-Forwarded-For wire order, adds no schema/dependency/global middleware change, uses only the existing project virtualenv, and keeps the global request.client rewrite deferred to TASK-13144.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -17,7 +17,8 @@ references:
 - TASK-13144
 documentation:
 - Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
-updated_date: 2026-08-30 02:51
+- Docs/superpowers/plans/2026-08-29-task-13013-5-trusted-proxy-login-lockout.md
+updated_date: 2026-08-30 05:45
 ---
 
 ## Description
@@ -48,4 +49,5 @@ Provide a production-safe trusted-proxy contract that preserves sanitized client
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-08-29: Approved architectural direction: add one shared pure trusted-hop resolver under app/core/Security while retaining the existing AUTH_* and RG_* environment-variable families through thin wrappers; replace shared raw-IP password-login lockout state with versioned deterministic client-plus-normalized-login buckets plus the existing account bucket; preserve the exact bucket through MFA; do not rewrite request.client globally in this release slice. Final pre-spec review requires canonical IP output only, X-Forwarded-For precedence and right-to-left trusted-hop walking, fail-closed malformed/repeated-header handling, login normalization matching fetch_user_by_login_identifier, versioned SHA-256 keys, and MFA key-shape validation. Global HTTP/WebSocket request.client rewriting is deferred to TASK-13144 and does not block TASK-13013.
 2026-08-29 spec baseline: isolated branch codex/task-13013-5-trusted-proxy-lockout starts from origin/dev f676e23549ea8ed82ef53493260621a05b281863. Existing focused proxy baseline passed with the project virtualenv: 15 passed across AuthNZ IP allowlist plus Resource Governor trusted-proxy dependency/middleware tests. No dependency or system installation was performed. Written design: Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md.
+2026-08-29 implementation planning: approved design decomposed into seven test-first review gates covering the pure trusted-hop resolver, AuthNZ and Resource Governor compatibility wrappers, stable client/login lockout keys, password-login isolation, exact MFA reset propagation, canonical/generated operator docs, and final security/CI verification. The plan explicitly rejects repeated single-address headers, preserves full repeated X-Forwarded-For wire order, adds no schema/dependency/global middleware change, uses only the existing project virtualenv, and keeps the global request.client rewrite deferred to TASK-13144.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13013.5
 title: Harden trusted proxy client identity and login lockout isolation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 15:42'
+updated_date: '2026-08-30 16:03'
 labels:
   - release-readiness
   - security
@@ -80,14 +80,16 @@ TASK-13144 remains the intentional deferred global HTTP/WebSocket request.client
 2026-08-30 final review gap closed test-only: production dependency endpoint coverage now proves durable composite/account separation, same-client identifier isolation, and exact success reset in isolated Postgres. Full affected/focused/static gates pass locally. Task intentionally remains In Progress with AC/DoD unchecked pending controller and hosted gates.
 
 2026-08-30 completed local closure after final production-backed Postgres regression 663ed880f07a5d7289dd70487b5a9509a05f19b6 and scoped independent re-review with no remaining findings. All acceptance criteria and local DoD evidence are complete; TASK-13144 remains deferred. Hosted backend-required, security-required, and coverage-required are still mandatory on the unchanged future PR head before merge.
+
+2026-08-30 Qodo closure on PR #2838: commit b873f76ceb addresses all ten submitted findings, each inline thread has an evidence-based reply and is resolved, and Qodo updated its review against that exact commit. Local gates passed: 96 focused tests, 4 isolated-Postgres production integration tests with Docker autostart disabled, exact touched-path Ruff and py_compile, Bandit with no Medium/High findings, docs mirrors, boundary guard, and diff checks. Hosted container-build-check, backend-required, security-required, coverage-required, frontend-required, e2e-required, and trusted frontend license policy all succeeded on b873f76ceb. No functional test skips or unresolved blockers remain; TASK-13144 is the intentional separately tracked global request.client rewrite.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
+- [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -4,7 +4,7 @@ title: Harden trusted proxy client identity and login lockout isolation
 status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 07:03'
+updated_date: '2026-08-30 07:31'
 labels:
   - release-readiness
   - security
@@ -58,6 +58,8 @@ Known pending items: do not mark acceptance/DoD complete or task Done until cont
 Fresh exact gates at the uncommitted fix-round head: ../../.venv/bin/ruff check [Task 7 exact 10 paths] => All checks passed, exit 0. ../../.venv/bin/python -m py_compile [same 10 paths] => exit 0. ../../.venv/bin/python -m pytest tldw_Server_API/tests/Security/test_trusted_proxy.py tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q => 96 passed, 132 warnings, exit 0. ../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q => 3 passed, 10 warnings, exit 0; no Postgres fixture skip. ../../.venv/bin/bandit -q -ll trusted_proxy.py ip_allowlist.py deps.py auth.py => exit 0, only existing nosec B105 warning (auth.py line 1267). git diff --check origin/dev...HEAD and git diff --check => exit 0. Narrowed assertion check: test_reset_password_weak_and_success initially showed its existing Pydantic ValidationError contract (not HTTPException); after precise assertion update, 1 passed / 48 deselected.
 
 Review status remains pending: leave all AC/DoD unchecked and TASK status In Progress until controller re-review plus hosted required gates. TASK-13144 remains deferred.
+
+2026-08-30 final production-lockout integration fix on baseline 8f9055d6b4: final review proved the prior endpoint module used isolated Postgres only for users while overriding get_rate_limiter_dep with _StubLimiter. RED: the new durable endpoint assertion under that fixture reached HTTP lockout but direct Postgres access failed with UndefinedTableError for failed_attempts, proving production RateLimiter/LockoutTracker storage was not exercised. GREEN: moved the scenario outside the stub fixture; it asserts no limiter dependency override, drives the configured production threshold, directly verifies exact versioned composite plus separate canonical account rows in failed_attempts/account_lockouts, proves another identifier on the same client returns 401 with its own row, expires only the attempted lockouts, succeeds login, and verifies exactly the attempted composite/account state is cleared while unrelated history remains. No production defect or production change. Fresh gates: new test 1 passed; affected integration module 4 passed/14 warnings; focused matrix 96 passed/130 warnings; exact ten-path Ruff and py_compile exit 0; Bandit -q -ll exit 0 with only existing B105 nosec warning and no Medium/High finding; both diff checks exit 0. Reports: task-7-report.md and final-fix-report.md. Keep In Progress and all AC/DoD unchecked pending controller review plus hosted required gates.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -66,6 +68,8 @@ Review status remains pending: leave all AC/DoD unchecked and TASK status In Pro
 2026-08-29 local completion-gate evidence recorded at head fdaf564a14. Focused security/wrapper/auth tests: 96 passed; integration lockout module: 3 passed (no fixture skip); compilation, changed-code Ruff safety selection, Bandit Medium/High gate, document mirrors/boundary, whitespace, and forbidden-path checks passed. Full-file Ruff has 10 inherited findings, unchanged/reduced versus base and outside changed code; no unrelated cleanup made. TASK remains In Progress pending controller reviews and hosted required gates; TASK-13144 remains the deferred global rewrite.
 
 2026-08-30 review fix round: the prior inherited-Ruff concern is resolved. Exact full-file Ruff now passes on all 10 Task 7 paths; compilation, 96 focused tests, 3 Postgres integration tests (no skip), Bandit Medium/High gate, and whitespace checks pass. Task remains In Progress with AC/DoD unchecked, pending controller re-review and hosted gates; TASK-13144 remains deferred.
+
+2026-08-30 final review gap closed test-only: production dependency endpoint coverage now proves durable composite/account separation, same-client identifier isolation, and exact success reset in isolated Postgres. Full affected/focused/static gates pass locally. Task intentionally remains In Progress with AC/DoD unchecked pending controller and hosted gates.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13013.5
 title: Harden trusted proxy client identity and login lockout isolation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 07:31'
+updated_date: '2026-08-30 07:41'
 labels:
   - release-readiness
   - security
@@ -31,9 +31,9 @@ Provide a production-safe trusted-proxy contract that preserves sanitized client
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Client identity is taken only from explicitly trusted proxy hops with deterministic anti-spoofing behavior.
-- [ ] #2 Login throttling and lockout cannot collapse all proxied users into one attacker-controlled bucket.
-- [ ] #3 Direct, single-proxy, multi-proxy, spoofed-header, IPv4, and IPv6 regression cases pass.
+- [x] #1 Client identity is taken only from explicitly trusted proxy hops with deterministic anti-spoofing behavior.
+- [x] #2 Login throttling and lockout cannot collapse all proxied users into one attacker-controlled bucket.
+- [x] #3 Direct, single-proxy, multi-proxy, spoofed-header, IPv4, and IPv6 regression cases pass.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -60,6 +60,10 @@ Fresh exact gates at the uncommitted fix-round head: ../../.venv/bin/ruff check 
 Review status remains pending: leave all AC/DoD unchecked and TASK status In Progress until controller re-review plus hosted required gates. TASK-13144 remains deferred.
 
 2026-08-30 final production-lockout integration fix on baseline 8f9055d6b4: final review proved the prior endpoint module used isolated Postgres only for users while overriding get_rate_limiter_dep with _StubLimiter. RED: the new durable endpoint assertion under that fixture reached HTTP lockout but direct Postgres access failed with UndefinedTableError for failed_attempts, proving production RateLimiter/LockoutTracker storage was not exercised. GREEN: moved the scenario outside the stub fixture; it asserts no limiter dependency override, drives the configured production threshold, directly verifies exact versioned composite plus separate canonical account rows in failed_attempts/account_lockouts, proves another identifier on the same client returns 401 with its own row, expires only the attempted lockouts, succeeds login, and verifies exactly the attempted composite/account state is cleared while unrelated history remains. No production defect or production change. Fresh gates: new test 1 passed; affected integration module 4 passed/14 warnings; focused matrix 96 passed/130 warnings; exact ten-path Ruff and py_compile exit 0; Bandit -q -ll exit 0 with only existing B105 nosec warning and no Medium/High finding; both diff checks exit 0. Reports: task-7-report.md and final-fix-report.md. Keep In Progress and all AC/DoD unchecked pending controller review plus hosted required gates.
+
+2026-08-30 final closure approved at exact reviewed head 663ed880f07a5d7289dd70487b5a9509a05f19b6. Independent whole-branch review initially identified the production RateLimiter/LockoutTracker Postgres persistence gap; final commit 663ed880f07a5d7289dd70487b5a9509a05f19b6 added the production-backed endpoint regression, and its scoped re-review verdict is ADDRESSED with no Critical, Important, or Minor findings. Evidence: 1 production-backed regression passed (3 deselected); affected integration module 4 passed; focused matrix 96 passed; exact ten-path Ruff and py_compile passed; Bandit -q -ll passed with only existing B105 nosec warning and no Medium/High finding; exact diff checks passed; canonical/published docs mirrors compare equal. This closes all three acceptance criteria and all six local DoD items.
+
+TASK-13144 remains the intentional deferred global HTTP/WebSocket request.client normalization rewrite. Hosted backend-required, security-required, and coverage-required checks remain mandatory on the unchanged future PR head before merge; they do not block this local task closure or authorize push/merge.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -70,14 +74,16 @@ Review status remains pending: leave all AC/DoD unchecked and TASK status In Pro
 2026-08-30 review fix round: the prior inherited-Ruff concern is resolved. Exact full-file Ruff now passes on all 10 Task 7 paths; compilation, 96 focused tests, 3 Postgres integration tests (no skip), Bandit Medium/High gate, and whitespace checks pass. Task remains In Progress with AC/DoD unchecked, pending controller re-review and hosted gates; TASK-13144 remains deferred.
 
 2026-08-30 final review gap closed test-only: production dependency endpoint coverage now proves durable composite/account separation, same-client identifier isolation, and exact success reset in isolated Postgres. Full affected/focused/static gates pass locally. Task intentionally remains In Progress with AC/DoD unchecked pending controller and hosted gates.
+
+2026-08-30 completed local closure after final production-backed Postgres regression 663ed880f07a5d7289dd70487b5a9509a05f19b6 and scoped independent re-review with no remaining findings. All acceptance criteria and local DoD evidence are complete; TASK-13144 remains deferred. Hosted backend-required, security-required, and coverage-required are still mandatory on the unchanged future PR head before merge.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -4,7 +4,7 @@ title: Harden trusted proxy client identity and login lockout isolation
 status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 06:51'
+updated_date: '2026-08-30 07:03'
 labels:
   - release-readiness
   - security
@@ -52,12 +52,20 @@ Exact local commands/results: (1) ../../.venv/bin/python -m pytest tldw_Server_A
 Docs/scope: cmp Docs/Operations/Env_Vars.md Docs/Published/Env_Vars.md => exit 0; cmp Docs/Deployment/horizontal-scaling.md Docs/Published/Deployment/horizontal-scaling.md => exit 0; python3 Helper_Scripts/docs/check_public_private_boundary.py => exit 0 (OK public OSS boundary); git diff --check origin/dev...HEAD => exit 0; forbidden-path scan => no output, exit 0. Changed-path review is limited to planned trusted-proxy/auth code and tests, docs/spec/plan, Resource_Governance README, and Backlog records; no migrations, dependency manifests, global security middleware, or websocket paths. Task 6 mirror-alignment ruling remains accepted; no docs regeneration performed.
 
 Known pending items: do not mark acceptance/DoD complete or task Done until controller task/final review and hosted backend-required, security-required, coverage-required gates pass on the unchanged reviewed head. TASK-13144 remains the deferred global request.client rewrite.
+
+2026-08-30 independent-review Ruff fix round: review identified Task 7 Step 3 as unmet because the exact 10-path full-file Ruff command exited 1 with 10 diagnostics. Reproduced RED with that exact command: auth.py I001/F401/B010/B010/B904; test_auth_endpoints_extended.py I001/B017/I001; integration test I001/I001. Minimal fixes only in those touched files: Ruff-organized imports; removed unused OIDCFederationService import; replaced constant-name setattr calls with equivalent state attributes; chained the verification-token HTTPException from None; narrowed the pre-existing broad reset-password assertion to Pydantic ValidationError (the observed model-validation boundary); and removed a redundant local datetime import. No proxy/auth feature behavior, docs, plan/spec, dependencies, services, or generated mirrors changed.
+
+Fresh exact gates at the uncommitted fix-round head: ../../.venv/bin/ruff check [Task 7 exact 10 paths] => All checks passed, exit 0. ../../.venv/bin/python -m py_compile [same 10 paths] => exit 0. ../../.venv/bin/python -m pytest tldw_Server_API/tests/Security/test_trusted_proxy.py tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py -q => 96 passed, 132 warnings, exit 0. ../../.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py -q => 3 passed, 10 warnings, exit 0; no Postgres fixture skip. ../../.venv/bin/bandit -q -ll trusted_proxy.py ip_allowlist.py deps.py auth.py => exit 0, only existing nosec B105 warning (auth.py line 1267). git diff --check origin/dev...HEAD and git diff --check => exit 0. Narrowed assertion check: test_reset_password_weak_and_success initially showed its existing Pydantic ValidationError contract (not HTTPException); after precise assertion update, 1 passed / 48 deselected.
+
+Review status remains pending: leave all AC/DoD unchecked and TASK status In Progress until controller re-review plus hosted required gates. TASK-13144 remains deferred.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 2026-08-29 local completion-gate evidence recorded at head fdaf564a14. Focused security/wrapper/auth tests: 96 passed; integration lockout module: 3 passed (no fixture skip); compilation, changed-code Ruff safety selection, Bandit Medium/High gate, document mirrors/boundary, whitespace, and forbidden-path checks passed. Full-file Ruff has 10 inherited findings, unchanged/reduced versus base and outside changed code; no unrelated cleanup made. TASK remains In Progress pending controller reviews and hosted required gates; TASK-13144 remains the deferred global rewrite.
+
+2026-08-30 review fix round: the prior inherited-Ruff concern is resolved. Exact full-file Ruff now passes on all 10 Task 7 paths; compilation, 96 focused tests, 3 Postgres integration tests (no skip), Bandit Medium/High gate, and whitespace checks pass. Task remains In Progress with AC/DoD unchecked, pending controller re-review and hosted gates; TASK-13144 remains deferred.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -1,18 +1,23 @@
 ---
 id: TASK-13013.5
 title: Harden trusted proxy client identity and login lockout isolation
-status: To Do
+status: In Progress
 assignee: []
-created_date: '2026-08-21 19:50'
+created_date: 2026-08-21 19:50
 labels:
-  - release-readiness
-  - security
-  - auth
-  - proxy
-  - rate-limit
+- release-readiness
+- security
+- auth
+- proxy
+- rate-limit
 dependencies: []
 parent_task_id: TASK-13013
 priority: high
+references:
+- TASK-13144
+documentation:
+- Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
+updated_date: 2026-08-30 02:51
 ---
 
 ## Description
@@ -37,3 +42,10 @@ Provide a production-safe trusted-proxy contract that preserves sanitized client
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-08-29: Approved architectural direction: add one shared pure trusted-hop resolver under app/core/Security while retaining the existing AUTH_* and RG_* environment-variable families through thin wrappers; replace shared raw-IP password-login lockout state with versioned deterministic client-plus-normalized-login buckets plus the existing account bucket; preserve the exact bucket through MFA; do not rewrite request.client globally in this release slice. Final pre-spec review requires canonical IP output only, X-Forwarded-For precedence and right-to-left trusted-hop walking, fail-closed malformed/repeated-header handling, login normalization matching fetch_user_by_login_identifier, versioned SHA-256 keys, and MFA key-shape validation. Global HTTP/WebSocket request.client rewriting is deferred to TASK-13144 and does not block TASK-13013.
+2026-08-29 spec baseline: isolated branch codex/task-13013-5-trusted-proxy-lockout starts from origin/dev f676e23549ea8ed82ef53493260621a05b281863. Existing focused proxy baseline passed with the project virtualenv: 15 passed across AuthNZ IP allowlist plus Resource Governor trusted-proxy dependency/middleware tests. No dependency or system installation was performed. Written design: Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
+++ b/backlog/tasks/task-13013.5 - Harden-trusted-proxy-client-identity-and-login-lockout-isolation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13013.5
 title: Harden trusted proxy client identity and login lockout isolation
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-30 07:41'
+updated_date: '2026-08-30 15:42'
 labels:
   - release-readiness
   - security
@@ -64,6 +64,10 @@ Review status remains pending: leave all AC/DoD unchecked and TASK status In Pro
 2026-08-30 final closure approved at exact reviewed head 663ed880f07a5d7289dd70487b5a9509a05f19b6. Independent whole-branch review initially identified the production RateLimiter/LockoutTracker Postgres persistence gap; final commit 663ed880f07a5d7289dd70487b5a9509a05f19b6 added the production-backed endpoint regression, and its scoped re-review verdict is ADDRESSED with no Critical, Important, or Minor findings. Evidence: 1 production-backed regression passed (3 deselected); affected integration module 4 passed; focused matrix 96 passed; exact ten-path Ruff and py_compile passed; Bandit -q -ll passed with only existing B105 nosec warning and no Medium/High finding; exact diff checks passed; canonical/published docs mirrors compare equal. This closes all three acceptance criteria and all six local DoD items.
 
 TASK-13144 remains the intentional deferred global HTTP/WebSocket request.client normalization rewrite. Hosted backend-required, security-required, and coverage-required checks remain mandatory on the unchanged future PR head before merge; they do not block this local task closure or authorize push/merge.
+
+2026-08-30 PR #2838 Qodo follow-up: reopened after Qodo submitted ten review comments on exact head e6e7b52ed9. Review scope: move lockout-key business rules into core AuthNZ, document new functions/module, classify changed tests with accepted pytest markers, remove endpoint-private helper coupling, and preserve safely completable in-flight MFA challenges created before login_lockout_key existed. Each comment will be technically validated, fixed or answered in-thread, and the task will return to Done only after focused/static gates and Qodo/required CI are green.
+
+2026-08-30 Qodo remediation local verification: moved stable login-client key construction and validation into core AuthNZ lockout_tracker and switched the endpoint to public core helpers; added requested production/helper docstrings and accepted unit classifications to all changed unit test modules; replaced endpoint-private helper assertions with the public core persistence contract. Rolling-deploy MFA compatibility now accepts only a genuinely absent legacy login_lockout_key, resets the canonical account bucket after successful MFA, and continues to reject every malformed present key before user lookup. TDD evidence: the new legacy MFA completion case failed before implementation and passed afterward. Fresh verification: 16 focused lockout/MFA cases passed; full focused matrix 96 passed; production-backed isolated Postgres module 4 passed with TLDW_TEST_NO_DOCKER=1 (no Docker startup/install); exact 11-path Ruff passed; py_compile passed; Bandit -q -ll passed with only the existing nosec B105 warning and no Medium/High finding; working-tree and branch diff checks, both published-doc cmp checks, and the public/private boundary check passed. Awaiting push, inline replies/thread resolution, Qodo follow-up, and required CI before final Done/merge.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -81,9 +85,9 @@ TASK-13144 remains the intentional deferred global HTTP/WebSocket request.client
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded
+- [ ] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [x] #5 Final summary added
-- [x] #6 Known skips or blockers documented
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13144 - Normalize-trusted-client-identity-globally-in-request-middleware.md
+++ b/backlog/tasks/task-13144 - Normalize-trusted-client-identity-globally-in-request-middleware.md
@@ -1,0 +1,54 @@
+---
+id: TASK-13144
+title: Normalize trusted client identity globally in request middleware
+status: To Do
+created_date: 2026-08-30 02:45
+dependencies:
+- TASK-13013.5
+labels:
+- security
+- proxy
+- middleware
+- architecture
+- future
+priority: medium
+references:
+- TASK-13013.5
+documentation:
+- Docs/superpowers/specs/2026-08-29-task-13013-5-trusted-proxy-login-lockout-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace per-consumer trusted-proxy resolution with one global HTTP and WebSocket middleware contract that rewrites the application-visible client identity while preserving the immutable physical peer separately. Audit every request.client consumer before migration so authorization, audit, setup, WebSocket, and Resource Governor behavior cannot change silently. This is future architecture work and is not part of the current core-release epic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 HTTP and WebSocket application code receives one canonical trusted client identity while the physical peer remains separately available for trust decisions and audit evidence.
+- [ ] #2 Every existing request.client consumer is inventoried and either migrated or explicitly exempted with compatibility tests.
+- [ ] #3 AuthNZ and Resource Governor duplicate resolver wrappers are removed only after direct, trusted-proxy, multi-hop, spoofed, malformed, IPv4, IPv6, setup, audit, and WebSocket regression coverage passes.
+- [ ] #4 Rollout includes observability, staged enablement, and an operator-safe rollback path without weakening forwarding-header trust boundaries.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests and verification recorded
+- [ ] #3 Operator and architecture documentation updated
+- [ ] #4 Bandit run for touched code with no new medium/high findings
+- [ ] #5 Final summary and rollout/rollback evidence added
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -5,7 +5,6 @@
 import asyncio
 import base64
 import contextlib
-import hashlib
 import json
 import os
 import re
@@ -98,6 +97,10 @@ from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
     resolve_client_ip,
 )
 from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+from tldw_Server_API.app.core.AuthNZ.lockout_tracker import (
+    build_login_client_lockout_key,
+    validate_login_client_lockout_key,
+)
 from tldw_Server_API.app.core.AuthNZ.orgs_teams import list_memberships_for_user
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -990,9 +993,6 @@ def _is_enterprise_admin_ui_mode() -> bool:
     return raw_value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-_LOGIN_CLIENT_LOCKOUT_KEY_RE = re.compile(r"login-client-v1:[0-9a-f]{64}\Z")
-
-
 def _auth_request_client_ip(request: Request) -> str:
     try:
         settings = get_settings()
@@ -1002,19 +1002,6 @@ def _auth_request_client_ip(request: Request) -> str:
         return resolve_client_ip(request, settings) or "unknown"
     except _AUTH_NONCRITICAL_EXCEPTIONS:
         return "unknown"
-
-
-def _login_client_lockout_key(client_ip: str | None, login_identifier: str) -> str:
-    payload = json.dumps(
-        [client_ip or "unknown", login_identifier.strip().lower()],
-        ensure_ascii=False,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return f"login-client-v1:{hashlib.sha256(payload).hexdigest()}"
-
-
-def _validated_login_client_lockout_key(value: object) -> str | None:
-    return value if isinstance(value, str) and _LOGIN_CLIENT_LOCKOUT_KEY_RE.fullmatch(value) else None
 
 
 def _auth_hashed_entity(raw_value: str) -> str:
@@ -1583,7 +1570,7 @@ async def login(
         # Get client info and normalize the identifier as the database lookup does.
         client_ip = _auth_request_client_ip(request)
         login_identifier = form_data.username.strip().lower()
-        client_login_lockout_key = _login_client_lockout_key(client_ip, login_identifier)
+        client_login_lockout_key = build_login_client_lockout_key(client_ip, login_identifier)
         user_agent = request.headers.get("User-Agent", "Unknown")
         # PII-aware logging
         if settings.PII_REDACT_LOGS:
@@ -3504,8 +3491,15 @@ async def mfa_login(
 
         session_id = payload.get("session_id")
         user_id = payload.get("user_id")
-        login_lockout_key = _validated_login_client_lockout_key(payload.get("login_lockout_key"))
-        if not session_id or not user_id or login_lockout_key is None:
+        login_lockout_key = None
+        if "login_lockout_key" in payload:
+            login_lockout_key = validate_login_client_lockout_key(payload.get("login_lockout_key"))
+            if login_lockout_key is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="MFA session expired or invalid",
+                )
+        if not session_id or not user_id:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="MFA session expired or invalid",
@@ -3624,7 +3618,8 @@ async def mfa_login(
         # Reset failed login attempts on successful MFA login
         if getattr(rate_limiter, 'enabled', False):
             try:
-                await rate_limiter.reset_failed_attempts(login_lockout_key, "login")
+                if login_lockout_key is not None:
+                    await rate_limiter.reset_failed_attempts(login_lockout_key, "login")
                 await rate_limiter.reset_failed_attempts(user.get("username", ""), "login")
             except _AUTH_NONCRITICAL_EXCEPTIONS as rl_exc:
                 logger.debug(f"rate_limiter.reset_failed_attempts failed: {rl_exc}")

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -45,7 +45,6 @@ from tldw_Server_API.app.api.v1.API_Deps.federation_deps import (
     get_oidc_federation_service_dep,
     require_enterprise_federation,
 )
-from tldw_Server_API.app.api.v1.utils.deprecation import build_deprecation_headers
 
 #
 # Local imports
@@ -63,6 +62,7 @@ from tldw_Server_API.app.api.v1.schemas.auth_schemas import (
     SingleUserSessionResponse,
     TokenResponse,
 )
+from tldw_Server_API.app.api.v1.utils.deprecation import build_deprecation_headers
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditContext,
     AuditEventType,
@@ -72,6 +72,8 @@ from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.auth_governor import get_auth_governor
 from tldw_Server_API.app.core.AuthNZ.csrf_protection import (
     global_settings as _csrf_globals,
+)
+from tldw_Server_API.app.core.AuthNZ.csrf_protection import (
     resolve_effective_csrf_enabled,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
@@ -87,6 +89,9 @@ from tldw_Server_API.app.core.AuthNZ.exceptions import (
     TokenExpiredError,
     WeakPasswordError,
 )
+from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import FederationProvisioningService
+from tldw_Server_API.app.core.AuthNZ.federation.state_repo import FederationStateRepo
 from tldw_Server_API.app.core.AuthNZ.input_validation import get_input_validator
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
     is_single_user_ip_allowed,
@@ -106,34 +111,50 @@ from tldw_Server_API.app.core.AuthNZ.single_user_session import (
     validate_single_user_session,
 )
 from tldw_Server_API.app.core.AuthNZ.token_blacklist import get_token_blacklist
+from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_Server_API.app.core.Resource_Governance.governor import MemoryResourceGovernor, RGRequest
 from tldw_Server_API.app.core.Resource_Governance.policy_loader import default_policy_loader
 from tldw_Server_API.app.core.Resource_Governance.tenant import hash_entity
-from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_Server_API.app.core.testing import (
+    env_flag_enabled as _env_flag_enabled,
+)
+from tldw_Server_API.app.core.testing import (
+    is_explicit_pytest_runtime as _is_explicit_pytest_runtime,
+)
+from tldw_Server_API.app.core.testing import (
+    is_test_mode as _is_test_mode,
+)
+from tldw_Server_API.app.core.testing import (
+    is_truthy as _is_truthy,
+)
 from tldw_Server_API.app.services.auth_service import (
     apply_password_reset as _svc_apply_password_reset,
+)
+from tldw_Server_API.app.services.auth_service import (
     fetch_active_user_by_id,
-    fetch_password_reset_token_record as _svc_fetch_password_reset_token_record,
-    fetch_user_by_email_for_password_reset as _svc_fetch_user_by_email_for_password_reset,
-    fetch_user_by_email_for_verification as _svc_fetch_user_by_email_for_verification,
     fetch_user_by_login_identifier,
-    mark_user_verified as _svc_mark_user_verified,
-    store_password_reset_token as _svc_store_password_reset_token,
-    verify_user_email_once as _svc_verify_user_email_once,
     update_user_last_login,
     update_user_password_hash,
 )
-from tldw_Server_API.app.services.registration_service import RegistrationService
-from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
-from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
-from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import FederationProvisioningService
-from tldw_Server_API.app.core.AuthNZ.federation.state_repo import FederationStateRepo
-from tldw_Server_API.app.core.testing import (
-    env_flag_enabled as _env_flag_enabled,
-    is_explicit_pytest_runtime as _is_explicit_pytest_runtime,
-    is_test_mode as _is_test_mode,
-    is_truthy as _is_truthy,
+from tldw_Server_API.app.services.auth_service import (
+    fetch_password_reset_token_record as _svc_fetch_password_reset_token_record,
 )
+from tldw_Server_API.app.services.auth_service import (
+    fetch_user_by_email_for_password_reset as _svc_fetch_user_by_email_for_password_reset,
+)
+from tldw_Server_API.app.services.auth_service import (
+    fetch_user_by_email_for_verification as _svc_fetch_user_by_email_for_verification,
+)
+from tldw_Server_API.app.services.auth_service import (
+    mark_user_verified as _svc_mark_user_verified,
+)
+from tldw_Server_API.app.services.auth_service import (
+    store_password_reset_token as _svc_store_password_reset_token,
+)
+from tldw_Server_API.app.services.auth_service import (
+    verify_user_email_once as _svc_verify_user_email_once,
+)
+from tldw_Server_API.app.services.registration_service import RegistrationService
 
 _AUTH_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -1080,9 +1101,9 @@ async def _get_auth_endpoint_rg_governor(request: Request) -> Optional[Any]:
             if loader is None:
                 loader = default_policy_loader()
                 await loader.load_once()
-                setattr(state, "rg_policy_loader", loader)
+                state.rg_policy_loader = loader
             fallback = MemoryResourceGovernor(policy_loader=loader)
-            setattr(state, "auth_endpoint_rg_governor", fallback)
+            state.auth_endpoint_rg_governor = fallback
             return fallback
         except _AUTH_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Auth endpoint RG fallback governor init failed: {}", exc)
@@ -2755,7 +2776,7 @@ async def verify_email(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid or expired verification token",
-            )
+            ) from None
 
         # Update user's verification status only when it is currently unverified.
         updated_rows = await _verify_user_email_once(

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -5,6 +5,7 @@
 import asyncio
 import base64
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -968,21 +969,31 @@ def _is_enterprise_admin_ui_mode() -> bool:
     return raw_value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+_LOGIN_CLIENT_LOCKOUT_KEY_RE = re.compile(r"login-client-v1:[0-9a-f]{64}\Z")
+
+
 def _auth_request_client_ip(request: Request) -> str:
     try:
         settings = get_settings()
     except _AUTH_NONCRITICAL_EXCEPTIONS:
         settings = None
     try:
-        resolved = resolve_client_ip(request, settings)
-        if resolved:
-            return str(resolved)
-    except _AUTH_NONCRITICAL_EXCEPTIONS:
-        pass
-    try:
-        return request.client.host if request.client else "unknown"
+        return resolve_client_ip(request, settings) or "unknown"
     except _AUTH_NONCRITICAL_EXCEPTIONS:
         return "unknown"
+
+
+def _login_client_lockout_key(client_ip: str | None, login_identifier: str) -> str:
+    payload = json.dumps(
+        [client_ip or "unknown", login_identifier.strip().lower()],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"login-client-v1:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _validated_login_client_lockout_key(value: object) -> str | None:
+    return value if isinstance(value, str) and _LOGIN_CLIENT_LOCKOUT_KEY_RE.fullmatch(value) else None
 
 
 def _auth_hashed_entity(raw_value: str) -> str:

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -1559,8 +1559,10 @@ async def login(
     log_counter("auth_login_attempt")
     auth_gov = await get_auth_governor()
     try:
-        # Get client info
+        # Get client info and normalize the identifier as the database lookup does.
         client_ip = _auth_request_client_ip(request)
+        login_identifier = form_data.username.strip().lower()
+        client_login_lockout_key = _login_client_lockout_key(client_ip, login_identifier)
         user_agent = request.headers.get("User-Agent", "Unknown")
         # PII-aware logging
         if settings.PII_REDACT_LOGS:
@@ -1568,18 +1570,18 @@ async def login(
         else:
             logger.info(f"Login attempt for user: {form_data.username} from IP: {client_ip}")
 
-        # Check if IP is locked out (only when rate limiting is enabled)
+        # Check if this client/login pair is locked out (only when rate limiting is enabled)
         is_locked = False
         lockout_expires = None
         if getattr(rate_limiter, 'enabled', False):
             is_locked, lockout_expires = await auth_gov.check_lockout(
-                client_ip,
+                client_login_lockout_key,
                 attempt_type="login",
                 rate_limiter=rate_limiter,
             )
         if is_locked:
-            logger.warning(f"Login attempt from locked IP: {client_ip}")
-            log_counter("auth_login_locked_ip")
+            logger.warning("Login attempt from locked client/login pair")
+            log_counter("auth_login_locked_client")
             retry_after_seconds = 900
             if isinstance(lockout_expires, datetime):
                 try:
@@ -1597,10 +1599,6 @@ async def login(
                 detail="Too many failed login attempts. Please try again later.",
                 headers={"Retry-After": str(retry_after_seconds)}
             )
-
-        # Sanitize input (lightweight). For login, avoid strict validation to not block
-        # legitimate existing accounts (e.g., reserved usernames like 'admin').
-        login_identifier = form_data.username.strip()
 
         # Helper to attempt audit logging without hard dependency (safe no-op in tests)
         async def _safe_audit_log_login(user_id: int, username: str, ip: str, ua: str, success: bool):
@@ -1638,10 +1636,10 @@ async def login(
             else:
                 logger.warning(f"Failed login: User not found - {login_identifier}")
 
-            # Track failed attempt by IP (only when rate limiting is enabled)
+            # Track failed attempt by client/login pair (only when rate limiting is enabled)
             if getattr(rate_limiter, 'enabled', False):
                 await auth_gov.record_auth_failure(
-                    identifier=client_ip,
+                    identifier=client_login_lockout_key,
                     attempt_type="login",
                     rate_limiter=rate_limiter,
                 )
@@ -1731,12 +1729,12 @@ async def login(
                 success=False,
             )
 
-            # Track failed attempt by IP and username
-            ip_result = {"is_locked": False, "remaining_attempts": 5}
+            # Track failed attempt by client/login pair and username
+            client_result = {"is_locked": False, "remaining_attempts": 5}
             user_result = {"is_locked": False, "remaining_attempts": 5}
             if getattr(rate_limiter, 'enabled', False):
-                ip_result = await auth_gov.record_auth_failure(
-                    identifier=client_ip,
+                client_result = await auth_gov.record_auth_failure(
+                    identifier=client_login_lockout_key,
                     attempt_type="login",
                     rate_limiter=rate_limiter,
                 )
@@ -1747,7 +1745,7 @@ async def login(
                 )
 
             # Provide informative error if locked out
-            if ip_result['is_locked'] or user_result['is_locked']:
+            if client_result['is_locked'] or user_result['is_locked']:
                 log_counter("auth_login_locked_user")
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -1756,7 +1754,7 @@ async def login(
                 )
 
             # Otherwise generic error
-            remaining = min(ip_result.get('remaining_attempts', 5), user_result.get('remaining_attempts', 5))
+            remaining = min(client_result.get('remaining_attempts', 5), user_result.get('remaining_attempts', 5))
             logger.info(f"Remaining login attempts: {remaining}")
 
             log_counter("auth_login_invalid_password")
@@ -1934,7 +1932,7 @@ async def login(
         # Reset failed login attempts on successful login
         if getattr(rate_limiter, 'enabled', False):
             try:
-                await rate_limiter.reset_failed_attempts(client_ip, "login")
+                await rate_limiter.reset_failed_attempts(client_login_lockout_key, "login")
                 await rate_limiter.reset_failed_attempts(user['username'], "login")
             except _AUTH_NONCRITICAL_EXCEPTIONS as rl_exc:
                 # Guardrails must not break successful logins; log and continue.

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -1867,6 +1867,7 @@ async def login(
                 payload = {
                     "user_id": int(user["id"]),
                     "session_id": int(session_id),
+                    "login_lockout_key": client_login_lockout_key,
                 }
                 try:
                     await session_manager.store_ephemeral_value(
@@ -3482,7 +3483,8 @@ async def mfa_login(
 
         session_id = payload.get("session_id")
         user_id = payload.get("user_id")
-        if not session_id or not user_id:
+        login_lockout_key = _validated_login_client_lockout_key(payload.get("login_lockout_key"))
+        if not session_id or not user_id or login_lockout_key is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="MFA session expired or invalid",
@@ -3601,7 +3603,7 @@ async def mfa_login(
         # Reset failed login attempts on successful MFA login
         if getattr(rate_limiter, 'enabled', False):
             try:
-                await rate_limiter.reset_failed_attempts(client_ip, "login")
+                await rate_limiter.reset_failed_attempts(login_lockout_key, "login")
                 await rate_limiter.reset_failed_attempts(user.get("username", ""), "login")
             except _AUTH_NONCRITICAL_EXCEPTIONS as rl_exc:
                 logger.debug(f"rate_limiter.reset_failed_attempts failed: {rl_exc}")

--- a/tldw_Server_API/app/core/AuthNZ/ip_allowlist.py
+++ b/tldw_Server_API/app/core/AuthNZ/ip_allowlist.py
@@ -53,6 +53,7 @@ def _ip_in_allowlist(ip: str | None, allowlist: list[str]) -> bool:
 
 
 def _header_values(request: Any, name: str) -> tuple[str, ...]:
+    """Return every value for a request header, or an empty tuple on failure."""
     try:
         headers = request.headers
         getlist = getattr(headers, "getlist", None)

--- a/tldw_Server_API/app/core/AuthNZ/ip_allowlist.py
+++ b/tldw_Server_API/app/core/AuthNZ/ip_allowlist.py
@@ -7,6 +7,10 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, get_settings
+from tldw_Server_API.app.core.Security.trusted_proxy import (
+    is_trusted_proxy_peer,
+    resolve_trusted_client_ip,
+)
 
 _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
@@ -48,14 +52,25 @@ def _ip_in_allowlist(ip: str | None, allowlist: list[str]) -> bool:
     return False
 
 
+def _header_values(request: Any, name: str) -> tuple[str, ...]:
+    try:
+        headers = request.headers
+        getlist = getattr(headers, "getlist", None)
+        if callable(getlist):
+            return tuple(str(value) for value in getlist(name))
+        value = headers.get(name)
+        return (str(value),) if value is not None else ()
+    except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
+        return ()
+
+
 def is_trusted_proxy_ip(ip: str | None, settings: Settings | None = None) -> bool:
     """Return True when IP is in the trusted proxy allowlist."""
-    s = settings or get_settings()
-    raw = getattr(s, "AUTH_TRUSTED_PROXY_IPS", None) or []
-    allowlist = _normalize_entries(raw)
-    if not allowlist:
-        return False
-    return _ip_in_allowlist(ip, allowlist)
+    resolved_settings = settings or get_settings()
+    entries = _normalize_entries(
+        getattr(resolved_settings, "AUTH_TRUSTED_PROXY_IPS", None) or []
+    )
+    return is_trusted_proxy_peer(ip, entries)
 
 
 def resolve_client_ip(request: Any, settings: Settings | None = None) -> str | None:
@@ -63,43 +78,31 @@ def resolve_client_ip(request: Any, settings: Settings | None = None) -> str | N
     if request is None:
         return None
     try:
-        s = settings or get_settings()
+        resolved_settings = settings or get_settings()
     except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
-        s = settings
+        resolved_settings = settings
     try:
         peer = getattr(getattr(request, "client", None), "host", None)
     except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
         peer = None
-
-    trust_xff = bool(getattr(s, "AUTH_TRUST_X_FORWARDED_FOR", False)) if s is not None else False
-    if trust_xff and is_trusted_proxy_ip(peer, s):
-        try:
-            xr = request.headers.get("x-real-ip") or request.headers.get("X-Real-IP")
-        except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
-            xr = None
-        if xr:
-            xr_val = xr.strip()
-            try:
-                ipaddress.ip_address(xr_val)
-                return xr_val
-            except ValueError:
-                pass
-        try:
-            fwd = request.headers.get("x-forwarded-for") or request.headers.get("X-Forwarded-For")
-        except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
-            fwd = None
-        if fwd:
-            try:
-                leftmost = fwd.split(",", 1)[0].strip()
-            except _IP_ALLOWLIST_NONCRITICAL_EXCEPTIONS:
-                leftmost = ""
-            if leftmost:
-                try:
-                    ipaddress.ip_address(leftmost)
-                    return leftmost
-                except ValueError:
-                    pass
-    return peer
+    trusted = (
+        _normalize_entries(
+            getattr(resolved_settings, "AUTH_TRUSTED_PROXY_IPS", None) or []
+        )
+        if resolved_settings is not None
+        else []
+    )
+    if not bool(getattr(resolved_settings, "AUTH_TRUST_X_FORWARDED_FOR", False)):
+        trusted = []
+    xff = _header_values(request, "x-forwarded-for")
+    real_ip_values = () if xff else _header_values(request, "x-real-ip")
+    real_ip = real_ip_values[0] if len(real_ip_values) == 1 else None
+    return resolve_trusted_client_ip(
+        peer,
+        trusted,
+        forwarded_for_values=xff,
+        single_forwarded_value=real_ip,
+    )
 
 
 def is_single_user_ip_allowed(ip: str | None, settings: Settings | None = None) -> bool:

--- a/tldw_Server_API/app/core/AuthNZ/lockout_tracker.py
+++ b/tldw_Server_API/app/core/AuthNZ/lockout_tracker.py
@@ -12,6 +12,9 @@ protection.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import re
 from datetime import datetime, timezone
 from typing import Any
 
@@ -20,6 +23,25 @@ from loguru import logger
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.rate_limits_repo import AuthnzRateLimitsRepo
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, get_settings
+
+_LOGIN_CLIENT_LOCKOUT_KEY_RE = re.compile(r"login-client-v1:[0-9a-f]{64}\Z")
+
+
+def build_login_client_lockout_key(client_ip: str | None, login_identifier: str) -> str:
+    """Build a stable, opaque lockout key for one client and login identifier."""
+    payload = json.dumps(
+        [client_ip or "unknown", login_identifier.strip().lower()],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"login-client-v1:{hashlib.sha256(payload).hexdigest()}"
+
+
+def validate_login_client_lockout_key(value: object) -> str | None:
+    """Return a canonical client lockout key, or ``None`` for invalid input."""
+    if isinstance(value, str) and _LOGIN_CLIENT_LOCKOUT_KEY_RE.fullmatch(value):
+        return value
+    return None
 
 
 class LockoutTracker:

--- a/tldw_Server_API/app/core/Resource_Governance/README.md
+++ b/tldw_Server_API/app/core/Resource_Governance/README.md
@@ -115,16 +115,18 @@ Notes
 - When `RG_POLICY_STORE=db` is active, the loader merges the file’s `route_map` into the snapshot containing DB policies. File `route_map` takes precedence on conflicts.
 - IMPORTANT: When `RG_POLICY_STORE=db` is active, YAML `policies:` are not used at runtime. Every `policy_id` referenced by `route_map` must exist in the DB store (`rg_policies`) or ingress enforcement will fail closed for that route (because missing request limits default to deny).
 - Durable daily caps can be specified with `daily_cap` under any category and are enforced via `ResourceDailyLedger` (e.g., `tokens.daily_cap`, `workflows_runs.daily_cap`).
-- Proxy/IP scoping (env):
-  - `RG_TRUSTED_PROXIES`: comma-separated CIDRs of reverse proxies
-  - `RG_CLIENT_IP_HEADER`: trusted header name (e.g., `X-Forwarded-For` or `CF-Connecting-IP`)
+- Proxy/IP scoping (opt-in env):
+  - `RG_TRUSTED_PROXIES`: comma-separated reverse-proxy hosts/CIDRs.
+  - `RG_CLIENT_IP_HEADER`: header to use only with a valid physical peer in that list (for example, `X-Forwarded-For`). Leave either unset to use the physical peer.
+  - `X-Forwarded-For` is parsed as a complete chain from the trusted edge inward (right-to-left); a malformed chain falls back to the physical peer. Any other header must be one plain IP literal.
+  - Invalid physical peers resolve to the safe `unknown` sentinel. If AuthNZ forwarding is also enabled, use equivalent trusted-proxy sets and compatible headers so login lockouts and RG derive the same client identity.
 - Metrics cardinality (env): `RG_METRICS_ENTITY_LABEL`: `true|false` (default `false`)
 - Test mode precedence: `RG_TEST_BYPASS` overrides Resource Governor behavior when set; otherwise falls back to `TLDW_TEST_MODE`
 
 ## Simple Middleware (default‑on)
 
 - Resolution order: path-based mapping (`route_map.by_path`) first, then tag-based mapping (`route_map.by_tag`). Wildcards like `/api/v1/chat/*` match by prefix.
-- Entity derivation: prefers authenticated user (`user:{id}`), then API key id/hash (`api_key:{id|hash}`), then trusted proxy IP header via `RG_CLIENT_IP_HEADER` when `RG_TRUSTED_PROXIES` contains the peer; otherwise falls back to `request.client.host`.
+- Entity derivation: prefers authenticated user (`user:{id}`), then API key id/hash (`api_key:{id|hash}`), then the configured trusted proxy header; otherwise falls back to the physical peer or safe `unknown` sentinel.
 - Behavior: performs a pre-check/reserve for the `requests` category before calling the endpoint and commits afterwards. On denial, sets `Retry-After` and `X-RateLimit-*` headers. On success, injects accurate `X-RateLimit-*` headers using a governor `peek` when available.
 - Scope: this middleware enforces **requests only**. Categories such as `tokens`, `streams`, `jobs`, and `minutes` require explicit endpoint-level RG reserve/commit plumbing (for example chat/embeddings tokens, audio streaming concurrency).
 - Enabled automatically whenever `RG_ENABLED=1`.

--- a/tldw_Server_API/app/core/Resource_Governance/deps.py
+++ b/tldw_Server_API/app/core/Resource_Governance/deps.py
@@ -11,11 +11,12 @@ Preference order:
   5) IP scope (trusted header via RG_CLIENT_IP_HEADER else request.client.host)
 """
 
-import ipaddress
 import os
 
 from fastapi import Request
 from loguru import logger
+
+from tldw_Server_API.app.core.Security.trusted_proxy import resolve_trusted_client_ip
 
 from .tenant import TenantScopeConfig, get_tenant_id, hash_entity, parse_tenant_config
 
@@ -30,38 +31,6 @@ _RG_DEPS_NONCRITICAL_EXCEPTIONS = (
 )
 
 
-def _parse_trusted_proxies(env_val: str | None) -> list[ipaddress._BaseNetwork]:
-    nets: list[ipaddress._BaseNetwork] = []
-    if not env_val:
-        return nets
-    for part in env_val.split(","):
-        s = part.strip()
-        if not s:
-            continue
-        try:
-            # Accept both single IPs and CIDRs
-            if "/" in s:
-                nets.append(ipaddress.ip_network(s, strict=False))
-            else:
-                # Represent single host as /32 or /128 network
-                ip_obj = ipaddress.ip_address(s)
-                mask = 32 if ip_obj.version == 4 else 128
-                nets.append(ipaddress.ip_network(f"{s}/{mask}", strict=False))
-        except ValueError:
-            continue
-    return nets
-
-
-def _is_trusted_proxy(remote_ip: str, trusted: list[ipaddress._BaseNetwork]) -> bool:
-    try:
-        if not remote_ip or not trusted:
-            return False
-        ip_obj = ipaddress.ip_address(remote_ip)
-        return any(ip_obj in n for n in trusted)
-    except ValueError:
-        return False
-
-
 def derive_client_ip(request: Request) -> str:
     """Derive client IP with trusted proxy handling.
 
@@ -69,50 +38,31 @@ def derive_client_ip(request: Request) -> str:
       the immediate peer (request.client.host) is within RG_TRUSTED_PROXIES (CIDR/IP list).
     - Otherwise, fall back to request.client.host.
     """
-    # Immediate peer address
-    remote_ip = None
     try:
-        client = request.client
-        if client and client.host:
-            remote_ip = client.host
+        peer = request.client.host if request.client and request.client.host else None
     except _RG_DEPS_NONCRITICAL_EXCEPTIONS:
-        remote_ip = None
-    # Normalize non-IP placeholders used by Starlette TestClient
-    # Many tests see client.host == 'testclient'; treat as loopback
-    try:
-        import ipaddress as _ip
-        if not remote_ip:
-            remote_ip = None
+        peer = None
+    trusted = tuple(
+        part.strip()
+        for part in (os.getenv("RG_TRUSTED_PROXIES") or "").split(",")
+        if part.strip()
+    )
+    header_name = (os.getenv("RG_CLIENT_IP_HEADER") or "").strip()
+    xff_values: tuple[str, ...] = ()
+    single_value = None
+    if header_name:
+        if header_name.lower() == "x-forwarded-for":
+            xff_values = tuple(request.headers.getlist(header_name))
         else:
-            try:
-                _ip.ip_address(remote_ip)
-            except ValueError:
-                # Not a valid IP literal → assume loopback for local tests
-                remote_ip = "127.0.0.1"
-    except ImportError:
-        # best-effort
-        pass
-
-    trusted = _parse_trusted_proxies(os.getenv("RG_TRUSTED_PROXIES"))
-    header_name = os.getenv("RG_CLIENT_IP_HEADER")
-
-    # Use header only when the remote peer is trusted
-    if header_name and _is_trusted_proxy(remote_ip or "", trusted):
-        val = request.headers.get(header_name) or request.headers.get(header_name.lower())
-        if val:
-            # For X-Forwarded-For, choose left-most IP
-            candidate = str(val).split(",")[0].strip()
-            try:
-                ipaddress.ip_address(candidate)
-                if candidate:
-                    return candidate
-            except ValueError:
-                pass
-
-    # Fallback: use direct peer address
-    if remote_ip:
-        return remote_ip
-    return "unknown"
+            header_values = tuple(request.headers.getlist(header_name))
+            single_value = header_values[0] if len(header_values) == 1 else None
+    resolved = resolve_trusted_client_ip(
+        peer,
+        trusted,
+        forwarded_for_values=xff_values,
+        single_forwarded_value=single_value,
+    )
+    return resolved or "unknown"
 
 
 def _tenant_claims_from_state(request: Request) -> dict[str, object]:

--- a/tldw_Server_API/app/core/Security/trusted_proxy.py
+++ b/tldw_Server_API/app/core/Security/trusted_proxy.py
@@ -1,3 +1,5 @@
+"""Resolve client IPs without trusting headers from untrusted network peers."""
+
 from __future__ import annotations
 
 import ipaddress
@@ -8,6 +10,7 @@ IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 def _parse_ip(value: str | None) -> IPAddress | None:
+    """Parse a plain IPv4 or IPv6 address, rejecting scoped and malformed values."""
     if not isinstance(value, str):
         return None
     token = value.strip()
@@ -20,6 +23,7 @@ def _parse_ip(value: str | None) -> IPAddress | None:
 
 
 def _parse_networks(entries: Iterable[str]) -> tuple[IPNetwork, ...]:
+    """Parse valid trusted-proxy host and network entries, ignoring invalid ones."""
     networks: list[IPNetwork] = []
     for entry in entries:
         token = str(entry).strip()
@@ -33,6 +37,7 @@ def _parse_networks(entries: Iterable[str]) -> tuple[IPNetwork, ...]:
 
 
 def _address_is_trusted(address: IPAddress, networks: tuple[IPNetwork, ...]) -> bool:
+    """Return whether an address belongs to any same-family trusted network."""
     return any(address.version == network.version and address in network for network in networks)
 
 
@@ -40,6 +45,7 @@ def is_trusted_proxy_peer(
     physical_peer: str | None,
     trusted_proxy_entries: Iterable[str],
 ) -> bool:
+    """Return whether the physical network peer is configured as trusted."""
     peer = _parse_ip(physical_peer)
     return peer is not None and _address_is_trusted(peer, _parse_networks(trusted_proxy_entries))
 
@@ -51,6 +57,7 @@ def resolve_trusted_client_ip(
     forwarded_for_values: Iterable[str] = (),
     single_forwarded_value: str | None = None,
 ) -> str | None:
+    """Resolve the client address, honoring forwarding headers only from trusted peers."""
     peer = _parse_ip(physical_peer)
     if peer is None:
         return None

--- a/tldw_Server_API/app/core/Security/trusted_proxy.py
+++ b/tldw_Server_API/app/core/Security/trusted_proxy.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Iterable
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+def _parse_ip(value: str | None) -> IPAddress | None:
+    if not isinstance(value, str):
+        return None
+    token = value.strip()
+    if not token or "%" in token:
+        return None
+    try:
+        return ipaddress.ip_address(token)
+    except ValueError:
+        return None
+
+
+def _parse_networks(entries: Iterable[str]) -> tuple[IPNetwork, ...]:
+    networks: list[IPNetwork] = []
+    for entry in entries:
+        token = str(entry).strip()
+        if not token:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(token, strict=False))
+        except ValueError:
+            continue
+    return tuple(networks)
+
+
+def _address_is_trusted(address: IPAddress, networks: tuple[IPNetwork, ...]) -> bool:
+    return any(address.version == network.version and address in network for network in networks)
+
+
+def is_trusted_proxy_peer(
+    physical_peer: str | None,
+    trusted_proxy_entries: Iterable[str],
+) -> bool:
+    peer = _parse_ip(physical_peer)
+    return peer is not None and _address_is_trusted(peer, _parse_networks(trusted_proxy_entries))
+
+
+def resolve_trusted_client_ip(
+    physical_peer: str | None,
+    trusted_proxy_entries: Iterable[str],
+    *,
+    forwarded_for_values: Iterable[str] = (),
+    single_forwarded_value: str | None = None,
+) -> str | None:
+    peer = _parse_ip(physical_peer)
+    if peer is None:
+        return None
+    networks = _parse_networks(trusted_proxy_entries)
+    if not _address_is_trusted(peer, networks):
+        return peer.compressed
+
+    xff_values = tuple(str(value) for value in forwarded_for_values)
+    if xff_values:
+        parsed_chain: list[IPAddress] = []
+        for token in ",".join(xff_values).split(","):
+            parsed = _parse_ip(token)
+            if parsed is None:
+                return peer.compressed
+            parsed_chain.append(parsed)
+        for address in reversed(parsed_chain):
+            if not _address_is_trusted(address, networks):
+                return address.compressed
+        return peer.compressed
+
+    if single_forwarded_value is not None:
+        forwarded = _parse_ip(single_forwarded_value)
+        return forwarded.compressed if forwarded is not None else peer.compressed
+    return peer.compressed

--- a/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
@@ -1,10 +1,9 @@
 """
 Integration tests for login lockouts routed via AuthGovernor.
 
-These tests focus on the HTTP surface of `/api/v1/auth/login` while
-exercising the AuthGovernor lockout facade through a stubbed rate
-limiter dependency. The underlying database remains Postgres via the
-`isolated_test_environment` fixture.
+These tests focus on the HTTP surface of `/api/v1/auth/login`. Precise call
+sequencing uses a stubbed limiter, while the durable-state regression uses the
+production RateLimiter and LockoutTracker against isolated Postgres.
 """
 
 import re
@@ -233,3 +232,158 @@ class TestAuthLoginLockoutViaAuthGovernor:
             if identifier != self.username
         )
         assert "testclient" not in client_identifiers
+
+
+@pytest.mark.asyncio
+async def test_production_limiter_persists_isolates_and_resets_login_buckets(
+    isolated_test_environment,
+):
+    client, db_name = isolated_test_environment
+    username = "lockout_user"
+    password = "Lockout@Pass#2025"
+    expected_client_key = (
+        "login-client-v1:d8c8452748a212e653073905b9b063f35c116cc0315f5f395f093efbfbb3142a"
+    )
+    other_client_key = (
+        "login-client-v1:38ab9c29623460391659117c61288e80587871f39d52535c6fa9cf689c5f76c8"
+    )
+
+    from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.main import app
+
+    assert get_rate_limiter_dep not in app.dependency_overrides
+
+    conn = await asyncpg.connect(
+        host=TEST_DB_HOST,
+        port=TEST_DB_PORT,
+        user=TEST_DB_USER,
+        password=TEST_DB_PASSWORD,
+        database=db_name,
+    )
+    try:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                uuid,
+                username,
+                email,
+                password_hash,
+                role,
+                is_active,
+                is_verified,
+                storage_quota_mb,
+                storage_used_mb
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            "00000000-0000-0000-0000-000000000001",
+            username,
+            "lockout@example.com",
+            PasswordService().hash_password(password),
+            "user",
+            True,
+            True,
+            5120,
+            0.0,
+        )
+    finally:
+        await conn.close()
+
+    threshold = get_settings().MAX_LOGIN_ATTEMPTS
+    for _ in range(threshold):
+        response = client.post(
+            "/api/v1/auth/login",
+            data={"username": username, "password": "WrongPassword1!"},
+        )
+    assert response.status_code == 429
+
+    other_response = client.post(
+        "/api/v1/auth/login",
+        data={"username": "other_identifier", "password": "WrongPassword1!"},
+    )
+    assert other_response.status_code == 401
+
+    conn = await asyncpg.connect(
+        host=TEST_DB_HOST,
+        port=TEST_DB_PORT,
+        user=TEST_DB_USER,
+        password=TEST_DB_PASSWORD,
+        database=db_name,
+    )
+    try:
+        failed_rows = await conn.fetch(
+            """
+            SELECT identifier, attempt_count
+            FROM failed_attempts
+            WHERE attempt_type = 'login'
+            ORDER BY identifier
+            """
+        )
+        lockout_rows = await conn.fetch(
+            """
+            SELECT identifier
+            FROM account_lockouts
+            WHERE attempt_type = 'login'
+            ORDER BY identifier
+            """
+        )
+
+        assert {row["identifier"]: row["attempt_count"] for row in failed_rows} == {
+            expected_client_key: threshold,
+            username: threshold,
+            other_client_key: 1,
+        }
+        assert {row["identifier"] for row in lockout_rows} == {
+            expected_client_key,
+            username,
+        }
+
+        await conn.execute(
+            """
+            UPDATE account_lockouts
+            SET locked_until = CURRENT_TIMESTAMP - INTERVAL '1 minute'
+            WHERE identifier = ANY($1::text[]) AND attempt_type = 'login'
+            """,
+            [expected_client_key, username],
+        )
+    finally:
+        await conn.close()
+
+    success = client.post(
+        "/api/v1/auth/login",
+        data={"username": username, "password": password},
+    )
+    assert success.status_code == 200
+
+    conn = await asyncpg.connect(
+        host=TEST_DB_HOST,
+        port=TEST_DB_PORT,
+        user=TEST_DB_USER,
+        password=TEST_DB_PASSWORD,
+        database=db_name,
+    )
+    try:
+        remaining_failed_rows = await conn.fetch(
+            """
+            SELECT identifier, attempt_count
+            FROM failed_attempts
+            WHERE attempt_type = 'login'
+            ORDER BY identifier
+            """
+        )
+        remaining_lockout_rows = await conn.fetch(
+            """
+            SELECT identifier
+            FROM account_lockouts
+            WHERE attempt_type = 'login'
+            ORDER BY identifier
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert [dict(row) for row in remaining_failed_rows] == [
+        {"identifier": other_client_key, "attempt_count": 1}
+    ]
+    assert remaining_lockout_rows == []

--- a/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
@@ -7,15 +7,15 @@ limiter dependency. The underlying database remains Postgres via the
 `isolated_test_environment` fixture.
 """
 
-from datetime import datetime, timedelta, timezone
 import re
+from datetime import datetime, timedelta, timezone
 
 import asyncpg
 import pytest
 import pytest_asyncio
 
-from tldw_Server_API.tests.helpers.pg_env import get_pg_env
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
+from tldw_Server_API.tests.helpers.pg_env import get_pg_env
 
 pytestmark = pytest.mark.integration
 
@@ -132,8 +132,8 @@ class TestAuthLoginLockoutViaAuthGovernor:
             await conn.close()
 
         # Override the rate limiter dependency to provide a deterministic stub
-        from tldw_Server_API.app.main import app as _app
         from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+        from tldw_Server_API.app.main import app as _app
 
         limiter = _StubLimiter(threshold=3)
 

--- a/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py
@@ -8,6 +8,7 @@ limiter dependency. The underlying database remains Postgres via the
 """
 
 from datetime import datetime, timedelta, timezone
+import re
 
 import asyncpg
 import pytest
@@ -39,8 +40,12 @@ class _StubLimiter:
         self.threshold = threshold
         self._attempts: dict[str, int] = {}
         self._locked_ids: set[str] = set()
+        self.checked_identifiers: list[str] = []
+        self.failed_identifiers: list[str] = []
+        self.reset_identifiers: list[str] = []
 
     async def check_lockout(self, identifier: str):
+        self.checked_identifiers.append(identifier)
         if identifier in self._locked_ids:
             # Provide a synthetic expiry time for HTTP 429 headers
             return True, datetime.now(timezone.utc) + timedelta(minutes=15)
@@ -49,6 +54,7 @@ class _StubLimiter:
     async def record_failed_attempt(self, *, identifier: str, attempt_type: str):
         # Track attempts per identifier; lock when threshold reached.
         _ = attempt_type
+        self.failed_identifiers.append(identifier)
         count = self._attempts.get(identifier, 0) + 1
         self._attempts[identifier] = count
         is_locked = count >= self.threshold
@@ -60,6 +66,12 @@ class _StubLimiter:
             "remaining_attempts": remaining,
             "is_locked": is_locked,
         }
+
+    async def reset_failed_attempts(self, identifier: str, attempt_type: str):
+        _ = attempt_type
+        self.reset_identifiers.append(identifier)
+        self._attempts.pop(identifier, None)
+        self._locked_ids.discard(identifier)
 
     def clear_all_locks(self) -> None:
 
@@ -198,3 +210,26 @@ class TestAuthLoginLockoutViaAuthGovernor:
         payload = success.json()
         assert payload.get("token_type") == "bearer"
         assert "access_token" in payload
+
+    def test_client_login_lockout_does_not_cross_login_identifiers(self):
+        for _ in range(3):
+            response = self.client.post(
+                "/api/v1/auth/login",
+                data={"username": self.username, "password": "WrongPassword1!"},
+            )
+        assert response.status_code == 429
+
+        other_identifier = self.client.post(
+            "/api/v1/auth/login",
+            data={"username": "other_identifier", "password": "WrongPassword1!"},
+        )
+
+        assert other_identifier.status_code == 401
+        client_identifiers = self.limiter.checked_identifiers + self.limiter.failed_identifiers
+        assert client_identifiers
+        assert all(
+            re.fullmatch(r"login-client-v1:[0-9a-f]{64}", identifier)
+            for identifier in client_identifiers
+            if identifier != self.username
+        )
+        assert "testclient" not in client_identifiers

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -1,12 +1,12 @@
-from types import SimpleNamespace
 import json
 import os
 import time
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
-from fastapi import Response
+from fastapi import HTTPException, Response
+from pydantic import ValidationError
 from starlette.requests import Request
 
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
@@ -155,7 +155,7 @@ async def test_reset_password_weak_and_success(monkeypatch):
     request = Request(scope)
 
     # Weak password
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         await _auth.reset_password(
             data=_auth.ResetPasswordRequest(token="tok", new_password="weak"),
             request=request,
@@ -938,9 +938,8 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
             self.redis_client = object()
 
         async def create_session(self, **kwargs):
-            from datetime import datetime, timezone as _tz
             self.created_kwargs = dict(kwargs)
-            self.created_at = datetime.now(_tz.utc)
+            self.created_at = datetime.now(timezone.utc)
             return {"session_id": 777}
 
         async def store_ephemeral_value(self, key: str, value: str, ttl_seconds: int):

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -9,24 +9,26 @@ from fastapi import HTTPException, Response
 from pydantic import ValidationError
 from starlette.requests import Request
 
+from tldw_Server_API.app.core.AuthNZ.lockout_tracker import (
+    build_login_client_lockout_key,
+    validate_login_client_lockout_key,
+)
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+pytestmark = pytest.mark.unit
 
 
 def test_login_client_lockout_key_has_stable_known_vector():
-    import tldw_Server_API.app.api.v1.endpoints.auth as auth
-
-    assert auth._login_client_lockout_key("203.0.113.9", " Alice@Example.COM ") == (
+    assert build_login_client_lockout_key("203.0.113.9", " Alice@Example.COM ") == (
         "login-client-v1:5573603ba3e0013f1788b2e3e4b7d67553500401252965ad3f2189a1a352b014"
     )
 
 
 def test_login_client_lockout_key_normalizes_identifier_but_preserves_aliases():
-    import tldw_Server_API.app.api.v1.endpoints.auth as auth
-
-    by_email = auth._login_client_lockout_key("2001:db8::9", " USER@example.com ")
-    assert by_email == auth._login_client_lockout_key("2001:db8::9", "user@example.com")
-    assert by_email != auth._login_client_lockout_key("2001:db8::9", "user")
-    assert auth._login_client_lockout_key(None, "user").startswith("login-client-v1:")
+    by_email = build_login_client_lockout_key("2001:db8::9", " USER@example.com ")
+    assert by_email == build_login_client_lockout_key("2001:db8::9", "user@example.com")
+    assert by_email != build_login_client_lockout_key("2001:db8::9", "user")
+    assert build_login_client_lockout_key(None, "user").startswith("login-client-v1:")
 
 
 @pytest.mark.parametrize(
@@ -36,9 +38,7 @@ def test_login_client_lockout_key_normalizes_identifier_but_preserves_aliases():
      "login-client-v1:" + "g" * 64],
 )
 def test_validated_login_client_lockout_key_rejects_noncanonical_values(value):
-    import tldw_Server_API.app.api.v1.endpoints.auth as auth
-
-    assert auth._validated_login_client_lockout_key(value) is None
+    assert validate_login_client_lockout_key(value) is None
 
 
 def test_auth_request_client_ip_uses_unknown_for_invalid_physical_peer(monkeypatch):
@@ -516,7 +516,7 @@ async def test_login_lockout_uses_trusted_forwarded_client_login_key(monkeypatch
         )
 
     assert exc.value.status_code == 429
-    assert captured["identifier"] == auth._login_client_lockout_key(
+    assert captured["identifier"] == build_login_client_lockout_key(
         "198.51.100.77", "user1"
     )
 
@@ -554,7 +554,7 @@ async def test_login_unknown_user_records_only_client_login_lockout_key(monkeypa
         "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
         "server": ("testserver", 80),
     })
-    composite_key = auth._login_client_lockout_key("203.0.113.9", "alice@example.com")
+    composite_key = build_login_client_lockout_key("203.0.113.9", "alice@example.com")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.login(
@@ -622,7 +622,7 @@ async def test_login_bad_password_uses_client_and_account_lockout_buckets(
         "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
         "server": ("testserver", 80),
     })
-    composite_key = auth._login_client_lockout_key("203.0.113.9", login_identifier)
+    composite_key = build_login_client_lockout_key("203.0.113.9", login_identifier)
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.login(
@@ -702,7 +702,7 @@ async def test_login_success_resets_client_and_account_lockout_buckets(monkeypat
         "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
         "server": ("testserver", 80),
     })
-    composite_key = auth._login_client_lockout_key("203.0.113.9", "alice")
+    composite_key = build_login_client_lockout_key("203.0.113.9", "alice")
 
     result = await auth.login(
         request=request, response=Response(),
@@ -717,7 +717,7 @@ async def test_login_success_resets_client_and_account_lockout_buckets(monkeypat
         (composite_key, "login"),
         ("stored_username", "login"),
     ]
-    assert auth._login_client_lockout_key("203.0.113.9", "alice") != auth._login_client_lockout_key(
+    assert build_login_client_lockout_key("203.0.113.9", "alice") != build_login_client_lockout_key(
         "203.0.113.9", "bob"
     )
 
@@ -1003,7 +1003,7 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
     assert cached == {
         "user_id": 5,
         "session_id": 777,
-        "login_lockout_key": auth._login_client_lockout_key("203.0.113.9", "mfa_user"),
+        "login_lockout_key": build_login_client_lockout_key("203.0.113.9", "mfa_user"),
     }
     assert "203.0.113.9" not in session_manager.stored_value
     assert "mfa_user" not in session_manager.stored_value
@@ -1018,7 +1018,8 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_mfa_login_completes_tokens(monkeypatch):
+@pytest.mark.parametrize("legacy_payload", [False, True])
+async def test_mfa_login_completes_tokens(monkeypatch, legacy_payload):
     monkeypatch.setenv("AUTH_MODE", "multi_user")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     reset_settings()
@@ -1111,12 +1112,14 @@ async def test_mfa_login_completes_tokens(monkeypatch):
     session_manager = _StubSessionManager()
     token = "mfa-session-token"
     cache_key = auth._mfa_login_cache_key(token)
-    original_login_lockout_key = auth._login_client_lockout_key("203.0.113.9", "mfa_user")
-    session_manager.ephemeral[cache_key] = json.dumps({
+    original_login_lockout_key = build_login_client_lockout_key("203.0.113.9", "mfa_user")
+    cached_payload = {
         "user_id": 5,
         "session_id": 55,
-        "login_lockout_key": original_login_lockout_key,
-    })
+    }
+    if not legacy_payload:
+        cached_payload["login_lockout_key"] = original_login_lockout_key
+    session_manager.ephemeral[cache_key] = json.dumps(cached_payload)
 
     scope = {
         "type": "http",
@@ -1146,10 +1149,14 @@ async def test_mfa_login_completes_tokens(monkeypatch):
     assert result.refresh_token == "REFRESH"
     assert session_manager.updated["session_id"] == 55
     assert cache_key in session_manager.deleted
-    assert reset_calls == [
-        (original_login_lockout_key, "login"),
-        ("mfa_user", "login"),
-    ]
+    assert reset_calls == (
+        [("mfa_user", "login")]
+        if legacy_payload
+        else [
+            (original_login_lockout_key, "login"),
+            ("mfa_user", "login"),
+        ]
+    )
     assert all(identifier != "198.51.100.44" for identifier, _ in reset_calls)
 
 
@@ -1157,7 +1164,6 @@ async def test_mfa_login_completes_tokens(monkeypatch):
 @pytest.mark.parametrize(
     "payload",
     [
-        {"user_id": 5, "session_id": 55},
         {"user_id": 5, "session_id": 55, "login_lockout_key": "203.0.113.9"},
         {"user_id": 5, "session_id": 55, "login_lockout_key": "login-client-v2:" + "a" * 64},
         {"user_id": 5, "session_id": 55, "login_lockout_key": "login-client-v1:" + "A" * 64},
@@ -1436,7 +1442,7 @@ async def test_mfa_login_rate_limited_returns_429(monkeypatch):
                 auth._mfa_login_cache_key("session-token"): json.dumps({
                     "user_id": 5,
                     "session_id": 55,
-                    "login_lockout_key": auth._login_client_lockout_key("203.0.113.10", "mfa_user"),
+                    "login_lockout_key": build_login_client_lockout_key("203.0.113.10", "mfa_user"),
                 })
             }
 

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -932,6 +932,7 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
     class _StubSessionManager:
         def __init__(self):
             self.cached = {}
+            self.stored_value = None
             self.created_kwargs = {}
             self.created_at = None
             self.redis_client = object()
@@ -943,6 +944,7 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
             return {"session_id": 777}
 
         async def store_ephemeral_value(self, key: str, value: str, ttl_seconds: int):
+            self.stored_value = value
             self.cached[key] = (value, ttl_seconds)
 
         async def update_session_tokens(self, **kwargs):
@@ -971,7 +973,7 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
         "method": "POST",
         "path": "/api/v1/auth/login",
         "headers": [],
-        "client": ("203.0.113.10", 1234),
+        "client": ("203.0.113.9", 1234),
         "scheme": "http",
         "query_string": b"",
         "server": ("testserver", 80),
@@ -998,6 +1000,14 @@ async def test_login_returns_mfa_challenge_when_enabled(monkeypatch):
     assert result.expires_in == 300
     assert result.session_token
     assert session_manager.cached
+    cached = json.loads(session_manager.stored_value)
+    assert cached == {
+        "user_id": 5,
+        "session_id": 777,
+        "login_lockout_key": auth._login_client_lockout_key("203.0.113.9", "mfa_user"),
+    }
+    assert "203.0.113.9" not in session_manager.stored_value
+    assert "mfa_user" not in session_manager.stored_value
     expires_at = session_manager.created_kwargs.get("expires_at_override")
     refresh_expires_at = session_manager.created_kwargs.get("refresh_expires_at_override")
     assert expires_at is not None
@@ -1057,14 +1067,16 @@ async def test_mfa_login_completes_tokens(monkeypatch):
         async def update_session_tokens(self, **kwargs):
             self.updated.update(kwargs)
 
+    reset_calls = []
+
     class _StubLimiter:
-        enabled = False
+        enabled = True
 
         async def check_user_rate_limit(self, user_id: int, endpoint: str):
             return True, {}
 
-        async def reset_failed_attempts(self, *args, **kwargs):
-            return None
+        async def reset_failed_attempts(self, identifier: str, attempt_type: str):
+            reset_calls.append((identifier, attempt_type))
 
     class _StubJWT:
         def create_access_token(self, **kwargs):
@@ -1100,14 +1112,19 @@ async def test_mfa_login_completes_tokens(monkeypatch):
     session_manager = _StubSessionManager()
     token = "mfa-session-token"
     cache_key = auth._mfa_login_cache_key(token)
-    session_manager.ephemeral[cache_key] = '{"user_id": 5, "session_id": 55}'
+    original_login_lockout_key = auth._login_client_lockout_key("203.0.113.9", "mfa_user")
+    session_manager.ephemeral[cache_key] = json.dumps({
+        "user_id": 5,
+        "session_id": 55,
+        "login_lockout_key": original_login_lockout_key,
+    })
 
     scope = {
         "type": "http",
         "method": "POST",
         "path": "/api/v1/auth/mfa/login",
         "headers": [],
-        "client": ("203.0.113.10", 1234),
+        "client": ("198.51.100.44", 1234),
         "scheme": "http",
         "query_string": b"",
         "server": ("testserver", 80),
@@ -1130,6 +1147,84 @@ async def test_mfa_login_completes_tokens(monkeypatch):
     assert result.refresh_token == "REFRESH"
     assert session_manager.updated["session_id"] == 55
     assert cache_key in session_manager.deleted
+    assert reset_calls == [
+        (original_login_lockout_key, "login"),
+        ("mfa_user", "login"),
+    ]
+    assert all(identifier != "198.51.100.44" for identifier, _ in reset_calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"user_id": 5, "session_id": 55},
+        {"user_id": 5, "session_id": 55, "login_lockout_key": "203.0.113.9"},
+        {"user_id": 5, "session_id": 55, "login_lockout_key": "login-client-v2:" + "a" * 64},
+        {"user_id": 5, "session_id": 55, "login_lockout_key": "login-client-v1:" + "A" * 64},
+        {"user_id": 5, "session_id": 55, "login_lockout_key": "login-client-v1:" + "a" * 63},
+        {"user_id": 5, "session_id": 55, "login_lockout_key": 123},
+    ],
+)
+async def test_mfa_login_rejects_invalid_cached_lockout_keys_before_user_lookup(monkeypatch, payload):
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    reset_settings()
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    class _StubSessionManager:
+        redis_client = object()
+        updated = {}
+
+        async def get_ephemeral_value(self, _key: str):
+            return json.dumps(payload)
+
+        async def update_session_tokens(self, **kwargs):
+            self.updated.update(kwargs)
+
+    reset_calls = []
+
+    class _StubLimiter:
+        enabled = True
+
+        async def reset_failed_attempts(self, identifier: str, attempt_type: str):
+            reset_calls.append((identifier, attempt_type))
+
+    async def _unexpected(*args, **kwargs):
+        raise AssertionError("invalid cached key must be rejected before this call")
+
+    async def _noop_async(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(auth, "_ensure_mfa_available", _noop_async)
+    monkeypatch.setattr(auth, "_ensure_mfa_cache_available", _noop_async)
+    monkeypatch.setattr(auth, "_reserve_auth_rg_requests", _unexpected)
+    monkeypatch.setattr(auth, "fetch_active_user_by_id", _unexpected)
+
+    request = Request({
+        "type": "http", "method": "POST", "path": "/api/v1/auth/mfa/login", "headers": [],
+        "client": ("198.51.100.44", 1234), "scheme": "http", "query_string": b"",
+        "server": ("testserver", 80),
+    })
+    session_manager = _StubSessionManager()
+
+    with pytest.raises(auth.HTTPException) as excinfo:
+        await auth.mfa_login(
+            data=auth.MFALoginRequest(session_token="session-token", mfa_token="123456"),
+            request=request,
+            response=Response(),
+            db=object(),
+            jwt_service=object(),
+            session_manager=session_manager,
+            rate_limiter=_StubLimiter(),
+            settings=auth.get_settings(),
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "MFA session expired or invalid"
+    assert reset_calls == []
+    assert session_manager.updated == {}
 
 
 @pytest.mark.asyncio
@@ -1338,7 +1433,13 @@ async def test_mfa_login_rate_limited_returns_429(monkeypatch):
     class _StubSessionManager:
         def __init__(self):
             self.redis_client = object()
-            self.ephemeral = {auth._mfa_login_cache_key("session-token"): '{"user_id": 5, "session_id": 55}'}
+            self.ephemeral = {
+                auth._mfa_login_cache_key("session-token"): json.dumps({
+                    "user_id": 5,
+                    "session_id": 55,
+                    "login_lockout_key": auth._login_client_lockout_key("203.0.113.10", "mfa_user"),
+                })
+            }
 
         async def initialize(self):
             return None

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -459,7 +459,7 @@ async def test_verify_magic_link_rejects_admin_reauth_purpose(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_login_lockout_uses_trusted_forwarded_client_ip(monkeypatch):
+async def test_login_lockout_uses_trusted_forwarded_client_login_key(monkeypatch):
     monkeypatch.setenv("AUTH_TRUST_X_FORWARDED_FOR", "true")
     monkeypatch.setenv("AUTH_TRUSTED_PROXY_IPS", "10.0.0.0/8")
     reset_settings()
@@ -516,7 +516,210 @@ async def test_login_lockout_uses_trusted_forwarded_client_ip(monkeypatch):
         )
 
     assert exc.value.status_code == 429
-    assert captured["identifier"] == "198.51.100.77"
+    assert captured["identifier"] == auth._login_client_lockout_key(
+        "198.51.100.77", "user1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_unknown_user_records_only_client_login_lockout_key(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    checked = []
+    recorded_unknown = []
+
+    class _StubGov:
+        async def check_lockout(self, identifier: str, *, attempt_type: str, rate_limiter):
+            checked.append((identifier, attempt_type))
+            return False, None
+
+        async def record_auth_failure(self, *, identifier: str, attempt_type: str, rate_limiter):
+            recorded_unknown.append((identifier, attempt_type))
+            return {"is_locked": False, "remaining_attempts": 5}
+
+    class _StubLimiter:
+        enabled = True
+
+    async def _fake_get_auth_governor():
+        return _StubGov()
+
+    async def _no_user(db, identifier: str):
+        assert identifier == "alice@example.com"
+        return None
+
+    monkeypatch.setattr(auth, "get_auth_governor", _fake_get_auth_governor)
+    monkeypatch.setattr(auth, "fetch_user_by_login_identifier", _no_user)
+    request = Request({
+        "type": "http", "method": "POST", "path": "/api/v1/auth/login", "headers": [],
+        "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
+        "server": ("testserver", 80),
+    })
+    composite_key = auth._login_client_lockout_key("203.0.113.9", "alice@example.com")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth.login(
+            request=request, response=Response(),
+            form_data=SimpleNamespace(username=" Alice@Example.COM ", password="wrong"),
+            db=object(), jwt_service=object(), password_service=object(), session_manager=object(),
+            rate_limiter=_StubLimiter(), settings=auth.get_settings(),
+        )
+
+    assert excinfo.value.status_code == 401
+    assert checked == [(composite_key, "login")]
+    assert recorded_unknown == [(composite_key, "login")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("login_identifier", ["stored_username", "stored@example.com"])
+async def test_login_bad_password_uses_client_and_account_lockout_buckets(
+    monkeypatch, login_identifier
+):
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    checked = []
+    recorded_bad_password = []
+
+    class _StubGov:
+        async def check_lockout(self, identifier: str, *, attempt_type: str, rate_limiter):
+            checked.append((identifier, attempt_type))
+            return False, None
+
+        async def record_auth_failure(self, *, identifier: str, attempt_type: str, rate_limiter):
+            recorded_bad_password.append((identifier, attempt_type))
+            return {"is_locked": False, "remaining_attempts": 5}
+
+    class _StubLimiter:
+        enabled = True
+
+    class _StubPasswordService:
+        def verify_password(self, password: str, password_hash: str):
+            return False, False
+
+    class _StubAuditService:
+        async def log_login(self, **kwargs):
+            return None
+
+        async def flush(self):
+            return None
+
+    async def _fake_get_auth_governor():
+        return _StubGov()
+
+    async def _user(db, identifier: str):
+        return {
+            "id": 1, "username": "stored_username", "password_hash": "hash",
+            "role": "user", "is_active": True,
+        }
+
+    async def _fake_audit_service(user_id: int):
+        return _StubAuditService()
+
+    monkeypatch.setattr(auth, "get_auth_governor", _fake_get_auth_governor)
+    monkeypatch.setattr(auth, "fetch_user_by_login_identifier", _user)
+    monkeypatch.setattr(auth, "get_or_create_audit_service_for_user_id", _fake_audit_service)
+    request = Request({
+        "type": "http", "method": "POST", "path": "/api/v1/auth/login", "headers": [],
+        "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
+        "server": ("testserver", 80),
+    })
+    composite_key = auth._login_client_lockout_key("203.0.113.9", login_identifier)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth.login(
+            request=request, response=Response(),
+            form_data=SimpleNamespace(username=login_identifier, password="wrong"),
+            db=object(), jwt_service=object(), password_service=_StubPasswordService(),
+            session_manager=object(), rate_limiter=_StubLimiter(), settings=auth.get_settings(),
+        )
+
+    assert excinfo.value.status_code == 401
+    assert checked[0] == (composite_key, "login")
+    assert checked[1] == ("stored_username", "login")
+    assert recorded_bad_password == [
+        (composite_key, "login"),
+        ("stored_username", "login"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_login_success_resets_client_and_account_lockout_buckets(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "test-api-key")
+    reset_settings()
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    checked = []
+    reset_on_success = []
+
+    class _StubGov:
+        async def check_lockout(self, identifier: str, *, attempt_type: str, rate_limiter):
+            checked.append((identifier, attempt_type))
+            return False, None
+
+    class _StubLimiter:
+        enabled = True
+
+        async def reset_failed_attempts(self, identifier: str, attempt_type: str):
+            reset_on_success.append((identifier, attempt_type))
+
+    class _StubPasswordService:
+        def verify_password(self, password: str, password_hash: str):
+            return True, False
+
+    class _StubSessionManager:
+        async def create_session(self, **kwargs):
+            return {"session_id": 1}
+
+    class _StubAuditService:
+        async def log_login(self, **kwargs):
+            return None
+
+        async def flush(self):
+            return None
+
+    async def _fake_get_auth_governor():
+        return _StubGov()
+
+    async def _user(db, identifier: str):
+        return {
+            "id": 1, "username": "stored_username", "password_hash": "hash",
+            "role": "user", "is_active": True,
+        }
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    async def _fake_audit_service(user_id: int):
+        return _StubAuditService()
+
+    monkeypatch.setattr(auth, "get_auth_governor", _fake_get_auth_governor)
+    monkeypatch.setattr(auth, "fetch_user_by_login_identifier", _user)
+    monkeypatch.setattr(auth, "update_user_last_login", _noop)
+    monkeypatch.setattr(auth, "get_or_create_audit_service_for_user_id", _fake_audit_service)
+    monkeypatch.setattr(auth, "_is_mfa_backend_supported", _noop)
+    request = Request({
+        "type": "http", "method": "POST", "path": "/api/v1/auth/login", "headers": [],
+        "client": ("203.0.113.9", 1234), "scheme": "http", "query_string": b"",
+        "server": ("testserver", 80),
+    })
+    composite_key = auth._login_client_lockout_key("203.0.113.9", "alice")
+
+    result = await auth.login(
+        request=request, response=Response(),
+        form_data=SimpleNamespace(username=" Alice ", password="correct"),
+        db=object(), jwt_service=object(), password_service=_StubPasswordService(),
+        session_manager=_StubSessionManager(), rate_limiter=_StubLimiter(), settings=auth.get_settings(),
+    )
+
+    assert result.access_token == "test-api-key"
+    assert checked == [(composite_key, "login"), ("stored_username", "login")]
+    assert reset_on_success == [
+        (composite_key, "login"),
+        ("stored_username", "login"),
+    ]
+    assert auth._login_client_lockout_key("203.0.113.9", "alice") != auth._login_client_lockout_key(
+        "203.0.113.9", "bob"
+    )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -12,6 +12,56 @@ from starlette.requests import Request
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
 
+def test_login_client_lockout_key_has_stable_known_vector():
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    assert auth._login_client_lockout_key("203.0.113.9", " Alice@Example.COM ") == (
+        "login-client-v1:5573603ba3e0013f1788b2e3e4b7d67553500401252965ad3f2189a1a352b014"
+    )
+
+
+def test_login_client_lockout_key_normalizes_identifier_but_preserves_aliases():
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    by_email = auth._login_client_lockout_key("2001:db8::9", " USER@example.com ")
+    assert by_email == auth._login_client_lockout_key("2001:db8::9", "user@example.com")
+    assert by_email != auth._login_client_lockout_key("2001:db8::9", "user")
+    assert auth._login_client_lockout_key(None, "user").startswith("login-client-v1:")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "login-client-v1:", "login-client-v1:" + "A" * 64,
+     "login-client-v2:" + "a" * 64, "login-client-v1:" + "a" * 63,
+     "login-client-v1:" + "g" * 64],
+)
+def test_validated_login_client_lockout_key_rejects_noncanonical_values(value):
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    assert auth._validated_login_client_lockout_key(value) is None
+
+
+def test_auth_request_client_ip_uses_unknown_for_invalid_physical_peer(monkeypatch):
+    monkeypatch.setenv("AUTH_TRUST_X_FORWARDED_FOR", "true")
+    monkeypatch.setenv("AUTH_TRUSTED_PROXY_IPS", "10.0.0.0/8")
+    reset_settings()
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/login",
+        "headers": [(b"x-forwarded-for", b"198.51.100.77, 10.1.2.3")],
+        "client": ("testclient", 1234),
+        "scheme": "http",
+        "query_string": b"",
+        "server": ("testserver", 80),
+    }
+
+    assert auth._auth_request_client_ip(Request(scope)) == "unknown"
+
+
 @pytest.mark.asyncio
 async def test_is_mfa_backend_supported_prefers_mfa_service_capability(monkeypatch):
     reset_settings()

--- a/tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py
@@ -8,6 +8,8 @@ from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
     resolve_client_ip,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _settings(allowed):
 

--- a/tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_ip_allowlist.py
@@ -1,14 +1,29 @@
 from types import SimpleNamespace
 
 import pytest
+from starlette.datastructures import Headers
 
-from tldw_Server_API.app.core.AuthNZ.ip_allowlist import is_single_user_ip_allowed
+from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
+    is_single_user_ip_allowed,
+    resolve_client_ip,
+)
 
 
 def _settings(allowed):
 
 
     return SimpleNamespace(SINGLE_USER_ALLOWED_IPS=allowed)
+
+
+def _request(peer, raw_headers):
+    return SimpleNamespace(client=SimpleNamespace(host=peer), headers=Headers(raw=raw_headers))
+
+
+def _proxy_settings(enabled=True):
+    return SimpleNamespace(
+        AUTH_TRUST_X_FORWARDED_FOR=enabled,
+        AUTH_TRUSTED_PROXY_IPS=["10.0.0.0/8"],
+    )
 
 
 def test_allowlist_empty_allows_any_ip():
@@ -54,3 +69,57 @@ def test_allowlist_invalid_client_ip_rejected():
 
     settings = _settings(["203.0.113.10"])
     assert is_single_user_ip_allowed("999.999.999.999", settings) is False
+
+
+def test_resolve_client_ip_combines_repeated_xff_and_ignores_attacker_prefix():
+    request = _request(
+        "10.0.0.1",
+        [
+            (b"x-forwarded-for", b"198.51.100.99"),
+            (b"x-forwarded-for", b"203.0.113.9, 10.0.0.2"),
+        ],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "203.0.113.9"
+
+
+def test_resolve_client_ip_ignores_forwarding_when_disabled():
+    request = _request("10.0.0.1", [(b"x-forwarded-for", b"203.0.113.9")])
+    assert resolve_client_ip(request, _proxy_settings(enabled=False)) == "10.0.0.1"
+
+
+def test_xff_takes_precedence_over_x_real_ip():
+    request = _request(
+        "10.0.0.1",
+        [
+            (b"x-forwarded-for", b"203.0.113.9"),
+            (b"x-real-ip", b"198.51.100.4"),
+        ],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "203.0.113.9"
+
+
+def test_malformed_xff_does_not_fall_through_to_x_real_ip():
+    request = _request(
+        "10.0.0.1",
+        [
+            (b"x-forwarded-for", b"bad, 10.0.0.2"),
+            (b"x-real-ip", b"203.0.113.4"),
+        ],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "10.0.0.1"
+
+
+def test_repeated_x_real_ip_is_not_treated_as_a_single_address():
+    request = _request(
+        "10.0.0.1",
+        [
+            (b"x-real-ip", b"203.0.113.4"),
+            (b"x-real-ip", b"198.51.100.4"),
+        ],
+    )
+    assert resolve_client_ip(request, _proxy_settings()) == "10.0.0.1"
+
+
+def test_invalid_physical_peer_never_authorizes_forwarded_headers():
+    request = _request("testclient", [(b"x-forwarded-for", b"203.0.113.4")])
+    assert resolve_client_ip(request, _proxy_settings()) is None

--- a/tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 
 from tldw_Server_API.app.core.Resource_Governance.deps import derive_client_ip, derive_entity_key
 
-pytestmark = pytest.mark.rate_limit
+pytestmark = [pytest.mark.unit, pytest.mark.rate_limit]
 
 
 def _build_request(headers=None, raw_headers=None, client_host="127.0.0.1", client_port=12345):

--- a/tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_deps_trusted_proxy.py
@@ -1,21 +1,21 @@
-import os
 from types import SimpleNamespace
 
 import pytest
-pytestmark = pytest.mark.rate_limit
 from starlette.requests import Request
 
-from tldw_Server_API.app.core.Resource_Governance.deps import derive_entity_key
+from tldw_Server_API.app.core.Resource_Governance.deps import derive_client_ip, derive_entity_key
+
+pytestmark = pytest.mark.rate_limit
 
 
-def _build_request(headers=None, client_host="127.0.0.1", client_port=12345):
+def _build_request(headers=None, raw_headers=None, client_host="127.0.0.1", client_port=12345):
 
 
     scope = {
         "type": "http",
         "method": "GET",
         "path": "/",
-        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+        "headers": raw_headers or [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
         "client": (client_host, client_port),
         "server": ("testserver", 80),
         "scheme": "http",
@@ -72,3 +72,50 @@ async def test_derive_entity_key_uses_policy_snapshot_tenant_when_config_omitted
     ent = derive_entity_key(request)
 
     assert ent == "tenant:acme"
+
+
+@pytest.mark.asyncio
+async def test_xff_uses_first_untrusted_hop_from_the_right(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "x-FoRwArDeD-fOr")
+    request = _build_request(
+        client_host="10.0.0.1",
+        raw_headers=[(b"x-forwarded-for", b"198.51.100.99, 203.0.113.9, 10.0.0.2")],
+    )
+    assert derive_client_ip(request) == "203.0.113.9"
+
+
+@pytest.mark.asyncio
+async def test_custom_header_is_single_ip_only(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "CF-Connecting-IP")
+    request = _build_request(
+        client_host="10.0.0.1",
+        raw_headers=[(b"cf-connecting-ip", b"203.0.113.9, 10.0.0.2")],
+    )
+    assert derive_client_ip(request) == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_repeated_custom_header_is_not_treated_as_a_single_address(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "10.0.0.0/8")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "CF-Connecting-IP")
+    request = _build_request(
+        client_host="10.0.0.1",
+        raw_headers=[
+            (b"cf-connecting-ip", b"203.0.113.9"),
+            (b"cf-connecting-ip", b"198.51.100.9"),
+        ],
+    )
+    assert derive_client_ip(request) == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_peer_is_unknown_not_loopback(monkeypatch):
+    monkeypatch.setenv("RG_TRUSTED_PROXIES", "127.0.0.1")
+    monkeypatch.setenv("RG_CLIENT_IP_HEADER", "X-Forwarded-For")
+    request = _build_request(
+        client_host="testclient",
+        raw_headers=[(b"x-forwarded-for", b"203.0.113.9")],
+    )
+    assert derive_client_ip(request) == "unknown"

--- a/tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from tldw_Server_API.app.core.Resource_Governance.governor import RGDecision
 from tldw_Server_API.app.core.Resource_Governance.middleware_simple import RGSimpleMiddleware
 
-pytestmark = pytest.mark.rate_limit
+pytestmark = [pytest.mark.unit, pytest.mark.rate_limit]
 
 
 class _Snap:

--- a/tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_middleware_trusted_proxy_ip.py
@@ -1,13 +1,11 @@
-import os
-
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.rate_limit
-
-from tldw_Server_API.app.core.Resource_Governance.middleware_simple import RGSimpleMiddleware
 from tldw_Server_API.app.core.Resource_Governance.governor import RGDecision
+from tldw_Server_API.app.core.Resource_Governance.middleware_simple import RGSimpleMiddleware
+
+pytestmark = pytest.mark.rate_limit
 
 
 class _Snap:
@@ -55,8 +53,8 @@ def _make_app_probe():
 
 
 @pytest.mark.asyncio
-async def test_middleware_sets_rg_client_ip_from_xff_when_proxy_trusted(monkeypatch):
-    # Trust the local peer and read X-Forwarded-For
+async def test_middleware_sets_unknown_client_ip_for_invalid_physical_peer(monkeypatch):
+    # TestClient's physical peer is not an IP and must not authorize XFF.
     monkeypatch.setenv("RG_TRUSTED_PROXIES", "127.0.0.1")
     monkeypatch.setenv("RG_CLIENT_IP_HEADER", "X-Forwarded-For")
 
@@ -64,7 +62,7 @@ async def test_middleware_sets_rg_client_ip_from_xff_when_proxy_trusted(monkeypa
     with TestClient(app) as c:
         r = c.get("/probe", headers={"X-Forwarded-For": "203.0.113.9, 127.0.0.1"})
         assert r.status_code == 200
-        assert r.json().get("client_ip") == "203.0.113.9"
+        assert r.json().get("client_ip") == "unknown"
 
 
 @pytest.mark.asyncio
@@ -76,5 +74,4 @@ async def test_middleware_ignores_xff_without_trusted_proxy(monkeypatch):
     with TestClient(app) as c:
         r = c.get("/probe", headers={"X-Forwarded-For": "198.51.100.7"})
         assert r.status_code == 200
-        # When proxy is not trusted, fallback to peer (TestClient defaults to 127.0.0.1)
-        assert r.json().get("client_ip") in {"127.0.0.1", "::1"}
+        assert r.json().get("client_ip") == "unknown"

--- a/tldw_Server_API/tests/Security/test_trusted_proxy.py
+++ b/tldw_Server_API/tests/Security/test_trusted_proxy.py
@@ -1,0 +1,77 @@
+import pytest
+
+from tldw_Server_API.app.core.Security.trusted_proxy import (
+    is_trusted_proxy_peer,
+    resolve_trusted_client_ip,
+)
+
+
+@pytest.mark.parametrize(
+    ("peer", "expected"),
+    [
+        ("203.0.113.7", "203.0.113.7"),
+        ("2001:0db8:0:0::7", "2001:db8::7"),
+        (None, None),
+        ("testclient", None),
+        ("127.0.0.1:8000", None),
+    ],
+)
+def test_direct_peer_is_canonical_or_absent(peer, expected):
+    assert resolve_trusted_client_ip(peer, ()) == expected
+
+
+def test_untrusted_peer_cannot_select_forwarded_identity():
+    assert resolve_trusted_client_ip(
+        "198.51.100.8",
+        ("10.0.0.0/8", "not-a-network"),
+        forwarded_for_values=("203.0.113.9",),
+        single_forwarded_value="192.0.2.4",
+    ) == "198.51.100.8"
+
+
+def test_trusted_peer_predicate_accepts_hosts_and_cidrs():
+    entries = ("192.0.2.10", "2001:db8:abcd::/48", "invalid")
+    assert is_trusted_proxy_peer("192.0.2.10", entries) is True
+    assert is_trusted_proxy_peer("2001:db8:abcd::4", entries) is True
+    assert is_trusted_proxy_peer("203.0.113.4", entries) is False
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (("203.0.113.9",), "203.0.113.9"),
+        (("198.51.100.99, 203.0.113.9, 10.0.0.2",), "203.0.113.9"),
+        (("198.51.100.99", "203.0.113.9, 10.0.0.2"), "203.0.113.9"),
+        (("2001:db8:ffff::9, 2001:db8:abcd::2",), "2001:db8:ffff::9"),
+        (("10.0.0.2, 10.0.0.3",), "10.0.0.1"),
+        (("203.0.113.9,,10.0.0.2",), "10.0.0.1"),
+        (("203.0.113.9:443,10.0.0.2",), "10.0.0.1"),
+        (("[2001:db8::9],10.0.0.2",), "10.0.0.1"),
+        (("for=203.0.113.9,10.0.0.2",), "10.0.0.1"),
+        (("fe80::1%eth0,10.0.0.2",), "10.0.0.1"),
+    ],
+)
+def test_xff_is_scanned_from_trusted_edge(values, expected):
+    assert resolve_trusted_client_ip(
+        "10.0.0.1",
+        ("10.0.0.0/8", "2001:db8:abcd::/48"),
+        forwarded_for_values=values,
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("203.0.113.9", "203.0.113.9"),
+        ("2001:0db8::9", "2001:db8::9"),
+        ("203.0.113.9, 10.0.0.2", "10.0.0.1"),
+        ("", "10.0.0.1"),
+        ("[2001:db8::9]", "10.0.0.1"),
+    ],
+)
+def test_single_forwarded_field_accepts_exactly_one_plain_ip(value, expected):
+    assert resolve_trusted_client_ip(
+        "10.0.0.1",
+        ("10.0.0.0/8",),
+        single_forwarded_value=value,
+    ) == expected

--- a/tldw_Server_API/tests/Security/test_trusted_proxy.py
+++ b/tldw_Server_API/tests/Security/test_trusted_proxy.py
@@ -5,6 +5,8 @@ from tldw_Server_API.app.core.Security.trusted_proxy import (
     resolve_trusted_client_ip,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     ("peer", "expected"),


### PR DESCRIPTION
## Summary

- What changed:
  - Added one shared, strict trusted-proxy client-IP resolver and retained the existing AuthNZ and Resource Governance configuration surfaces through thin wrappers.
  - Replaced shared raw-IP password-login lockout state with versioned client-plus-normalized-login SHA-256 buckets while retaining the separate account-wide bucket.
  - Preserved the exact original composite lockout key through MFA and reset only that key plus the account bucket after successful authentication.
  - Added direct, proxy-chain, spoofing, IPv4/IPv6, MFA, and production `RateLimiter`/`LockoutTracker` PostgreSQL regressions; updated canonical/generated operator docs.
- Why:
  - Multiple users behind one trusted proxy could otherwise collapse into the same login-lockout bucket, allowing one attacker to lock out unrelated users. Forwarding headers also require a single deterministic anti-spoofing contract.

Backlog: `TASK-13013.5` (Done). The broader global `request.client` HTTP/WebSocket rewrite remains intentionally deferred to `TASK-13144`.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Local evidence on exact head `e6e7b52ed9e0cefff3ec468b6b9354fcbe28e5f6`:

- 96 focused resolver/AuthNZ/Resource Governance tests passed.
- 4 endpoint integration tests passed against the existing local PostgreSQL service with Docker auto-start disabled, including durable production `RateLimiter -> LockoutTracker -> Postgres` row isolation/reset coverage.
- Exact touched-path Ruff and `py_compile` passed.
- Bandit Medium/High gate passed with no finding.
- Canonical/generated documentation mirrors, public/private boundary, forbidden-scope scan, and range `git diff --check` passed.
- Independent final security review and scoped re-review found no remaining Critical, Important, or Minor issues.

Hosted `backend-required`, `security-required`, and `coverage-required` checks must pass on the unchanged PR head before merge.

## UX Audit Checklist (v2 Stage 5)

Not applicable: backend authentication/proxy logic and operator documentation only; no WebUI or extension changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

Not applicable: no Watchlists or UI changes.

## Watchlists Scale Checklist (Group 10 Stage 5)

Not applicable: no Watchlists polling, notifications, or batch behavior changes.

## Risk & Rollback

- Risk level: Medium — security-sensitive authentication and trusted-proxy behavior, with compatibility wrappers and production-backed regression coverage.
- Rollback plan: revert this PR. Existing environment-variable names remain unchanged, and the change adds no migration, schema, dependency, global middleware, WebSocket, or system-service requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens trusted-proxy client identity resolution and isolates password-login lockouts so users behind a shared proxy no longer collapse into one lockout bucket, and forwarded client IPs can't be spoofed. Resolves TASK-13013.5.

**Bug Fixes**
- Replaces the duplicated AuthNZ and Resource Governance IP parsers with one strict resolver in `app/core/Security/trusted_proxy.py`; existing `RG_*` and `AUTH_*` env vars keep working through thin wrappers.
- Keys password-failure lockouts on a versioned SHA-256 bucket of client plus normalized login, keeping the separate account-wide bucket; MFA success resets only the original composite key and the account bucket.
- Forwarded identity is opt-in and honored only when the physical peer is in the trusted-proxy list; malformed chains and invalid peers resolve to the physical peer or the `unknown` sentinel.
- Adds proxy-chain, spoofing, IPv4/IPv6, MFA, and PostgreSQL `RateLimiter`/`LockoutTracker` regressions and updates deployment and env-var docs.

No env var renames, schema changes, or new dependencies; rollback is a plain revert. The broader global `request.client` rewrite is deferred to TASK-13144.

<sup>Written for commit bce8b1a9b32a465905c35465201de6866231f532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

