### PR TITLE
perf: cut provider discovery 107x, per-request schema DDL to zero, and PBKDF2 per request

### DIFF
--- a/tldw_Server_API/Config_Files/config.txt
+++ b/tldw_Server_API/Config_Files/config.txt
@@ -1093,7 +1093,7 @@ llama_max_tokens = 4096
 llama_api_timeout = 90
 llama_api_retry = 3
 llama_api_retry_delay = 1
-ooba_api_IP = http://192.168.2.235:5000/v1/chat/completions
+ooba_api_IP = http://127.0.0.1:5000/v1/chat/completions
 # text-generation-webui OpenAI routes accept the OpenAI payload; include model to be explicit
 # (docs/12 - OpenAI API.md; server will fall back to the loaded model if omitted).
 # ooba_model = <model_name_for_openai_endpoint>
@@ -1131,7 +1131,7 @@ vllm_api_timeout = 90
 vllm_api_retry = 3
 vllm_api_retry_delay = 1
 # Ollama API requires model (docs/api.md: POST /api/generate -> model required).
-ollama_api_IP =  http://192.168.2.216:11434/v1
+ollama_api_IP =  http://127.0.0.1:11434/v1
 ollama_model = gemma3:1b
 ollama_streaming = False
 ollama_temperature = 0.7

--- a/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
@@ -19,9 +19,11 @@ async def get_watchlists_db_for_user(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="User identification failed")
     try:
         db = WatchlistsDatabase.for_user(user_id=current_user.id)
-        # Defensive: ensure schema exists for this user's DB in test/minimal app contexts
+        # Defensive: ensure schema exists for this user's DB in test/minimal app
+        # contexts. Uses the de-duplicated path -- ensure_schema() itself issues
+        # ~60 DDL statements and this runs on every request.
         try:
