### PR TITLE
test(extension): stabilize API-key persistence lifecycle

### DIFF
--- a/apps/tldw-frontend/e2e/extension-api-key-persistence.spec.ts
+++ b/apps/tldw-frontend/e2e/extension-api-key-persistence.spec.ts
@@ -95,7 +95,8 @@ const setExtensionStorage = async (
 
 const launchExtension = async (
   userDataDir: string,
-  extensionPath: string
+  extensionPath: string,
+  seedStartupState = true
 ): Promise<{ context: BrowserContext; page: Page; extensionId: string }> => {
   mkdirSync(path.join(userDataDir, "home"), { recursive: true })
   const context = await chromium.launchPersistentContext(userDataDir, {
@@ -117,11 +118,13 @@ const launchExtension = async (
   })
   try {
     const extensionId = await resolveExtensionId(context)
-    await setExtensionStorage(context, "local", {
-      __e2eSeeded: true,
-      __tldw_first_run_complete: true,
-      tldw_skip_landing_hub: true
-    })
+    if (seedStartupState) {
+      await setExtensionStorage(context, "local", {
+        __e2eSeeded: true,
+        __tldw_first_run_complete: true,
+        tldw_skip_landing_hub: true
+      })
+    }
     const page = context.pages()[0] || (await context.newPage())
     return { context, page, extensionId }
   } catch (startupError) {
@@ -186,18 +189,21 @@ const saveManualConnection = async (
     await rememberControl.click()
   }
   await page.getByRole("button", { name: /^save$/i }).click()
+  const storageArea = remember ? "local" : "session"
+  const storageKey = remember ? "tldwConfig" : "tldwManualSessionApiKey"
   await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          new Promise<unknown>((resolve) => {
-            chrome.storage.local.get("tldwConfig", (items) =>
-              resolve(items.tldwConfig)
-            )
-          })
+    .poll(async () =>
+      JSON.stringify(
+        await page.evaluate(
+          ({ area, key }) =>
+            new Promise<unknown>((resolve) => {
+              chrome.storage[area].get(key, (items) => resolve(items[key]))
+            }),
+          { area: storageArea, key: storageKey }
+        )
       )
     )
-    .not.toBeUndefined()
+    .toContain(MANUAL_API_KEY)
 }
 
 const extensionStorageValue = async (
@@ -346,7 +352,8 @@ test.describe.serial("manual extension API-key persistence", () => {
     {
       const { context, page, extensionId } = await launchExtension(
         profile,
-        extensionPath
+        extensionPath,
+        false
       )
       try {
         expect(extensionId).toBe(originalExtensionId)
@@ -482,7 +489,8 @@ test.describe.serial("manual extension API-key persistence", () => {
     {
       const { context, page, extensionId } = await launchExtension(
         profile,
-        extensionPath
+        extensionPath,
+        false
       )
       try {
         expect(extensionId).toBe(originalExtensionId)

--- a/backlog/tasks/task-13149 - Stabilize-extension-API-key-persistence-lifecycle.md
+++ b/backlog/tasks/task-13149 - Stabilize-extension-API-key-persistence-lifecycle.md
@@ -1,0 +1,58 @@
+---
+id: TASK-13149
+title: Stabilize extension API-key persistence lifecycle
+status: Done
+assignee: []
+created_date: '2026-09-01 00:21'
+updated_date: '2026-09-01 00:36'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the existing extension API-key persistence lifecycle so pull requests can reliably validate device and session credential behavior without timing out on the current dev baseline.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The extension persistence lifecycle completes reliably on the current `dev` baseline.
+- [x] #2 Device-scoped credentials survive extension restart while session-scoped credentials are cleared.
+- [x] #3 The focused lifecycle test and relevant frontend checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the current dev failure and trace the extension launch and persistence flow to the blocking boundary.
+2. Add the smallest regression check that fails for the identified race or lifecycle defect.
+3. Implement the minimal condition-based fix and verify the regression red-green cycle.
+4. Run the focused extension lifecycle plus relevant lint/build checks.
+5. Push a dedicated PR, address review feedback, and merge it before rebasing the Personal Context stack.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a routine reliability fix within the existing extension test and storage lifecycle boundaries; it does not change data ownership, persistence semantics, or architecture.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Reproduced the 180-second lifecycle timeout on the unmodified `dev` baseline and traced it to reseeding extension storage after reopening the same persistent Chromium profile.
+- Made startup seeding optional for restart checks and changed the save helper to wait for the credential in its actual storage area, removing both the restart hang and the session-save race without changing product persistence semantics.
+- Verified the focused ESLint check and nine serial Playwright lifecycle cases (`--repeat-each=3 --workers=1`); all passed. `git diff --check` also passed.
+- No user documentation update was needed because this is test-harness stabilization. Bandit is not applicable to the TypeScript-only change. No known skips or blockers remain.
+- ADR required: no. ADR path: N/A. This change stays inside the existing test and storage lifecycle boundaries.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- avoid reseeding extension storage when reopening an existing persistent profile
- wait for device or session credentials in the storage area selected by the save flow
- record the reproduced baseline failure, focused fix, and verification in TASK-13149

## Verification

- `bunx eslint e2e/extension-api-key-persistence.spec.ts`
- `bunx playwright test e2e/extension-api-key-persistence.spec.ts --reporter=line --workers=1 --repeat-each=3` (9 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the extension API-key persistence test (TASK-13149) so it no longer times out when reopening a persistent profile or races when checking session-stored credentials.

**Bug Fixes**
- Stops reseeding extension storage when restarting an existing profile, so the restart check uses preserved state.
- Waits for the credential in the actual storage area (local or session) selected by the save flow.

<sup>Written for commit 623143fedddea1739cc1e3a47656c52e8403a75a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

