### PR TITLE
test(ci): fix the workflow concurrency contract test, red on dev since July

### DIFF
--- a/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
+++ b/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
@@ -1,39 +1,102 @@
+"""Superseded runs of a PR's required checks must cancel each other.
+
+Every required workflow puts the PR identity in its concurrency group so a new
+push cancels the runs still going for the previous one. Get this wrong in a
+single workflow and that workflow keeps burning runners on commits nobody is
+waiting for, while the PR's other checks move on.
+
+This pins the shape of that contract rather than one exact expression. The
+expression has grown a fallback twice -- most recently ``workflow_run`` support,
+in a0cce60c7b, so runs triggered by another workflow group with the PR that
+caused them -- and both times the previous version of this test asserted a
+string literal and simply went red, unnoticed, for weeks. What actually matters
+is that the workflows agree with each other and key on the PR.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
-PR_STABLE_CONCURRENCY = "${{ github.event.pull_request.number || github.ref }}"
+# The required checks: the set whose runs must collapse together.
+TARGET_WORKFLOWS = (
+    "ci.yml",
+    "backend-required.yml",
+    "coverage-required.yml",
+    "frontend-required.yml",
+    "security-required.yml",
+    "e2e-required.yml",
+    "frontend-ux-gates.yml",
+    "pre-commit.yml",
+    "pypi-package.yml",
+    "sbom.yml",
+)
 
-EXPECTED_WORKFLOW_GROUPS = {
-    "ci.yml": f"ci-{PR_STABLE_CONCURRENCY}",
-    "backend-required.yml": f"backend-required-{PR_STABLE_CONCURRENCY}",
-    "coverage-required.yml": f"coverage-required-{PR_STABLE_CONCURRENCY}",
-    "frontend-required.yml": f"frontend-required-{PR_STABLE_CONCURRENCY}",
-    "security-required.yml": f"security-required-{PR_STABLE_CONCURRENCY}",
-    "e2e-required.yml": f"e2e-required-{PR_STABLE_CONCURRENCY}",
-    "frontend-ux-gates.yml": f"frontend-ux-gates-{PR_STABLE_CONCURRENCY}",
-    "pre-commit.yml": f"pre-commit-{PR_STABLE_CONCURRENCY}",
-    "pypi-package.yml": f"pypi-package-{PR_STABLE_CONCURRENCY}",
-    "sbom.yml": f"sbom-{PR_STABLE_CONCURRENCY}",
-}
+# Whatever else the expression falls back to, the PR number is what makes runs
+# for the same PR collapse. Without it they never group and nothing cancels.
+REQUIRED_KEY = "github.event.pull_request.number"
 
 
-def _load_workflow(name: str) -> dict:
+def _concurrency(name: str) -> dict:
     with (WORKFLOWS_DIR / name).open("r", encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+        workflow = yaml.safe_load(handle)
+    concurrency = workflow.get("concurrency")
+    assert isinstance(concurrency, dict), f"{name} is missing a concurrency block"
+    return concurrency
 
 
-def test_target_workflows_use_pr_stable_concurrency_groups():
-    for filename, expected_group in EXPECTED_WORKFLOW_GROUPS.items():
-        workflow = _load_workflow(filename)
-        concurrency = workflow.get("concurrency")
+def _suffix(name: str, group: str) -> str:
+    """Strip the per-workflow prefix, leaving the shared identity expression."""
+    prefix = f"{name.removesuffix('.yml')}-"
+    assert group.startswith(prefix), (
+        f"{name} has concurrency group {group!r}, which does not start with "
+        f"{prefix!r}. The prefix is what keeps one workflow's runs from "
+        f"cancelling another's."
+    )
+    return group.removeprefix(prefix)
 
-        assert isinstance(concurrency, dict), f"{filename} is missing a concurrency block"  # nosec B101
-        assert concurrency.get("group") == expected_group  # nosec B101
-        assert concurrency.get("cancel-in-progress") is True  # nosec B101
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", TARGET_WORKFLOWS)
+def test_required_workflow_cancels_superseded_runs(name: str) -> None:
+    """Without this, a superseded run keeps holding runners to completion."""
+    assert _concurrency(name).get("cancel-in-progress") is True, (
+        f"{name} does not cancel in-progress runs, so pushing to a PR leaves "
+        f"the previous run going."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", TARGET_WORKFLOWS)
+def test_required_workflow_groups_on_the_pull_request(name: str) -> None:
+    """A group that does not key on the PR never collapses anything."""
+    group = _concurrency(name).get("group", "")
+
+    assert REQUIRED_KEY in group, (
+        f"{name} has concurrency group {group!r}, which does not reference "
+        f"{REQUIRED_KEY}. Runs for the same pull request will not group, so "
+        f"none of them cancel."
+    )
+
+
+@pytest.mark.unit
+def test_required_workflows_agree_on_one_identity_expression() -> None:
+    """One workflow drifting is the failure this guard exists to catch.
+
+    They are prefixed per workflow and otherwise identical, so comparing the
+    suffixes catches a single file being edited in isolation -- which is how
+    this last broke.
+    """
+    suffixes = {name: _suffix(name, _concurrency(name).get("group", "")) for name in TARGET_WORKFLOWS}
+
+    distinct = set(suffixes.values())
+    assert len(distinct) == 1, (
+        "required workflows disagree on how they identify a run, so their runs "
+        "will not collapse together:\n"
+        + "\n".join(f"  {name}: {suffix}" for name, suffix in sorted(suffixes.items()))
+    )

--- a/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
+++ b/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
@@ -45,8 +45,16 @@ TARGET_WORKFLOWS = (
 # The distinction matters: on a workflow_run trigger there is no
 # github.event.pull_request, so a group keyed only on that form degrades to the
 # ref and stops collapsing anything.
+#
+# Every trigger whose payload carries a pull request is listed, not just the two
+# in use today. A trigger that is absent from this mapping has no requirement at
+# all, so an unlisted PR trigger would let a group with no PR identity through
+# silently -- the guard failing open is worse than it failing loudly.
 PR_IDENTITY_BY_TRIGGER = {
     "pull_request": "github.event.pull_request.number",
+    "pull_request_target": "github.event.pull_request.number",
+    "pull_request_review": "github.event.pull_request.number",
+    "pull_request_review_comment": "github.event.pull_request.number",
     "workflow_run": "github.event.workflow_run.pull_requests[0].number",
 }
 

--- a/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
+++ b/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
@@ -37,15 +37,41 @@ TARGET_WORKFLOWS = (
     "sbom.yml",
 )
 
-# Whatever else the expression falls back to, the PR number is what makes runs
-# for the same PR collapse. Without it they never group and nothing cancels.
-REQUIRED_KEY = "github.event.pull_request.number"
+# How each trigger names the pull request a run belongs to. These are GitHub's
+# own event paths, not a style choice -- there is one way to reach the PR number
+# from each event -- but which ones a workflow *needs* is read from its triggers
+# rather than assumed, so dropping a trigger drops its requirement too.
+#
+# The distinction matters: on a workflow_run trigger there is no
+# github.event.pull_request, so a group keyed only on that form degrades to the
+# ref and stops collapsing anything.
+PR_IDENTITY_BY_TRIGGER = {
+    "pull_request": "github.event.pull_request.number",
+    "workflow_run": "github.event.workflow_run.pull_requests[0].number",
+}
+
+
+def _workflow(name: str) -> dict:
+    with (WORKFLOWS_DIR / name).open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _triggers(name: str) -> set[str]:
+    """Return the workflow's trigger names.
+
+    ``on`` is a YAML 1.1 boolean, so PyYAML parses the key as ``True``.
+    """
+    workflow = _workflow(name)
+    on = workflow.get("on", workflow.get(True))
+    if isinstance(on, dict):
+        return set(on)
+    if isinstance(on, list):
+        return set(on)
+    return {on} if on else set()
 
 
 def _concurrency(name: str) -> dict:
-    with (WORKFLOWS_DIR / name).open("r", encoding="utf-8") as handle:
-        workflow = yaml.safe_load(handle)
-    concurrency = workflow.get("concurrency")
+    concurrency = _workflow(name).get("concurrency")
     assert isinstance(concurrency, dict), f"{name} is missing a concurrency block"
     return concurrency
 
@@ -74,13 +100,25 @@ def test_required_workflow_cancels_superseded_runs(name: str) -> None:
 @pytest.mark.unit
 @pytest.mark.parametrize("name", TARGET_WORKFLOWS)
 def test_required_workflow_groups_on_the_pull_request(name: str) -> None:
-    """A group that does not key on the PR never collapses anything."""
+    """A group that does not key on the PR never collapses anything.
+
+    Checked per trigger the workflow actually declares, so a workflow that only
+    ever runs on ``pull_request`` is not asked for the ``workflow_run`` form.
+    """
+    triggers = _triggers(name)
     group = _concurrency(name).get("group", "")
 
-    assert REQUIRED_KEY in group, (
-        f"{name} has concurrency group {group!r}, which does not reference "
-        f"{REQUIRED_KEY}. Runs for the same pull request will not group, so "
-        f"none of them cancel."
+    missing = {
+        trigger: token
+        for trigger, token in PR_IDENTITY_BY_TRIGGER.items()
+        if trigger in triggers and token not in group
+    }
+    assert not missing, (
+        f"{name} triggers on {sorted(missing)} but its concurrency group "
+        f"{group!r} has no way to identify the pull request on "
+        f"{'that trigger' if len(missing) == 1 else 'those triggers'}:\n"
+        + "\n".join(f"  {trigger}: expected {token}" for trigger, token in sorted(missing.items()))
+        + "\nRuns arriving that way fall back to the ref and never collapse."
     )
 
 


### PR DESCRIPTION
`test_target_workflows_use_pr_stable_concurrency_groups` has been failing on `dev` since **a0cce60c7b** (2026-07-24). It is not a real defect — the workflows are fine, the test was left behind.

That commit added `workflow_run` support to every required workflow's concurrency group, so runs triggered by another workflow group with the PR that caused them:

```
- ci-${{ github.event.pull_request.number || github.ref }}
+ ci-${{ github.event.workflow_run.pull_requests[0].number
+        || github.event.pull_request.number || github.ref || github.run_id }}
```

All ten workflows were updated together. The test asserted one exact string, so it went red and stayed red for over a month — long enough that it now reads as expected noise in any full-suite run.

## Why not just update the string

This is the second time the expression grew a fallback and this test broke for it. A guard that fails on every legitimate edit gets ignored, and an ignored guard is worse than no guard. So it now pins what the contract actually is:

- every required workflow cancels in-progress runs
- every group references `github.event.pull_request.number` — without it, runs for a PR never group and nothing cancels
- all ten agree on one identity expression, prefixed per workflow

The last one is the check that matters. A single file edited in isolation is exactly how this broke, and comparing suffixes catches that while leaving a deliberate change to all ten alone.

## Verification

Mutation-tested against the three failures it claims to catch:

| mutation | result |
|---|---|
| one workflow's identity expression drifts | 1 failed |
| a workflow stops keying on the PR | 2 failed |
| `cancel-in-progress` turned off | 1 failed |

Each reverts cleanly to 21 passed. `tests/Infrastructure`: 293 passed, 1 xfailed.

Also parametrized per workflow, so a failure names the file instead of stopping at the first one inside a loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the workflow concurrency contract test, which has been failing on `dev` since July because it asserted one exact expression string after the workflows legitimately changed.

- Now derives the PR-identity requirement per workflow from its own declared triggers: `pull_request` events must key on `github.event.pull_request.number` and `workflow_run` events on `github.event.workflow_run.pull_requests[0].number`, plus `cancel-in-progress` must be on.
- Also covers every other PR-carrying trigger (`pull_request_target`, `pull_request_review`, `pull_request_review_comment`) so a workflow adopting one can't pass with no PR identity in its group.
- All ten required workflows must agree on one identity expression, prefixed per workflow.
- Parametrized per workflow so a failure names the file instead of stopping at the first one in a loop.

<sup>Written for commit 5df83aefe3541171dd0935db9009d0d220f22baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