-            db.ensure_schema()
+            db.ensure_schema_once()
         except Exception as schema_error:
             # Best-effort; creation may have already occurred or be gated by init
             logger.debug(

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -1242,11 +1242,16 @@ def discover_models_from_endpoint(
     # timeout x len(candidates) on every call -- and failures are deliberately
     # never cached, so that cost repeated on every request.
     #
-    # Results are consumed as they complete and the loop stops on the first
-    # "ready", so a healthy endpoint still answers as fast as its quickest
-    # candidate. A healthy endpoint does receive the extra candidate requests,
-    # but a "ready" result is cached for LOCAL_MODEL_DISCOVERY_TTL, so that
-    # happens at most once per TTL rather than per request.
+    # Cancelling on the first "ready" only skips candidates that have not started
+    # yet, which is why it is worth doing at all: with more candidates than
+    # workers, the queued ones never run. Probes already in flight are still
+    # waited for -- the executor shuts down normally rather than abandoning
+    # threads -- so the floor is one probe's worth of time, bounded by
+    # LOCAL_MODEL_DISCOVERY_TIMEOUT, not the sum across candidates.
+    #
+    # A healthy endpoint does receive the extra candidate requests, but a "ready"
+    # result is cached for LOCAL_MODEL_DISCOVERY_TTL, so that happens at most
+    # once per TTL rather than per request.
     if candidates:
         with ThreadPoolExecutor(
             max_workers=min(len(candidates), _MODEL_DISCOVERY_MAX_PARALLEL_PROBES),

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -1027,7 +1027,10 @@ def parse_model_string(model_value: str) -> list[str]:
 
 
 # Local model discovery helpers (best-effort; cached to avoid hammering endpoints)
-LOCAL_MODEL_DISCOVERY_TIMEOUT = 3.0  # seconds
+LOCAL_MODEL_DISCOVERY_TIMEOUT = 1.5  # seconds
+# Local/LAN endpoints answer in milliseconds when present. This bound is only
+# ever paid in full by an endpoint that is configured but not listening, so it
+# is kept short: it is discovery, and a miss degrades to "no models found".
 LOCAL_MODEL_DISCOVERY_TTL = 300  # seconds
 _LOCAL_MODEL_CACHE: dict[str, tuple[float, ModelDiscoveryResult]] = {}
 # Upper bound on simultaneous discovery probes for one endpoint.

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -1,6 +1,7 @@
 # llm_providers.py
 import asyncio
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import os
 import time
 from functools import partial
@@ -1029,6 +1030,8 @@ def parse_model_string(model_value: str) -> list[str]:
 LOCAL_MODEL_DISCOVERY_TIMEOUT = 3.0  # seconds
 LOCAL_MODEL_DISCOVERY_TTL = 300  # seconds
 _LOCAL_MODEL_CACHE: dict[str, tuple[float, ModelDiscoveryResult]] = {}
+# Upper bound on simultaneous discovery probes for one endpoint.
+_MODEL_DISCOVERY_MAX_PARALLEL_PROBES = 6
 OPENROUTER_MODEL_DISCOVERY_TIMEOUT = 5.0  # seconds
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 
@@ -1174,7 +1177,9 @@ def discover_models_from_endpoint(
         "auth_failed": 3,
         "ready": 4,
     }
-    for url in candidates:
+    def _probe_candidate(url: str) -> ModelDiscoveryResult:
+        """Probe one candidate URL and classify the outcome."""
+        candidate_result = ModelDiscoveryResult("unreachable")
         try:
             resp = _http_fetch(
                 method="GET",
@@ -1222,11 +1227,35 @@ def discover_models_from_endpoint(
         except Exception:  # noqa: BLE001 - best-effort local discovery must fail open
             logger.debug("Model discovery endpoint query failed unexpectedly")
             candidate_result = ModelDiscoveryResult("unreachable")
+        return candidate_result
 
-        if precedence[candidate_result.status] > precedence[best_result.status]:
-            best_result = candidate_result
-        if best_result.status == "ready":
-            break
+    def _merge(result: ModelDiscoveryResult) -> None:
+        nonlocal best_result
+        if precedence[result.status] > precedence[best_result.status]:
+            best_result = result
+
+    # Candidates are probed concurrently. An endpoint that is not listening burns
+    # LOCAL_MODEL_DISCOVERY_TIMEOUT per candidate, so probing them in series cost
+    # timeout x len(candidates) on every call -- and failures are deliberately
+    # never cached, so that cost repeated on every request.
+    #
+    # Results are consumed as they complete and the loop stops on the first
+    # "ready", so a healthy endpoint still answers as fast as its quickest
+    # candidate. A healthy endpoint does receive the extra candidate requests,
+    # but a "ready" result is cached for LOCAL_MODEL_DISCOVERY_TTL, so that
+    # happens at most once per TTL rather than per request.
+    if candidates:
+        with ThreadPoolExecutor(
+            max_workers=min(len(candidates), _MODEL_DISCOVERY_MAX_PARALLEL_PROBES),
+            thread_name_prefix="model-discovery",
+        ) as pool:
+            futures = [pool.submit(_probe_candidate, url) for url in candidates]
+            for future in as_completed(futures):
+                _merge(future.result())
+                if best_result.status == "ready":
+                    for pending in futures:
+                        pending.cancel()
+                    break
 
     if best_result.status in {"ready", "unsupported"}:
         _LOCAL_MODEL_CACHE[cache_key] = (now, best_result)

--- a/tldw_Server_API/app/core/AuthNZ/crypto_utils.py
+++ b/tldw_Server_API/app/core/AuthNZ/crypto_utils.py
@@ -9,6 +9,7 @@ between JWTService, APIKeyManager, CSRF, and SessionManager.
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import os
 
@@ -36,7 +37,30 @@ def _derive_hmac_kdf_salt(source: bytes) -> bytes:
     return hashlib.sha256(_HMAC_KDF_SALT_PREFIX + hashlib.sha256(source).digest()).digest()
 
 
-def _derive_hmac_key_from_source(source: bytes, *, legacy: bool = False) -> bytes:
+# Derived keys are memoized on the secret material they come from.
+#
+# The KDF is deliberately expensive -- 100,000 PBKDF2 rounds -- but its input
+# here is server configuration (SINGLE_USER_API_KEY, API_KEY_PEPPER, JWT
+# secrets), not anything a caller supplies, and API key validation re-derived it
+# several times per request:
+#
+#   POST /api/v1/chat/completions   8 derivations, 110 ms of a 167 ms request
+#   POST /api/v1/embeddings         6 derivations,  82 ms of a 107 ms request
+#
+# Caching changes no security property. The stretching exists to make the server
+# secret expensive to recover from a leaked fingerprint, and an attacker gains
+# no additional attempts from a cache the server keeps of its own configuration.
+# The per-request secret -- the presented API key -- is the HMAC *message*, not
+# the KDF input, and is unaffected.
+#
+# Keying on the source bytes means a rotated or reconfigured secret is a
+# different key and misses the cache, so there is nothing to invalidate. The
+# bound keeps rotation or per-test settings churn from growing it without limit.
+_HMAC_KEY_CACHE_MAXSIZE = 64
+
+
+@functools.lru_cache(maxsize=_HMAC_KEY_CACHE_MAXSIZE)
+def _derive_hmac_key_cached(source: bytes, legacy: bool) -> bytes:
     return hashlib.pbkdf2_hmac(
         "sha256",
         source,
@@ -44,6 +68,15 @@ def _derive_hmac_key_from_source(source: bytes, *, legacy: bool = False) -> byte
         _HMAC_KDF_ITERATIONS,
         dklen=_HMAC_KDF_DKLEN,
     )
+
+
+def _derive_hmac_key_from_source(source: bytes, *, legacy: bool = False) -> bytes:
+    return _derive_hmac_key_cached(source, legacy)
+
+
+def reset_hmac_key_cache() -> None:
+    """Drop memoized derived keys. For tests that rotate secrets in place."""
+    _derive_hmac_key_cached.cache_clear()
 
 
 def derive_hmac_key_from_source(raw: str | bytes, *, legacy: bool = False) -> bytes:
@@ -172,4 +205,9 @@ def derive_hmac_key_candidates(settings: Settings | None = None) -> list[bytes]:
     return keys
 
 
-__all__ = ["derive_hmac_key", "derive_hmac_key_candidates", "derive_hmac_key_from_source"]
+__all__ = [
+    "derive_hmac_key",
+    "derive_hmac_key_candidates",
+    "derive_hmac_key_from_source",
+    "reset_hmac_key_cache",
+]

--- a/tldw_Server_API/app/core/AuthNZ/crypto_utils.py
+++ b/tldw_Server_API/app/core/AuthNZ/crypto_utils.py
@@ -9,9 +9,10 @@ between JWTService, APIKeyManager, CSRF, and SessionManager.
 
 from __future__ import annotations
 
-import functools
 import hashlib
 import os
+import threading
+from collections import OrderedDict
 
 from loguru import logger
 
@@ -53,15 +54,36 @@ def _derive_hmac_kdf_salt(source: bytes) -> bytes:
 # The per-request secret -- the presented API key -- is the HMAC *message*, not
 # the KDF input, and is unaffected.
 #
-# Keying on the source bytes means a rotated or reconfigured secret is a
-# different key and misses the cache, so there is nothing to invalidate. The
-# bound keeps rotation or per-test settings churn from growing it without limit.
+# Entries are keyed by a fingerprint of the source rather than the source, so
+# the cache is not a second long-lived copy of the configured secret. A rotated
+# or reconfigured secret has a different fingerprint and misses the cache, so
+# there is nothing to invalidate; the bound keeps rotation or per-test settings
+# churn from growing the cache without limit.
 _HMAC_KEY_CACHE_MAXSIZE = 64
 
+_HMAC_KEY_CACHE: OrderedDict[tuple[bytes, bool], bytes] = OrderedDict()
+_HMAC_KEY_CACHE_LOCK = threading.Lock()
 
-@functools.lru_cache(maxsize=_HMAC_KEY_CACHE_MAXSIZE)
-def _derive_hmac_key_cached(source: bytes, legacy: bool) -> bytes:
-    return hashlib.pbkdf2_hmac(
+
+def _derive_hmac_key_from_source(source: bytes, *, legacy: bool = False) -> bytes:
+    """Return the stretched key for ``source``, deriving it at most once.
+
+    Args:
+        source: Secret material to stretch. Server configuration, never
+            caller-supplied input.
+        legacy: When True, use the fixed legacy salt instead of a per-secret one.
+
+    Returns:
+        The 32-byte derived key.
+    """
+    cache_key = (hashlib.sha256(source).digest(), legacy)
+    with _HMAC_KEY_CACHE_LOCK:
+        cached = _HMAC_KEY_CACHE.get(cache_key)
+        if cached is not None:
+            _HMAC_KEY_CACHE.move_to_end(cache_key)
+            return cached
+
+    derived = hashlib.pbkdf2_hmac(
         "sha256",
         source,
         _HMAC_KDF_SALT_LEGACY if legacy else _derive_hmac_kdf_salt(source),
@@ -69,14 +91,25 @@ def _derive_hmac_key_cached(source: bytes, legacy: bool) -> bytes:
         dklen=_HMAC_KDF_DKLEN,
     )
 
-
-def _derive_hmac_key_from_source(source: bytes, *, legacy: bool = False) -> bytes:
-    return _derive_hmac_key_cached(source, legacy)
+    with _HMAC_KEY_CACHE_LOCK:
+        _HMAC_KEY_CACHE[cache_key] = derived
+        _HMAC_KEY_CACHE.move_to_end(cache_key)
+        while len(_HMAC_KEY_CACHE) > _HMAC_KEY_CACHE_MAXSIZE:
+            _HMAC_KEY_CACHE.popitem(last=False)
+    return derived
 
 
 def reset_hmac_key_cache() -> None:
-    """Drop memoized derived keys. For tests that rotate secrets in place."""
-    _derive_hmac_key_cached.cache_clear()
+    """Drop memoized derived keys.
+
+    For tests that rotate a secret in place, and for anything that needs the
+    next derivation to start from scratch.
+
+    Returns:
+        None.
+    """
+    with _HMAC_KEY_CACHE_LOCK:
+        _HMAC_KEY_CACHE.clear()
 
 
 def derive_hmac_key_from_source(raw: str | bytes, *, legacy: bool = False) -> bytes:

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -29,6 +29,7 @@ from uuid import uuid4
 
 from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.Collections.utils import (
     build_highlight_context,
     find_highlight_span,
@@ -653,7 +654,17 @@ class CollectionsDatabase:
         if self._backend.backend_type == BackendType.POSTGRESQL:
             self._ensure_bootstrap_for_backend(self._backend)
         else:
-            self._run_backend_bootstrap()
+            # SQLite ran the full bootstrap on every construction -- roughly 85
+            # DDL statements, and this class is built per request. It is
+            # de-duplicated on the database's *file identity* rather than the
+            # Postgres target key, which for SQLite is just a path: a database
+            # deleted and recreated at that path must be bootstrapped again.
+            ensure_once(
+                "collections",
+                getattr(getattr(self._backend, "config", None), "sqlite_path", None),
+                self._run_backend_bootstrap,
+                verify=self._collections_schema_present,
+            )
 
     @classmethod
     def for_user(cls, user_id: int | str) -> CollectionsDatabase:
@@ -715,6 +726,26 @@ class CollectionsDatabase:
 
     def _get_pinned_backend(self) -> DatabaseBackend | None:
         return getattr(self._local, "backend_pin", None)
+
+    def _collections_schema_present(self) -> bool:
+        """Cheap check that bootstrap output still exists in this database.
+
+        Test fixtures delete and recreate the database at a fixed path, and a
+        filesystem may reuse the inode, so file identity alone can produce a
+        false memo hit. One catalogue lookup is enough to catch that, and is
+        still far cheaper than replaying the whole bootstrap.
+        """
+        try:
+            rows = self._backend.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                ("output_templates",),
+            )
+        except Exception:
+            return False
+        try:
+            return bool(list(rows))
+        except TypeError:
+            return bool(rows)
 
     def _run_backend_bootstrap(self) -> None:
         self.ensure_schema()

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -630,6 +630,17 @@ def _decorate_collections_public_operations(cls: type["CollectionsDatabase"]) ->
     return cls
 
 
+# Spans the whole of ensure_schema(): the first table it creates through the
+# last, so a partially built database fails verification.
+_COLLECTIONS_REQUIRED_TABLES = (
+    "output_templates",
+    "outputs",
+    "reminder_tasks",
+    "file_artifacts",
+    "audio_studio_idempotency_keys",
+)
+
+
 @_decorate_collections_public_operations
 class CollectionsDatabase:
     """Adapter for Collections tables stored in the per-user Media DB."""
@@ -654,17 +665,22 @@ class CollectionsDatabase:
         if self._backend.backend_type == BackendType.POSTGRESQL:
             self._ensure_bootstrap_for_backend(self._backend)
         else:
-            # SQLite ran the full bootstrap on every construction -- roughly 85
-            # DDL statements, and this class is built per request. It is
+            # SQLite replayed the schema on every construction -- roughly 85 DDL
+            # statements, and this class is built per request. It is
             # de-duplicated on the database's *file identity* rather than the
             # Postgres target key, which for SQLite is just a path: a database
-            # deleted and recreated at that path must be bootstrapped again.
+            # deleted and recreated at that path must be set up again.
             ensure_once(
                 "collections",
                 getattr(getattr(self._backend, "config", None), "sqlite_path", None),
-                self._run_backend_bootstrap,
+                self.ensure_schema,
                 verify=self._collections_schema_present,
             )
+            # Deliberately outside the memo. This reconciles output templates
+            # against files that change on disk, so it has to keep running:
+            # "the tables exist" says nothing about whether their contents are
+            # current. Only the schema DDL above is safe to skip.
+            self._seed_watchlists_output_templates()
 
     @classmethod
     def for_user(cls, user_id: int | str) -> CollectionsDatabase:
@@ -728,24 +744,26 @@ class CollectionsDatabase:
         return getattr(self._local, "backend_pin", None)
 
     def _collections_schema_present(self) -> bool:
-        """Cheap check that bootstrap output still exists in this database.
+        """Cheap check that this database still has the collections tables.
 
         Test fixtures delete and recreate the database at a fixed path, and a
         filesystem may reuse the inode, so file identity alone can produce a
-        false memo hit. One catalogue lookup is enough to catch that, and is
-        still far cheaper than replaying the whole bootstrap.
+        false memo hit. A catalogue lookup catches that, and is still far
+        cheaper than replaying the whole schema.
+
+        Checks a set spanning the whole of ``ensure_schema()`` rather than one
+        table, so a database holding only part of the schema is rebuilt instead
+        of being accepted. ``audio_studio_idempotency_keys`` is the last table
+        the routine creates. Failures propagate to :func:`ensure_once`, which
+        logs them and rebuilds.
         """
-        try:
-            rows = self._backend.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                ("output_templates",),
-            )
-        except Exception:
-            return False
-        try:
-            return bool(list(rows))
-        except TypeError:
-            return bool(rows)
+        rows = self._backend.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+            "(?, ?, ?, ?, ?)",
+            _COLLECTIONS_REQUIRED_TABLES,
+        )
+        found = {row[0] for row in rows}
+        return found.issuperset(_COLLECTIONS_REQUIRED_TABLES)
 
     def _run_backend_bootstrap(self) -> None:
         self.ensure_schema()

--- a/tldw_Server_API/app/core/DB_Management/RPG_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/RPG_DB.py
@@ -8,8 +8,8 @@ from typing import Any, cast
 
 from loguru import logger
 
-from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.RPG.constants import (
     RPG_EVENT_SCHEMA_VERSION,
     RPG_REDUCER_VERSION,
@@ -42,6 +42,18 @@ class CommitEventsResult:
     replayed: bool
 
 
+# Every table ensure_schema() creates, so a partially built database fails
+# verification instead of being accepted from the memo.
+_RPG_REQUIRED_TABLES = (
+    "rpg_campaigns",
+    "rpg_sessions",
+    "rpg_session_proposals",
+    "rpg_session_events",
+    "rpg_idempotency_records",
+    "rpg_session_snapshots",
+)
+
+
 class RPGRepository:
     """Persistence adapter for RPG campaign/session state in a user's ChaChaNotes DB."""
 
@@ -57,8 +69,28 @@ class RPGRepository:
         database file rather than repeated on every call.
         """
         repo = cls(db)
-        ensure_once("rpg", getattr(db, "db_path_str", None), repo.ensure_schema)
+        ensure_once(
+            "rpg",
+            getattr(db, "db_path_str", None),
+            repo.ensure_schema,
+            verify=repo._schema_present,
+        )
         return repo
+
+    def _schema_present(self) -> bool:
+        """Cheap check that this database still has the RPG tables.
+
+        Checks the whole set rather than one table, so a database holding only
+        part of the schema is rebuilt instead of being accepted. Failures
+        propagate to :func:`ensure_once`, which logs them and rebuilds.
+        """
+        with self.db.transaction() as conn:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+                "(?, ?, ?, ?, ?, ?)",
+                _RPG_REQUIRED_TABLES,
+            ).fetchall()
+        return {row[0] for row in rows}.issuperset(_RPG_REQUIRED_TABLES)
 
     def ensure_schema(self) -> None:
         statements = (

--- a/tldw_Server_API/app/core/DB_Management/RPG_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/RPG_DB.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.RPG.constants import (
     RPG_EVENT_SCHEMA_VERSION,
@@ -49,8 +50,14 @@ class RPGRepository:
 
     @classmethod
     def initialized(cls, db: CharactersRAGDB) -> RPGRepository:
+        """Return a repository whose tables exist, creating them once per process.
+
+        This is called per request from the RPG endpoints. ensure_schema() is
+        idempotent but issues ten DDL statements, so it is de-duplicated per
+        database file rather than repeated on every call.
+        """
         repo = cls(db)
-        repo.ensure_schema()
+        ensure_once("rpg", getattr(db, "db_path_str", None), repo.ensure_schema)
         return repo
 
     def ensure_schema(self) -> None:

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -1706,6 +1706,18 @@ def _idempotency_record_from_row(row: sqlite3.Row | None) -> IdempotencyRecordRo
     )
 
 
+# Every table ensure_schema() creates, so a partially built database fails
+# verification instead of being accepted from the memo.
+_SCHEDULED_TASKS_REQUIRED_TABLES = (
+    "scheduled_task_previews",
+    "scheduled_task_definitions",
+    "scheduled_task_audit_events",
+    "scheduled_task_idempotency",
+    "scheduled_task_runs",
+    "scheduled_task_results",
+)
+
+
 class ScheduledTasksDatabase:
     """SQLite repository for one user's Scheduled Tasks automation database."""
 
@@ -1717,6 +1729,22 @@ class ScheduledTasksDatabase:
         """Return the per-user Scheduled Tasks repository for ``user_id``."""
         user_dir = DatabasePaths.get_user_base_directory(user_id)
         return cls(user_dir / _SCHEDULED_TASKS_DB_NAME)
+
+    def schema_present(self) -> bool:
+        """Report whether this database still has the Scheduled Tasks tables.
+
+        Cheap enough to run in place of :meth:`ensure_schema` when that has
+        already run for this database in this process -- one catalogue query
+        against roughly 175 DDL statements. Checks every table the routine
+        creates, so a partially built database reports False and is rebuilt.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+                "(?, ?, ?, ?, ?, ?)",
+                _SCHEDULED_TASKS_REQUIRED_TABLES,
+            ).fetchall()
+        return {row[0] for row in rows}.issuperset(_SCHEDULED_TASKS_REQUIRED_TABLES)
 
     def ensure_schema(self) -> None:
         """Create Scheduled Tasks automation tables and indexes if needed."""

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.DB_Management.content_backend import (
     backend_target_key,
@@ -537,6 +538,40 @@ class WatchlistsDatabase:
         finally:
             self._backend_refresh_suspended = previous_suspend
         WatchlistsDatabase._schema_init_keys.add(db_key)
+
+    def _watchlists_schema_present(self) -> bool:
+        """Cheap check that this database still has the watchlists tables."""
+        try:
+            rows = self._backend.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                ("sources",),
+            )
+        except Exception:
+            return False
+        try:
+            return bool(list(rows))
+        except TypeError:
+            return bool(rows)
+
+    def ensure_schema_once(self) -> None:
+        """Ensure the schema, skipping the work when it is demonstrably present.
+
+        ``ensure_schema()`` issues roughly sixty DDL statements, and the FastAPI
+        dependency called it on every request.
+
+        The constructor's ``_schema_init_keys`` memo is not sufficient on its
+        own here: for SQLite its key is just the database path, so a database
+        deleted and recreated at that path (test fixtures do exactly this) keeps
+        a stale entry and the schema would be skipped when it no longer exists.
+        A single catalogue lookup confirms the tables really are there, and is
+        still far cheaper than replaying the schema.
+        """
+        ensure_once(
+            "watchlists",
+            getattr(getattr(self._backend, "config", None), "sqlite_path", None),
+            self.ensure_schema,
+            verify=self._watchlists_schema_present,
+        )
 
     @contextlib.contextmanager
     def _operation_backend_pin(self) -> Generator[DatabaseBackend, None, None]:

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -468,6 +468,18 @@ def _decorate_watchlists_public_operations(cls: type["WatchlistsDatabase"]) -> t
     return cls
 
 
+# Spans the whole of ensure_schema(): the first table it creates through the
+# last, so a partially built database fails verification.
+_WATCHLISTS_REQUIRED_TABLES = (
+    "sources",
+    "watchlists",
+    "scrape_jobs",
+    "scraped_items",
+    "feed_websub_subscriptions",
+    "deleted_jobs",
+)
+
+
 @_decorate_watchlists_public_operations
 class WatchlistsDatabase:
     # Keep track of schema initialization per DB path to avoid redundant ALTER checks/noise
@@ -534,24 +546,46 @@ class WatchlistsDatabase:
         self._backend_refresh_suspended = True
         try:
             self._backend = backend
-            self.ensure_schema()
+            self._ensure_schema_deduplicated()
         finally:
             self._backend_refresh_suspended = previous_suspend
         WatchlistsDatabase._schema_init_keys.add(db_key)
 
     def _watchlists_schema_present(self) -> bool:
-        """Cheap check that this database still has the watchlists tables."""
-        try:
-            rows = self._backend.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                ("sources",),
-            )
-        except Exception:
-            return False
-        try:
-            return bool(list(rows))
-        except TypeError:
-            return bool(rows)
+        """Cheap check that this database still has the watchlists tables.
+
+        Checks a set spanning the whole of ``ensure_schema()`` rather than one
+        table, so a database holding only part of the schema is rebuilt instead
+        of being accepted. ``deleted_jobs`` is the last table the routine
+        creates, which makes it the strongest single signal that a previous run
+        got all the way through.
+
+        Failures propagate to :func:`ensure_once`, which logs them and rebuilds.
+        """
+        rows = self._backend.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+            "(?, ?, ?, ?, ?, ?)",
+            _WATCHLISTS_REQUIRED_TABLES,
+        )
+        found = {row[0] for row in rows}
+        return found.issuperset(_WATCHLISTS_REQUIRED_TABLES)
+
+    def _ensure_schema_deduplicated(self) -> None:
+        """Ensure the schema, going through the process-wide memo when possible.
+
+        PostgreSQL has no ``sqlite_path`` for :func:`ensure_once` to identify the
+        database by, so it keeps using the class-level target-key memo; routing
+        it here anyway would fall through to the full DDL on every call.
+        """
+        if self._backend.backend_type == BackendType.POSTGRESQL:
+            self.ensure_schema()
+            return
+        ensure_once(
+            "watchlists",
+            getattr(getattr(self._backend, "config", None), "sqlite_path", None),
+            self.ensure_schema,
+            verify=self._watchlists_schema_present,
+        )
 
     def ensure_schema_once(self) -> None:
         """Ensure the schema, skipping the work when it is demonstrably present.
@@ -563,15 +597,18 @@ class WatchlistsDatabase:
         own here: for SQLite its key is just the database path, so a database
         deleted and recreated at that path (test fixtures do exactly this) keeps
         a stale entry and the schema would be skipped when it no longer exists.
-        A single catalogue lookup confirms the tables really are there, and is
-        still far cheaper than replaying the schema.
+        A catalogue lookup confirms the tables really are there, and is still far
+        cheaper than replaying the schema.
+
+        Construction goes through the same memo, so the first request for a
+        database does not run the setup twice.
         """
-        ensure_once(
-            "watchlists",
-            getattr(getattr(self._backend, "config", None), "sqlite_path", None),
-            self.ensure_schema,
-            verify=self._watchlists_schema_present,
-        )
+        if self._backend.backend_type == BackendType.POSTGRESQL:
+            self._ensure_schema_for_key(
+                self._backend, self._backend_target_key(self._backend)
+            )
+            return
+        self._ensure_schema_deduplicated()
 
     @contextlib.contextmanager
     def _operation_backend_pin(self) -> Generator[DatabaseBackend, None, None]:

--- a/tldw_Server_API/app/core/DB_Management/schema_once.py
+++ b/tldw_Server_API/app/core/DB_Management/schema_once.py
@@ -1,0 +1,103 @@
+"""Process-level de-duplication for idempotent schema setup.
+
+``ensure_schema()`` implementations are idempotent -- they are written with
+``CREATE TABLE IF NOT EXISTS`` and guarded ``ALTER TABLE`` -- but they are not
+free. Running one issues tens to hundreds of DDL statements.
+
+Several repositories are constructed per request and ensure their schema on
+construction, so that cost landed on every request:
+
+    GET /api/v1/scheduled-tasks    229 SQL statements, 175 of them DDL
+    GET /api/v1/watchlists/items    73 SQL statements,  61 of them DDL
+    GET /api/v1/rpg/rules/adapters  19 SQL statements,  10 of them DDL
+
+This does not change *whether* the schema is ensured, only how often. The first
+construction for a given database still runs the full setup; later ones in the
+same process skip it.
+
+The key includes the file's device and inode, so a database that is deleted and
+recreated at the same path -- test teardown, a restored backup -- is set up
+again rather than assumed. Databases with no resolvable path are never
+memoized, which keeps in-memory databases (distinct per connection despite
+sharing a name) correct by default.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Callable
+
+_COMPLETED: set[tuple[str, str, int, int]] = set()
+_LOCK = threading.Lock()
+
+
+def _identity(scope: str, path: str | os.PathLike[str] | None) -> tuple[str, str, int, int] | None:
+    """Build a stable identity for a database file, or ``None`` if unsafe to cache."""
+    if not path:
+        return None
+    text = str(path)
+    if not text or text == ":memory:" or text.startswith("file::memory:"):
+        return None
+    try:
+        stat = os.stat(text)
+    except OSError:
+        return None
+    return (scope, text, stat.st_dev, stat.st_ino)
+
+
+def ensure_once(
+    scope: str,
+    path: str | os.PathLike[str] | None,
+    ensure: Callable[[], None],
+    *,
+    verify: Callable[[], bool] | None = None,
+) -> None:
+    """Run ``ensure`` the first time this database is seen in this process.
+
+    Args:
+        scope: Distinguishes callers that share a database file but own
+            different tables, so one caller's setup cannot satisfy another's.
+        path: Filesystem path of the database. When it cannot be resolved the
+            call falls through to ``ensure`` every time, which is the safe
+            direction.
+        ensure: The idempotent schema routine to run.
+        verify: Optional cheap check that the schema really is present. Supply
+            this whenever a database may be deleted and recreated underneath a
+            live process: path/device/inode is not sufficient on its own,
+            because a filesystem may hand back the same inode for a file
+            recreated at the same path. When the memo hits and ``verify``
+            returns False, the full setup runs again. One existence query is
+            still far cheaper than replaying the whole schema.
+    """
+    identity = _identity(scope, path)
+    if identity is not None:
+        with _LOCK:
+            remembered = identity in _COMPLETED
+        if remembered:
+            if verify is None:
+                return
+            try:
+                if verify():
+                    return
+            except Exception:
+                pass  # fall through and rebuild
+            with _LOCK:
+                _COMPLETED.discard(identity)
+
+    ensure()
+
+    # Only remember setups that completed; a failure must be retried.
+    if identity is not None:
+        with _LOCK:
+            _COMPLETED.add(identity)
+
+
+def reset(scope: str | None = None) -> None:
+    """Forget completed setups, for tests that recreate databases in place."""
+    with _LOCK:
+        if scope is None:
+            _COMPLETED.clear()
+            return
+        for entry in [e for e in _COMPLETED if e[0] == scope]:
+            _COMPLETED.discard(entry)

--- a/tldw_Server_API/app/core/DB_Management/schema_once.py
+++ b/tldw_Server_API/app/core/DB_Management/schema_once.py
@@ -12,38 +12,107 @@ construction, so that cost landed on every request:
     GET /api/v1/rpg/rules/adapters  19 SQL statements,  10 of them DDL
 
 This does not change *whether* the schema is ensured, only how often. The first
-construction for a given database still runs the full setup; later ones in the
-same process skip it.
+call for a given database still runs the full setup; later ones in the same
+process replace it with a single catalogue lookup.
 
-The key includes the file's device and inode, so a database that is deleted and
-recreated at the same path -- test teardown, a restored backup -- is set up
-again rather than assumed. Databases with no resolvable path are never
-memoized, which keeps in-memory databases (distinct per connection despite
-sharing a name) correct by default.
+Only wrap the schema setup itself. Anything that reconciles ongoing state --
+re-seeding rows from files that can change on disk, for instance -- must keep
+running on its own schedule, because "the tables exist" says nothing about
+whether that state is current.
 """
 
 from __future__ import annotations
 
 import os
 import threading
+from collections import OrderedDict
 from collections.abc import Callable
+from urllib.parse import unquote, urlsplit
 
-_COMPLETED: set[tuple[str, str, int, int]] = set()
-_LOCK = threading.Lock()
+from loguru import logger
+
+# Databases are identified by (scope, path, device, inode).
+_Identity = tuple[str, str, int, int]
+
+# Per-database bookkeeping. ``done`` guards the memo; ``lock`` serializes
+# concurrent first-touches of the same database so they cannot each run the
+# full DDL.
+class _Entry:
+    __slots__ = ("done", "lock")
+
+    def __init__(self) -> None:
+        self.done = False
+        self.lock = threading.Lock()
 
 
-def _identity(scope: str, path: str | os.PathLike[str] | None) -> tuple[str, str, int, int] | None:
+# Bounded so a long-lived multi-user process that opens a database per user does
+# not accumulate entries forever. Eviction is least-recently-used; an evicted
+# database simply pays for its setup again on next use.
+_MAX_TRACKED_DATABASES = 4096
+
+_ENTRIES: OrderedDict[_Identity, _Entry] = OrderedDict()
+_ENTRIES_LOCK = threading.Lock()
+
+
+def _resolve_path(text: str) -> str | None:
+    """Reduce a SQLite path or URI to something ``os.stat`` accepts.
+
+    Returns ``None`` for anything that is not a real file, which disables
+    memoization for that caller -- the safe direction, since an in-memory
+    database is distinct per connection despite sharing a name.
+    """
+    if not text or text == ":memory:":
+        return None
+    if not text.startswith("file:"):
+        return text
+
+    # file:/srv/app.db?mode=rwc -> /srv/app.db, and file::memory:... -> None
+    split = urlsplit(text)
+    path = unquote(split.path)
+    if not path or ":memory:" in text[: text.find("?") if "?" in text else len(text)]:
+        return None
+    return path
+
+
+def _identity(scope: str, path: str | os.PathLike[str] | None) -> _Identity | None:
     """Build a stable identity for a database file, or ``None`` if unsafe to cache."""
     if not path:
         return None
-    text = str(path)
-    if not text or text == ":memory:" or text.startswith("file::memory:"):
+    resolved = _resolve_path(str(path))
+    if resolved is None:
         return None
     try:
-        stat = os.stat(text)
+        stat = os.stat(resolved)
     except OSError:
         return None
-    return (scope, text, stat.st_dev, stat.st_ino)
+    return (scope, resolved, stat.st_dev, stat.st_ino)
+
+
+def _entry_for(identity: _Identity) -> _Entry:
+    """Return this database's bookkeeping, creating and aging it as needed."""
+    with _ENTRIES_LOCK:
+        entry = _ENTRIES.get(identity)
+        if entry is None:
+            entry = _Entry()
+            _ENTRIES[identity] = entry
+            while len(_ENTRIES) > _MAX_TRACKED_DATABASES:
+                _ENTRIES.popitem(last=False)
+        else:
+            _ENTRIES.move_to_end(identity)
+        return entry
+
+
+def _schema_still_present(verify: Callable[[], bool], identity: _Identity) -> bool:
+    """Run the caller's check, treating a failed check as "rebuild"."""
+    try:
+        return bool(verify())
+    except Exception as exc:  # noqa: BLE001 - any failure means we cannot trust the memo
+        logger.warning(
+            "schema_once: verification failed for {} ({}); re-running schema setup",
+            identity[1],
+            exc,
+        )
+        return False
 
 
 def ensure_once(
@@ -51,53 +120,65 @@ def ensure_once(
     path: str | os.PathLike[str] | None,
     ensure: Callable[[], None],
     *,
-    verify: Callable[[], bool] | None = None,
+    verify: Callable[[], bool],
 ) -> None:
     """Run ``ensure`` the first time this database is seen in this process.
 
     Args:
         scope: Distinguishes callers that share a database file but own
             different tables, so one caller's setup cannot satisfy another's.
-        path: Filesystem path of the database. When it cannot be resolved the
-            call falls through to ``ensure`` every time, which is the safe
-            direction.
-        ensure: The idempotent schema routine to run.
-        verify: Optional cheap check that the schema really is present. Supply
-            this whenever a database may be deleted and recreated underneath a
-            live process: path/device/inode is not sufficient on its own,
-            because a filesystem may hand back the same inode for a file
-            recreated at the same path. When the memo hits and ``verify``
-            returns False, the full setup runs again. One existence query is
-            still far cheaper than replaying the whole schema.
+        path: Filesystem path or SQLite URI of the database. When it cannot be
+            resolved to a real file the call falls through to ``ensure`` every
+            time, which is the safe direction.
+        ensure: The idempotent schema routine to run. It must set up schema
+            only; see the module docstring.
+        verify: Cheap check that the schema really is present, run on every
+            memo hit. Required, because path/device/inode is not sufficient on
+            its own: a filesystem may hand back the same inode for a file
+            recreated at the same path, and the memo would then skip setup for
+            a database that no longer has the tables. One catalogue query is
+            still far cheaper than replaying the whole schema. A check that
+            raises is treated as a failed check.
+
+    Returns:
+        None.
     """
     identity = _identity(scope, path)
-    if identity is not None:
-        with _LOCK:
-            remembered = identity in _COMPLETED
-        if remembered:
-            if verify is None:
-                return
-            try:
-                if verify():
-                    return
-            except Exception:
-                pass  # fall through and rebuild
-            with _LOCK:
-                _COMPLETED.discard(identity)
+    if identity is None:
+        ensure()
+        return
 
-    ensure()
+    entry = _entry_for(identity)
+    if entry.done and _schema_still_present(verify, identity):
+        return
 
-    # Only remember setups that completed; a failure must be retried.
-    if identity is not None:
-        with _LOCK:
-            _COMPLETED.add(identity)
+    # Serialize first-touches of this database so concurrent callers do not each
+    # replay the DDL. (An entry evicted while its lock is held is replaced by a
+    # fresh one; the worst case is a duplicate run of an idempotent routine.)
+    with entry.lock:
+        if entry.done and _schema_still_present(verify, identity):
+            return
+        entry.done = False
+        ensure()
+        # Only remember setups that completed; a failure must be retried.
+        entry.done = True
 
 
 def reset(scope: str | None = None) -> None:
-    """Forget completed setups, for tests that recreate databases in place."""
-    with _LOCK:
+    """Forget completed setups, so the next call runs the full schema routine.
+
+    For tests that delete and recreate databases in place.
+
+    Args:
+        scope: Forget only this scope's entries. When ``None``, forget every
+            scope.
+
+    Returns:
+        None.
+    """
+    with _ENTRIES_LOCK:
         if scope is None:
-            _COMPLETED.clear()
+            _ENTRIES.clear()
             return
-        for entry in [e for e in _COMPLETED if e[0] == scope]:
-            _COMPLETED.discard(entry)
+        for identity in [key for key in _ENTRIES if key[0] == scope]:
+            del _ENTRIES[identity]

--- a/tldw_Server_API/app/services/app_lifecycle.py
+++ b/tldw_Server_API/app/services/app_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Literal
@@ -9,6 +10,17 @@ from fastapi import FastAPI, HTTPException
 _LIFECYCLE_EVENTS_ATTR = "_tldw_lifecycle_events"
 _LIFECYCLE_STATE_ATTR = "_tldw_lifecycle_state"
 _LifecycleEvent = Literal["startup", "shutdown"]
+
+# Every app that has lifecycle state, so all of them can be reset together.
+#
+# More than one app object can be live at once: the test suite replaces
+# ``sys.modules["tldw_Server_API.app.main"]`` to get a freshly built app,
+# but modules that already did ``from ... .main import app`` keep routing
+# through the object they pinned at import time. Draining one of those
+# pinned objects is invisible to anything that looks only at the current
+# module, so the registry keeps hold of them. It is weak, so an app that
+# goes out of scope is not kept alive by being listed here.
+_LIFECYCLE_APPS: weakref.WeakSet[FastAPI] = weakref.WeakSet()
 
 
 @dataclass
@@ -31,13 +43,28 @@ def get_or_create_lifecycle_state(app: FastAPI) -> AppLifecycleState:
     if state is None:
         state = AppLifecycleState()
         app.state._tldw_lifecycle_state = state
+        _LIFECYCLE_APPS.add(app)
     return state
 
 
 def reset_lifecycle_state(app: FastAPI) -> AppLifecycleState:
     state = AppLifecycleState()
     app.state._tldw_lifecycle_state = state
+    _LIFECYCLE_APPS.add(app)
     return state
+
+
+def reset_all_lifecycle_states() -> None:
+    """Reset every app that has lifecycle state.
+
+    Resetting only the app reachable through the current ``app.main`` module is
+    not enough. A ``TestClient`` lifespan exit marks whichever app object it was
+    given as draining, and that object may no longer be the one the module
+    exports -- in which case it stays drained for the rest of the process and
+    ``DrainGateMiddleware`` answers 503 to every request routed through it.
+    """
+    for app in list(_LIFECYCLE_APPS):
+        reset_lifecycle_state(app)
 
 
 def is_lifecycle_draining(app: FastAPI) -> bool:

--- a/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
+++ b/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
@@ -17,15 +17,15 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas im
     ScheduledTaskDeleteResponse,
     ScheduledTaskListResponse,
 )
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ReminderTaskRow
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import DefinitionRow, ScheduledTasksDatabase
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
+from tldw_Server_API.app.core.DB_Management.Watchlists_DB import JobRow, WatchlistsDatabase
 from tldw_Server_API.app.core.Personalization.companion_activity import (
     record_reminder_task_created,
     record_reminder_task_deleted,
     record_reminder_task_updated,
 )
-from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ReminderTaskRow
-from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import DefinitionRow, ScheduledTasksDatabase
-from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
-from tldw_Server_API.app.core.DB_Management.Watchlists_DB import JobRow, WatchlistsDatabase
 from tldw_Server_API.app.services.reminders_scheduler import get_reminders_scheduler
 
 _NONCRITICAL_SCHEDULER_EXCEPTIONS = (
@@ -165,7 +165,12 @@ class ScheduledTasksControlPlaneService:
     def _scheduled_tasks_db(user_id: int) -> ScheduledTasksDatabase:
         db = ScheduledTasksDatabase.for_user(user_id=user_id)
         # ensure_schema() issues ~175 DDL statements and this runs per request.
-        ensure_once("scheduled_tasks", db.db_path, db.ensure_schema)
+        ensure_once(
+            "scheduled_tasks",
+            db.db_path,
+            db.ensure_schema,
+            verify=db.schema_present,
+        )
         return db
 
     @staticmethod

--- a/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
+++ b/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
 )
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ReminderTaskRow
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import DefinitionRow, ScheduledTasksDatabase
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import JobRow, WatchlistsDatabase
 from tldw_Server_API.app.services.reminders_scheduler import get_reminders_scheduler
 
@@ -157,13 +158,14 @@ class ScheduledTasksControlPlaneService:
     def _watchlists_db(user_id: int) -> WatchlistsDatabase:
         db = WatchlistsDatabase.for_user(user_id=user_id)
         with suppress(Exception):
-            db.ensure_schema()
+            db.ensure_schema_once()
         return db
 
     @staticmethod
     def _scheduled_tasks_db(user_id: int) -> ScheduledTasksDatabase:
         db = ScheduledTasksDatabase.for_user(user_id=user_id)
-        db.ensure_schema()
+        # ensure_schema() issues ~175 DDL statements and this runs per request.
+        ensure_once("scheduled_tasks", db.db_path, db.ensure_schema)
         return db
 
     @staticmethod

--- a/tldw_Server_API/tests/AuthNZ/unit/test_crypto_utils_key_cache.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_crypto_utils_key_cache.py
@@ -1,0 +1,104 @@
+"""Contracts for memoized HMAC key derivation.
+
+The KDF is deliberately expensive -- 100,000 PBKDF2 rounds -- and API key
+validation re-derived it several times per request. Memoizing it is only safe
+while it stays indistinguishable from deriving every time, so these pin the
+properties that make it so.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ import crypto_utils
+from tldw_Server_API.app.core.AuthNZ.crypto_utils import (
+    derive_hmac_key_from_source,
+    reset_hmac_key_cache,
+)
+
+
+def _uncached(source: bytes, *, legacy: bool = False) -> bytes:
+    """Derive without touching the cache, the way the code used to."""
+    salt = (
+        crypto_utils._HMAC_KDF_SALT_LEGACY
+        if legacy
+        else crypto_utils._derive_hmac_kdf_salt(source)
+    )
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        source,
+        salt,
+        crypto_utils._HMAC_KDF_ITERATIONS,
+        dklen=crypto_utils._HMAC_KDF_DKLEN,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    reset_hmac_key_cache()
+    yield
+    reset_hmac_key_cache()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("legacy", [False, True])
+def test_cached_key_matches_deriving_every_time(legacy: bool) -> None:
+    """The whole point: caching must not change the derived key."""
+    secret = b"a-server-secret"
+
+    first = derive_hmac_key_from_source(secret, legacy=legacy)
+    second = derive_hmac_key_from_source(secret, legacy=legacy)
+
+    assert first == _uncached(secret, legacy=legacy)
+    assert second == first
+
+
+@pytest.mark.unit
+def test_different_secrets_derive_different_keys() -> None:
+    """A cache that collided across secrets would be a key-confusion bug."""
+    assert derive_hmac_key_from_source(b"one") != derive_hmac_key_from_source(b"two")
+
+
+@pytest.mark.unit
+def test_legacy_salt_is_a_separate_entry() -> None:
+    """Same secret, different salt mode, different key."""
+    secret = b"a-server-secret"
+
+    assert derive_hmac_key_from_source(secret) != derive_hmac_key_from_source(
+        secret, legacy=True
+    )
+
+
+@pytest.mark.unit
+def test_cache_is_keyed_by_fingerprint_not_by_the_secret() -> None:
+    """The cache must not be another long-lived copy of the configured secret."""
+    secret = b"a-server-secret"
+    derive_hmac_key_from_source(secret)
+
+    keys = list(crypto_utils._HMAC_KEY_CACHE)
+    assert (hashlib.sha256(secret).digest(), False) in keys
+    assert all(secret != key[0] for key in keys), "the raw secret is a cache key"
+
+
+@pytest.mark.unit
+def test_cache_is_bounded() -> None:
+    """Secret rotation and per-test settings churn must not grow it forever."""
+    for index in range(crypto_utils._HMAC_KEY_CACHE_MAXSIZE * 4):
+        derive_hmac_key_from_source(f"secret-{index}".encode())
+
+    assert len(crypto_utils._HMAC_KEY_CACHE) == crypto_utils._HMAC_KEY_CACHE_MAXSIZE
+
+
+@pytest.mark.unit
+def test_reset_forces_the_next_derivation_to_run_again() -> None:
+    """Tests that rotate a secret in place depend on this."""
+    secret = b"a-server-secret"
+    derive_hmac_key_from_source(secret)
+    assert crypto_utils._HMAC_KEY_CACHE
+
+    reset_hmac_key_cache()
+
+    assert not crypto_utils._HMAC_KEY_CACHE
+    assert derive_hmac_key_from_source(secret) == _uncached(secret)

--- a/tldw_Server_API/tests/DB_Management/test_schema_once.py
+++ b/tldw_Server_API/tests/DB_Management/test_schema_once.py
@@ -1,0 +1,210 @@
+"""Contracts for the process-level schema setup memo.
+
+``ensure_once`` decides whether a database's schema routine gets to be skipped.
+Getting that wrong is not a slow request, it is a request against a database
+with no tables, so the conditions under which it says "already done" are worth
+pinning down.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management import schema_once
+from tldw_Server_API.app.core.DB_Management.schema_once import ensure_once
+
+
+@pytest.fixture(autouse=True)
+def _isolate_memo():
+    """Each test starts from an empty memo and leaves one behind."""
+    schema_once.reset()
+    yield
+    schema_once.reset()
+
+
+def _make_db(path: Path) -> None:
+    """Create a database with the table our verify callback looks for."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS marker (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _has_marker(path: Path) -> bool:
+    if not path.exists():
+        return False
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='marker'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return bool(rows)
+
+
+@pytest.mark.unit
+def test_setup_runs_once_for_the_same_database(tmp_path: Path) -> None:
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+
+    for _ in range(5):
+        ensure_once("s", db, lambda: calls.append(1), verify=lambda: _has_marker(db))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_scopes_do_not_satisfy_each_other(tmp_path: Path) -> None:
+    """Two callers sharing a file own different tables."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+
+    ensure_once("a", db, lambda: calls.append("a"), verify=lambda: True)
+    ensure_once("b", db, lambda: calls.append("b"), verify=lambda: True)
+    ensure_once("a", db, lambda: calls.append("a"), verify=lambda: True)
+
+    assert calls == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_failed_setup_is_retried(tmp_path: Path) -> None:
+    """A crash halfway through must not be remembered as success."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    attempts = []
+
+    def ensure() -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        ensure_once("s", db, ensure, verify=lambda: True)
+    ensure_once("s", db, ensure, verify=lambda: True)
+
+    assert len(attempts) == 2
+
+
+@pytest.mark.unit
+def test_database_recreated_at_the_same_path_is_set_up_again(tmp_path: Path) -> None:
+    """The reason verify exists: a filesystem may reuse the inode."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+
+    def ensure() -> None:
+        calls.append(1)
+        _make_db(db)
+
+    ensure_once("s", db, ensure, verify=lambda: _has_marker(db))
+    db.unlink()
+    _make_db_without_marker = sqlite3.connect(db)
+    _make_db_without_marker.close()
+    ensure_once("s", db, ensure, verify=lambda: _has_marker(db))
+
+    assert len(calls) == 2, "a database missing its tables was served from the memo"
+
+
+@pytest.mark.unit
+def test_a_verify_that_raises_is_treated_as_absent(tmp_path: Path) -> None:
+    """We cannot trust a memo whose check blew up."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+
+    def exploding_verify() -> bool:
+        raise sqlite3.DatabaseError("file is not a database")
+
+    ensure_once("s", db, lambda: calls.append(1), verify=exploding_verify)
+    ensure_once("s", db, lambda: calls.append(1), verify=exploding_verify)
+
+    assert len(calls) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", [None, "", ":memory:", "file::memory:?cache=shared"])
+def test_databases_without_a_real_file_are_never_memoized(path) -> None:
+    """In-memory databases are distinct per connection despite sharing a name."""
+    calls = []
+
+    for _ in range(3):
+        ensure_once("s", path, lambda: calls.append(1), verify=lambda: True)
+
+    assert len(calls) == 3
+
+
+@pytest.mark.unit
+def test_sqlite_uris_are_memoized(tmp_path: Path) -> None:
+    """A file-backed URI names a real file, so it can be identified."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+    uri = f"file:{db}?mode=rwc"
+
+    for _ in range(3):
+        ensure_once("s", uri, lambda: calls.append(1), verify=lambda: _has_marker(db))
+
+    assert len(calls) == 1, "a file-backed URI fell through to setup every time"
+
+
+@pytest.mark.unit
+def test_concurrent_first_touches_run_setup_once(tmp_path: Path) -> None:
+    """Two requests arriving together must not both replay the DDL."""
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+    calls_lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def ensure() -> None:
+        with calls_lock:
+            calls.append(1)
+
+    def worker() -> None:
+        start.wait()
+        ensure_once("s", db, ensure, verify=lambda: _has_marker(db))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_tracking_is_bounded(tmp_path: Path, monkeypatch) -> None:
+    """A process opening a database per user must not grow this forever."""
+    monkeypatch.setattr(schema_once, "_MAX_TRACKED_DATABASES", 4)
+
+    for index in range(20):
+        db = tmp_path / f"user{index}.db"
+        _make_db(db)
+        ensure_once("s", db, lambda: None, verify=lambda: True)
+
+    assert len(schema_once._ENTRIES) <= 4
+
+
+@pytest.mark.unit
+def test_reset_targets_one_scope(tmp_path: Path) -> None:
+    db = tmp_path / "app.db"
+    _make_db(db)
+    calls = []
+
+    ensure_once("a", db, lambda: calls.append("a"), verify=lambda: True)
+    ensure_once("b", db, lambda: calls.append("b"), verify=lambda: True)
+    schema_once.reset("a")
+    ensure_once("a", db, lambda: calls.append("a"), verify=lambda: True)
+    ensure_once("b", db, lambda: calls.append("b"), verify=lambda: True)
+
+    assert calls == ["a", "b", "a"]

--- a/tldw_Server_API/tests/Infrastructure/test_lifecycle_drain_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_lifecycle_drain_isolation.py
@@ -1,0 +1,89 @@
+"""Drain state must not survive the test that produced it.
+
+``DrainGateMiddleware`` answers 503 to every non-control-plane request while an
+app is draining, and a ``TestClient`` lifespan exit drains whichever app object
+it was handed. That object is not always the one ``app.main`` currently
+exports: suites reload ``app.main``, while test modules that ran
+``from ...main import app`` at collection time keep routing through the object
+they pinned. Resetting only the current module's app therefore left the pinned
+one draining for the rest of the process, and every later request through it
+came back as::
+
+    {"status": "not_ready", "reason": "shutdown_in_progress"}
+
+which surfaced as ~29 unrelated Setup failures depending on suite order.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from tldw_Server_API.app.services.app_lifecycle import (
+    _LIFECYCLE_APPS,
+    is_lifecycle_draining,
+    mark_lifecycle_shutdown,
+    reset_all_lifecycle_states,
+)
+
+ROOT_CONFTEST = Path(__file__).resolve().parents[1] / "conftest.py"
+
+
+@pytest.mark.unit
+def test_reset_all_clears_an_app_that_is_not_the_current_module_app() -> None:
+    """The app being reset is usually not the one ``app.main`` exports."""
+    pinned = FastAPI()
+    current = FastAPI()
+    mark_lifecycle_shutdown(pinned)
+    assert is_lifecycle_draining(pinned)
+
+    reset_all_lifecycle_states()
+
+    assert not is_lifecycle_draining(pinned), (
+        "a drained app stayed drained because it was no longer the app "
+        "reachable through app.main; every request through it would 503"
+    )
+    assert not is_lifecycle_draining(current)
+
+
+@pytest.mark.unit
+def test_reset_all_clears_several_drained_apps_at_once() -> None:
+    """Reloading repeatedly leaves more than one pinned app behind."""
+    apps = [FastAPI() for _ in range(3)]
+    for app in apps:
+        mark_lifecycle_shutdown(app)
+    assert all(is_lifecycle_draining(app) for app in apps)
+
+    reset_all_lifecycle_states()
+
+    assert not any(is_lifecycle_draining(app) for app in apps)
+
+
+@pytest.mark.unit
+def test_registry_does_not_keep_apps_alive() -> None:
+    """Tracking apps must not turn every test app into a permanent leak."""
+    app = FastAPI()
+    mark_lifecycle_shutdown(app)
+    assert app in _LIFECYCLE_APPS
+    ref = weakref.ref(app)
+
+    del app
+    gc.collect()
+
+    assert ref() is None, "the app registry is holding a strong reference"
+
+
+@pytest.mark.unit
+def test_root_fixture_resets_every_app_not_just_the_current_one() -> None:
+    """Guard the wiring: the semantics above only help if the fixture uses them."""
+    source = ROOT_CONFTEST.read_text(encoding="utf-8")
+
+    assert "reset_all_lifecycle_states" in source, (
+        f"{ROOT_CONFTEST.name} no longer resets every app with lifecycle state. "
+        "Resetting only the app exported by app.main leaves apps pinned by "
+        "earlier imports draining, which 503s unrelated tests downstream."
+    )

--- a/tldw_Server_API/tests/Infrastructure/test_lifecycle_drain_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_lifecycle_drain_isolation.py
@@ -16,6 +16,7 @@ which surfaced as ~29 unrelated Setup failures depending on suite order.
 
 from __future__ import annotations
 
+import ast
 import gc
 import weakref
 from pathlib import Path
@@ -24,13 +25,13 @@ import pytest
 from fastapi import FastAPI
 
 from tldw_Server_API.app.services.app_lifecycle import (
-    _LIFECYCLE_APPS,
     is_lifecycle_draining,
     mark_lifecycle_shutdown,
     reset_all_lifecycle_states,
 )
 
 ROOT_CONFTEST = Path(__file__).resolve().parents[1] / "conftest.py"
+FIXTURE_NAME = "_reset_main_app_lifecycle_state_between_tests"
 
 
 @pytest.mark.unit
@@ -68,7 +69,10 @@ def test_registry_does_not_keep_apps_alive() -> None:
     """Tracking apps must not turn every test app into a permanent leak."""
     app = FastAPI()
     mark_lifecycle_shutdown(app)
-    assert app in _LIFECYCLE_APPS
+    # Reaching it here proves it is tracked, so the collection check below is
+    # about a real entry rather than passing vacuously.
+    reset_all_lifecycle_states()
+    assert not is_lifecycle_draining(app)
     ref = weakref.ref(app)
 
     del app
@@ -79,11 +83,35 @@ def test_registry_does_not_keep_apps_alive() -> None:
 
 @pytest.mark.unit
 def test_root_fixture_resets_every_app_not_just_the_current_one() -> None:
-    """Guard the wiring: the semantics above only help if the fixture uses them."""
-    source = ROOT_CONFTEST.read_text(encoding="utf-8")
+    """Guard the wiring: the semantics above only help if the fixture calls them.
 
-    assert "reset_all_lifecycle_states" in source, (
-        f"{ROOT_CONFTEST.name} no longer resets every app with lifecycle state. "
+    Checks for the *call*, inside the fixture, rather than for the name
+    anywhere in the file -- an import left behind after the call was deleted
+    would satisfy a substring check while resetting nothing.
+    """
+    tree = ast.parse(ROOT_CONFTEST.read_text(encoding="utf-8"))
+
+    fixture = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == FIXTURE_NAME
+        ),
+        None,
+    )
+    assert fixture is not None, (
+        f"{ROOT_CONFTEST.name} no longer defines {FIXTURE_NAME}(), so nothing "
+        "clears drain state between tests."
+    )
+
+    called = {
+        node.func.id
+        for node in ast.walk(fixture)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "reset_all_lifecycle_states" in called, (
+        f"{FIXTURE_NAME}() no longer calls reset_all_lifecycle_states(). "
         "Resetting only the app exported by app.main leaves apps pinned by "
         "earlier imports draining, which 503s unrelated tests downstream."
     )

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -627,14 +627,24 @@ def pytest_collection_modifyitems(config, items):  # pragma: no cover - collecti
 
 @pytest.fixture(autouse=True)
 def _reset_main_app_lifecycle_state_between_tests():
-    """Keep TestClient lifespan shutdown from leaking drain state across tests."""
+    """Keep TestClient lifespan shutdown from leaking drain state across tests.
+
+    Resets every app that has lifecycle state, not just the one the current
+    ``app.main`` module exports. Suites that reload ``app.main`` leave earlier
+    app objects live -- test modules that imported ``app`` at collection time
+    keep routing through the object they pinned -- and it is those pinned
+    objects a lifespan exit tends to drain. Resetting only the current one
+    leaves them draining, and ``DrainGateMiddleware`` then answers 503 to every
+    request through them.
+    """
 
     def _reset() -> None:
         try:
-            from tldw_Server_API.app.main import app as fastapi_app
-            from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
+            from tldw_Server_API.app.services.app_lifecycle import (
+                reset_all_lifecycle_states,
+            )
 
-            reset_lifecycle_state(fastapi_app)
+            reset_all_lifecycle_states()
         except Exception:
             _ = None
 

--- a/tldw_Server_API/tests/sanity_tests/test_app_import_sanity.py
+++ b/tldw_Server_API/tests/sanity_tests/test_app_import_sanity.py
@@ -1,0 +1,40 @@
+"""The FastAPI application must import cleanly and register its routes.
+
+This is the most basic assertion a server project can make, and until now the
+suite made it only by accident: an autouse fixture in the root conftest ran
+``from tldw_Server_API.app.main import app`` before every test purely to reach
+the app object it wanted to reset. Importing ``app.main`` executes the whole
+route-registration graph, which is roughly nine points of the global coverage
+floor -- the fixture no longer needs that import, and removing it dropped the
+measured total from 12.91% to 4.11% against a 12% gate.
+
+The import belongs somewhere that says what it is for, so it lives here as a
+test rather than as a side effect of unrelated fixture code. It is at module
+scope so the app is loaded during collection, which is when the fixture used to
+load it.
+
+Note that the coverage this contributes is import-time execution, not exercised
+behaviour. That the floor leans on it this heavily is worth addressing on its
+own; this file at least makes the dependency visible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.main import app
+
+
+@pytest.mark.unit
+def test_app_imports_and_registers_routes() -> None:
+    """A broken import or an empty router is a total outage, not a subtle bug."""
+    assert app.routes, "the application registered no routes"
+
+
+@pytest.mark.unit
+def test_app_exposes_the_versioned_api_prefix() -> None:
+    """Every documented endpoint hangs off this prefix."""
+    paths = {getattr(route, "path", "") for route in app.routes}
+    assert any(path.startswith("/api/v1/") for path in paths), (
+        "no /api/v1 routes are registered; the v1 router did not load"
+    )


### PR DESCRIPTION
Round 2 of the holistic performance review, measured against `dev`. Four hot paths, plus one test-isolation defect found while verifying them.

Every number below is an interleaved A/B in-process measurement (`httpx.ASGITransport`), not an estimate.

## 1. `GET /api/v1/llm/providers`: 18.21s → 0.17s (107x)

Two independent causes.

**Sequential probing.** `discover_models_from_endpoint` walked its candidate URLs one at a time, so every dead candidate's timeout was paid in series. Now probed concurrently (capped at 6); the first `ready` result cancels the rest.

I did *not* cache negative discovery results. The first attempt did, and it broke a deliberate contract — `test_model_discovery_transient_failure_is_not_cached` asserts a provider that recovers is visible on the *next* call. Concurrency gets the same win without weakening that guarantee.

**LAN addresses in the shipped config.** `config.txt` pointed two providers at a developer's network:

```
ooba_api_IP   = http://192.168.2.235:5000/v1/chat/completions
ollama_api_IP = http://192.168.2.216:11434/v1
```

Off that network those aren't refused, they're silently dropped, so each probe ran to the full timeout. Both now point at loopback. A refused loopback connection returns in microseconds, and users actually running Ollama or text-generation-webui locally still get working discovery out of the box — which nulling the default would have removed. `LOCAL_MODEL_DISCOVERY_TIMEOUT` drops 3.0s → 1.5s to bound what remains.

## 2. Per-request schema DDL: 246 statements → 0

Four repositories ran their full `ensure_schema()` on every construction, and they're constructed per request.

| endpoint | before | after |
|---|---|---|
| `GET /scheduled-tasks` | 229 stmt / 175 DDL / 12.5ms | 13 / 0 / 5.9ms |
| `GET /watchlists/items` | 73 / 61 / 5.6ms | 3 / 0 / 3.9ms |
| `GET /rpg/rules/adapters` | 19 / 10 / 4.8ms | 9 / 0 / 4.4ms |

New `schema_once.ensure_once()` memoizes on `(scope, path, st_dev, st_ino)`. This changes *how often* the schema is ensured, never *whether*: the first construction per database still runs the full setup, and a failed setup is not memoized.

`verify` exists because path+dev+inode alone is not enough — a fixture `rmtree`s and recreates a database at a fixed path, and macOS handed back the same inode. A cheap `sqlite_master` lookup catches that and rebuilds; still far cheaper than replaying the schema. Databases with no resolvable path are never memoized, which keeps `:memory:` correct by default.

Collections keeps its Postgres bootstrap on the original path — widening the memo to cover it broke 29 tests, because the SQLite backend target key has no inode.

## 3. PBKDF2 on every authenticated request

`_derive_hmac_key_from_source` ran a full PBKDF2-HMAC-SHA256 stretch per call, on input that is server config — not user-supplied. Now memoized behind a bounded `lru_cache`.

| endpoint | before | after |
|---|---|---|
| `POST /chat/completions` | 161.5ms | 49.6ms |
| `POST /embeddings` | 102.9ms | 19.4ms |
| `GET /embeddings/models` | 95.5ms | 12.9ms |

The presented key stays the HMAC *message* and never enters the KDF, so nothing attacker-influenced is cached. Verified byte-identical to uncached PBKDF2 for both salt modes, distinct secrets stay distinct, cache bounded (hits=50 misses=1 maxsize=64). `reset_hmac_key_cache()` is exported for tests that rotate secrets in place.

## 4. Drain state leaking across tests (bonus — found while verifying the above)

`DrainGateMiddleware` answers 503 to every non-control-plane request while an app is draining, and a `TestClient` lifespan exit drains whichever app object it was handed. The autouse fixture meant to undo that reset only the app reachable through the *current* `app.main` — usually not the one that got drained:

```
test_setup_readiness_api.py
  pinned  id=4730158032  draining=True   phase=draining
  current id=13821470352 draining=False  phase=starting   same=False
```

Several app objects are live at once: suites reload `app.main`, while modules that ran `from ...main import app` at collection time keep routing through the object they pinned. The reset landed on the new app; the pinned one stayed drained for the rest of the process, and every later request through it returned `{"status": "not_ready", "reason": "shutdown_in_progress"}`.

`app_lifecycle` now keeps a `WeakSet` of every app that has lifecycle state, and `reset_all_lifecycle_states()` clears all of them. Weak, so tracking an app doesn't keep it alive — there's a test pinning that.

```
LLM_Adapters + Chat_NEW + Setup + Config
before: 29 failed, 1561 passed
after:   0 failed, 1590 passed
```

This does **not** fix the underlying `sys.modules` leak in `reload_app_main` (#2585) — multiple app objects still survive a reload. It stops that leak from causing spurious 503s. The hand-rolled workaround in `tests/Embeddings/conftest.py` is left in place rather than widening the change.

## Verification

Rebased on current `dev` and re-run: **1862 passed, 1 failed**. The one failure is `test_workflow_concurrency_policy.py::test_target_workflows_use_pr_stable_concurrency_groups`, which asserts a `concurrency.group` expression in a `.github` workflow — this PR touches no `.github` files, and it fails on `dev` too. Someone changed the workflow without updating the contract test.

Other suites, comparing failing **sets** against an unmodified baseline rather than counts:

- LLM_Adapters + Chat_NEW: 1005 passed, 0 failed
- AuthNZ + AuthNZ_SQLite + AuthNZ_Unit: 2664 passed, same 30 failures on baseline and patched, **0 new**
- Collections / RPG / Scheduler / Watchlists / VN: 1470 passed, 3 failed, all reproduce on baseline
- Services + Infrastructure: patched failures are a **subset** of baseline's (7 ⊂ 8)
- Setup: 344/344 under both the old and new `config.txt`

One apparent new failure in Embeddings — `test_upsert_idempotent_under_permutation` — turned out to be pre-existing. With a fresh Hypothesis database per run it fails 4 in 5 on baseline and 4 in 5 patched; it's a load-sensitive `FailedHealthCheck: Input generation is slow`. Worth flagging that a single-run set diff would have called it a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts three request hot paths against `dev`: provider discovery drops from 18.21s to 0.17s (107x), per-request schema DDL goes to zero, and HMAC key derivation is memoized instead of running PBKDF2 per call.

**Performance**
- Model discovery probes candidate URLs concurrently (capped at six) and cancels queued candidates on the first ready result; in-flight probes are still awaited, and failed probes stay uncached so a recovering provider is visible on the next call.
- Shipped `config.txt` pointed two providers at LAN addresses that silently time out elsewhere; they now default to loopback and the discovery timeout drops from 3.0s to 1.5s.
- New `schema_once.ensure_once()` memoizes schema setup on database file identity behind a 4096-entry LRU; concurrent first-touches are serialized so the DDL runs once, and a failed setup or a recreated database still re-runs.
- Schema verification checks the full required table set via one `sqlite_master` lookup; Collections' output-template seeding stays outside the memo and still runs per construction.
- PBKDF2 key derivation is memoized behind a bounded 64-entry cache keyed by a SHA-256 fingerprint of the secret, never the secret itself; it derives only server config, never the presented key, and `reset_hmac_key_cache()` is exported for secret rotation.

**Bug Fixes**
- Drain state no longer leaks across tests: `reset_all_lifecycle_states()` resets every app with lifecycle state via a WeakSet, fixing ~29 spurious Setup failures without keeping apps alive.
- Removing the fixture's `app.main` import would have dropped coverage below the 12% gate, so a new module-scope sanity test imports the app and asserts routes register.
- The one remaining failing test also fails on unmodified `dev`; it asserts a `.github` workflow expression this PR doesn't touch.

<sup>Written for commit 96fc20822cced11963141dec488cfef0708780fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

