### PR TITLE
fix(tests): stop app-main reloads outliving the test that made them (#2585)

### DIFF
--- a/tldw_Server_API/tests/Embeddings/conftest.py
+++ b/tldw_Server_API/tests/Embeddings/conftest.py
@@ -255,27 +255,24 @@ def regular_user():
 
 @pytest.fixture(autouse=True)
 def _reset_app_lifecycle_state():
-    """Clear stale drain state on THIS conftest's pinned ``app`` before each test.
+    """Clear stale lifecycle state on this conftest's pinned ``app``.
 
-    Why the root-conftest reset (tests/conftest.py,
-    _reset_main_app_lifecycle_state_between_tests) is not enough here,
-    verified empirically for issue #2581 (46F -> 0F with this fixture;
-    removing it reproduces the 46 failures):
+    Kept, but no longer for the reason it was written. It was added for #2581
+    (46F -> 0F) because ``reload_app_main()`` permanently swapped
+    ``sys.modules["tldw_Server_API.app.main"]``, so the root conftest's reset
+    landed on the new app while the drained original -- the one every pinned
+    test still routed through -- stayed drained and 503'd every request.
 
-    1. Test modules import ``app`` at collection time, pinning the ORIGINAL
-       app object (this conftest pins the same one at line 8).
-    2. ``test_backpressure_and_quotas.py`` calls ``reload_app_main()``, which
-       permanently replaces ``sys.modules['tldw_Server_API.app.main']`` with
-       a new module (new app object) and never restores the original.
-    3. A later ``with TestClient(app)`` lifespan exit marks the pinned
-       ORIGINAL app draining (mark_lifecycle_shutdown).
-    4. The root fixture re-imports ``app.main`` at reset time, so it resets
-       only the NEW app; the drained original — which every pinned test
-       still routes through — stays drained, and DrainGateMiddleware 503s
-       every request: {"status": "not_ready", "reason": "shutdown_in_progress"}.
+    Both halves of that are fixed now. The root reset covers every app that has
+    lifecycle state, not just the current module's, and reloads no longer outlive
+    the test that performed them (#2585). Removing this fixture leaves zero
+    ``shutdown_in_progress`` responses in a full Embeddings run.
 
-    This fixture resets the pinned original directly. The underlying
-    reload_app_main sys.modules leak is tracked in issue #2585.
+    It stays because removing it still perturbs four orchestrator-parity tests,
+    which fail with a provider-authentication error that has nothing to do with
+    lifecycle state and pass in isolation either way. That is an ordering
+    dependency somewhere else in this suite; until it is understood, dropping
+    this fixture would trade one known-good state for an unknown one.
     """
     from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
 

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
@@ -7,8 +7,7 @@ test fail (the "would have caught it" property).
 
 * #2580 — service/DB singleton caches registered against the wrong DB
 * #2581 — Embeddings drain singletons bleeding across suites
-* #2585 — reload_app_main() swapping the app-main module identity (STILL OPEN;
-          its meta-test is xfail-with-issue-link until the fix ships)
+* #2585 — reload_app_main() swapping the app-main module identity
 """
 from __future__ import annotations
 
@@ -87,34 +86,70 @@ async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
 
 
 # --------------------------------------------------------------------------- #
-# #2585 — reload_app_main() swaps sys.modules['...app.main'] identity (OPEN)
+# #2585 — reload_app_main() swaps sys.modules['...app.main'] identity
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(
-    reason="#2585 open: reload_app_main() swaps the app-main module identity and "
-    "there is no autouse restore, so references held before a reload go stale. "
-    "Flip to strict (remove xfail) when #2585 ships.",
-    strict=False,
-)
-def test_app_main_identity_is_stable_across_a_reload() -> None:
-    """DESIRED invariant (currently failing → xfail): a test that reloads the app
-    main module should not leave a different module identity behind for code that
-    imported it earlier. Uses ``import_app_main()`` (never None) and restores in
-    ``finally`` so the meta-test never pollutes the rest of the session.
+def test_a_reload_does_not_outlive_the_block_that_asked_for_it() -> None:
+    """A reload is legitimate; leaving it behind for everyone else is not.
+
+    The earlier version of this test asserted ``reloaded is original``, which a
+    working reload can never satisfy -- reloading is *supposed* to produce a new
+    module. The invariant that actually protects the session is that the swap is
+    undone afterwards, so no later code sees a module identity it did not ask
+    for.
     """
     from tldw_Server_API.tests.helpers.app_main_state import (
+        app_main_isolated,
         import_app_main,
         reload_app_main,
-        restore_app_main,
+        snapshot_app_main,
     )
 
     original = import_app_main()
     assert original is not None
-    try:
+
+    with app_main_isolated():
         reloaded = reload_app_main()
-        # The hazard: a fresh module object. Asserting identity documents the fix
-        # target; while #2585 is open this fails and is xfail'd.
-        assert reloaded is original, (
-            "reload_app_main swapped the app-main module identity (#2585)"
-        )
-    finally:
-        restore_app_main(original)
+        assert reloaded is not original, "reload_app_main() did not reload anything"
+        assert snapshot_app_main() is reloaded, "the reload was not published"
+
+    assert snapshot_app_main() is original, (
+        "a reload outlived its block, so every later import of app.main resolves "
+        "to a module the rest of the session never saw (#2585)"
+    )
+
+
+def test_every_test_is_wrapped_in_the_app_main_guard() -> None:
+    """The guard only helps if the root conftest actually applies it.
+
+    Checks for the ``app_main_isolated()`` call inside the autouse fixture rather
+    than the name anywhere in the file, so an orphaned import cannot satisfy it.
+    """
+    import ast
+
+    conftest = Path(__file__).resolve().parents[1] / "conftest.py"
+    tree = ast.parse(conftest.read_text(encoding="utf-8"))
+
+    fixture = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_keep_app_main_reloads_from_leaking"
+        ),
+        None,
+    )
+    assert fixture is not None, (
+        "tests/conftest.py no longer defines _keep_app_main_reloads_from_leaking(), "
+        "so a reload in one test again changes what app.main means for every test "
+        "after it (#2585)."
+    )
+
+    called = {
+        node.func.id
+        for node in ast.walk(fixture)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "app_main_isolated" in called, (
+        "the autouse fixture no longer calls app_main_isolated(), so reloads leak "
+        "again (#2585)."
+    )

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
@@ -118,38 +118,71 @@ def test_a_reload_does_not_outlive_the_block_that_asked_for_it() -> None:
     )
 
 
-def test_every_test_is_wrapped_in_the_app_main_guard() -> None:
-    """The guard only helps if the root conftest actually applies it.
+PROBE = """\
+from tldw_Server_API.tests.helpers.app_main_state import (
+    import_app_main,
+    reload_app_main,
+    snapshot_app_main,
+)
 
-    Checks for the ``app_main_isolated()`` call inside the autouse fixture rather
-    than the name anywhere in the file, so an orphaned import cannot satisfy it.
+PINNED = import_app_main()
+
+
+def test_one_reloads_app_main():
+    assert reload_app_main() is not PINNED, "reload_app_main() did not reload"
+
+
+def test_two_still_sees_the_module_it_pinned():
+    assert snapshot_app_main() is PINNED, (
+        "a reload in an earlier test leaked into this one (#2585)"
+    )
+"""
+
+
+def test_a_reload_in_one_test_does_not_leak_into_the_next() -> None:
+    """The suite-wide property, proved by running it.
+
+    Asserting that the conftest fixture calls a particular helper would pass a
+    rename and fail a harmless refactor, and would say nothing about whether the
+    fixture is autouse -- dropping that decorator disables isolation everywhere
+    while every structural check still passes.
+
+    So this runs two tests in a real pytest session instead. The probe module
+    lives under tests/ so the root conftest applies to it, and is named with a
+    leading underscore so the outer run does not collect it.
     """
-    import ast
+    import subprocess
+    import sys
 
-    conftest = Path(__file__).resolve().parents[1] / "conftest.py"
-    tree = ast.parse(conftest.read_text(encoding="utf-8"))
+    probe = Path(__file__).parent / "_app_main_leak_probe.py"
+    probe.write_text(PROBE, encoding="utf-8")
+    try:
+        result = subprocess.run(
+            # no:randomly is load-bearing: pytest-randomly shuffles collection,
+            # and this probe means nothing unless the reload runs before the
+            # test that checks for it.
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                str(probe),
+                "-q",
+                "-p",
+                "no:cacheprovider",
+                "-p",
+                "no:randomly",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parents[3],
+            timeout=600,
+        )
+    finally:
+        probe.unlink(missing_ok=True)
 
-    fixture = next(
-        (
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.FunctionDef)
-            and node.name == "_keep_app_main_reloads_from_leaking"
-        ),
-        None,
-    )
-    assert fixture is not None, (
-        "tests/conftest.py no longer defines _keep_app_main_reloads_from_leaking(), "
-        "so a reload in one test again changes what app.main means for every test "
-        "after it (#2585)."
-    )
-
-    called = {
-        node.func.id
-        for node in ast.walk(fixture)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
-    assert "app_main_isolated" in called, (
-        "the autouse fixture no longer calls app_main_isolated(), so reloads leak "
-        "again (#2585)."
+    assert result.returncode == 0, (
+        "a reload in one test leaked into the next, so app.main means different "
+        "things to different tests (#2585). Check that tests/conftest.py still "
+        "wraps every test in app_main_isolated() and that the fixture is "
+        f"autouse.\n\n{result.stdout[-3000:]}\n{result.stderr[-2000:]}"
     )

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
@@ -151,10 +151,14 @@ def test_a_reload_in_one_test_does_not_leak_into_the_next() -> None:
     lives under tests/ so the root conftest applies to it, and is named with a
     leading underscore so the outer run does not collect it.
     """
+    import os
     import subprocess
     import sys
 
-    probe = Path(__file__).parent / "_app_main_leak_probe.py"
+    # Unique per process: xdist workers running this same leaf test would
+    # otherwise write, spawn against, and unlink one shared pathname, and a hard
+    # kill leaves a stale file behind under a name the next run reuses.
+    probe = Path(__file__).parent / f"_app_main_leak_probe_{os.getpid()}.py"
     probe.write_text(PROBE, encoding="utf-8")
     try:
         result = subprocess.run(
@@ -175,7 +179,10 @@ def test_a_reload_in_one_test_does_not_leak_into_the_next() -> None:
             capture_output=True,
             text=True,
             cwd=Path(__file__).resolve().parents[3],
-            timeout=600,
+            # Under the global pytest-timeout budget (300s in pyproject), so
+            # this fires with a usable message instead of the outer test being
+            # killed first.
+            timeout=240,
         )
     finally:
         probe.unlink(missing_ok=True)

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -15,6 +15,7 @@ pytest_plugins = [
 
 from collections.abc import Callable
 import os
+from collections.abc import Iterator
 from pathlib import Path
 import sys
 try:
@@ -626,7 +627,7 @@ def pytest_collection_modifyitems(config, items):  # pragma: no cover - collecti
 
 
 @pytest.fixture(autouse=True)
-def _keep_app_main_reloads_from_leaking():
+def _keep_app_main_reloads_from_leaking() -> Iterator[None]:
     """Undo any ``reload_app_main()`` the test performed.
 
     The helper swaps ``sys.modules["tldw_Server_API.app.main"]`` for a freshly

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -626,6 +626,29 @@ def pytest_collection_modifyitems(config, items):  # pragma: no cover - collecti
 
 
 @pytest.fixture(autouse=True)
+def _keep_app_main_reloads_from_leaking():
+    """Undo any ``reload_app_main()`` the test performed.
+
+    The helper swaps ``sys.modules["tldw_Server_API.app.main"]`` for a freshly
+    imported module and never put the original back, so a single reload changed
+    what that name meant for every test after it. Modules that imported ``app``
+    at collection time kept the object they pinned, leaving the session with two
+    live apps and no way to tell which one a given piece of code was talking to.
+
+    That split is what made drain state leak: a lifespan exit drained a pinned
+    app while anything checking ``app.main`` saw the other one and reported
+    nothing wrong (#2585).
+
+    Tests that reload still get their reloaded app for the duration of the test.
+    They just do not hand it to everything downstream.
+    """
+    from tldw_Server_API.tests.helpers.app_main_state import app_main_isolated
+
+    with app_main_isolated():
+        yield
+
+
+@pytest.fixture(autouse=True)
 def _reset_main_app_lifecycle_state_between_tests():
     """Keep TestClient lifespan shutdown from leaking drain state across tests.
 

--- a/tldw_Server_API/tests/helpers/app_main_state.py
+++ b/tldw_Server_API/tests/helpers/app_main_state.py
@@ -96,6 +96,11 @@ def app_main_isolated() -> Iterator[None]:
     asked for it. Callers that want a reloaded app still get one; they just do
     not leave it behind. Restoring is skipped when nothing swapped, which is the
     overwhelmingly common case.
+
+    Yields:
+        None. The block runs with whatever module is current; on exit the module
+        that was current on entry is put back, or removed again if there was
+        none.
     """
     snapshot = snapshot_app_main()
     try:

--- a/tldw_Server_API/tests/helpers/app_main_state.py
+++ b/tldw_Server_API/tests/helpers/app_main_state.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import sys
+from collections.abc import Iterator
 from types import ModuleType
-
 
 APP_PACKAGE_NAME = "tldw_Server_API.app"
 APP_MAIN_MODULE_NAME = "tldw_Server_API.app.main"
@@ -73,3 +74,32 @@ def reload_app_main() -> ModuleType:
     importlib.invalidate_caches()
     imported = importlib.import_module(APP_MAIN_MODULE_NAME)
     return set_app_main(imported)
+
+
+@contextlib.contextmanager
+def app_main_isolated() -> Iterator[None]:
+    """Confine an app-main reload to this block.
+
+    :func:`reload_app_main` replaces ``sys.modules[APP_MAIN_MODULE_NAME]`` with a
+    new module object holding a new FastAPI app. Modules that already ran
+    ``from ...main import app`` keep the object they pinned at import time, so
+    leaving the swap in place hands the rest of the session a split view: the
+    name resolves to one app while earlier importers hold another.
+
+    That is not hypothetical. A ``TestClient`` lifespan exit drains whichever app
+    object it was given, which tends to be a pinned one, while anything looking
+    at ``app.main`` sees the new app and reports nothing wrong -- and
+    ``DrainGateMiddleware`` answers 503 to every request through the drained one
+    for the rest of the process (#2585).
+
+    Restoring the original module on exit keeps a reload local to the code that
+    asked for it. Callers that want a reloaded app still get one; they just do
+    not leave it behind. Restoring is skipped when nothing swapped, which is the
+    overwhelmingly common case.
+    """
+    snapshot = snapshot_app_main()
+    try:
+        yield
+    finally:
+        if snapshot_app_main() is not snapshot:
+            restore_app_main(snapshot)


### PR DESCRIPTION
Closes #2585.

`reload_app_main()` replaces `sys.modules["tldw_Server_API.app.main"]` with a freshly imported module holding a new FastAPI app, and never puts the original back — even though the helper has shipped `snapshot_app_main()` / `restore_app_main()` for exactly that. One reload changes what that name means for every test after it.

Modules that ran `from ...main import app` at collection time keep the object they pinned, so the session ends up with several live apps and no way to tell which one a given piece of code is talking to. That split is what let drain state hide: a `TestClient` lifespan exit drains a pinned app while anything checking `app.main` sees a different one and reports nothing wrong — and `DrainGateMiddleware` then 503s every request through the drained one.

## Approach

Ten call sites reload without restoring; six others already snapshot and restore by hand. That hand-rolled pattern is correct — it just wasn't enforced anywhere, so each new caller had to rediscover it.

Rather than migrate ten callers and rely on the eleventh remembering, an autouse fixture in the root conftest wraps every test in a new `app_main_isolated()` context manager. Tests that reload still get their reloaded app for the duration of the test; they just don't hand it to everything downstream. Restoring is skipped when nothing swapped, which is every test but a handful.

All ten leaking call sites are function-scoped (plain tests, function-scoped fixtures, or helpers called from tests), so per-test restoration doesn't cut anything short. Callers capture `.app` and use that object directly, so restoring `sys.modules` doesn't invalidate what they hold.

## The meta-test was vacuous

`test_app_main_identity_is_stable_across_a_reload` asserted `reloaded is original` — something a working reload can never satisfy, since reloading is *supposed* to produce a new module. It was `xfail`'d, so it never said anything either way.

It now asserts the invariant that actually protects the session: the swap does not survive the block. A second test checks via AST that the autouse fixture really *calls* `app_main_isolated()`, so an orphaned import can't satisfy it.

## Verification

| check | result |
|---|---|
| Embeddings with its local workaround removed — the issue's repro, which reported **46 failures** | **0** `shutdown_in_progress` responses |
| Admin + MediaDB2 + Watchlists + LLM_Adapters + Services + Notifications + Infrastructure | **65 failed on this branch, 65 on a clean `origin/dev` worktree** |
| Notifications directory alone | 362 passed on both |
| mutation: remove the `app_main_isolated()` call | guard fails |

The combined run differs by two-in/two-out between branches. All four are cross-suite ordering — each passes in isolation on both branches, and they're in the flaky families (reminders, scheduled-tasks control plane, drain gate) seen throughout this work. One of the two that *this branch fixes* is `test_drain_gate_middleware::test_drain_gate_allows_health_and_liveness_but_rejects_mutation`, which is the expected direction.

## The Embeddings workaround stays

Its stated rationale is now obsolete and the docstring says so. But removing it still perturbs four orchestrator-parity tests that fail on **provider authentication** — nothing to do with lifecycle state, and they pass in isolation either way. That's a separate ordering dependency in that suite; trading a known-good state for an unknown one isn't worth it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test isolation so `reload_app_main()` swaps are confined to the test that performed them instead of permanently changing what `app.main` resolves to for every later test. This prevents drain state from leaking across tests, which caused 503 `shutdown_in_progress` responses, and keeps pinned imports consistent.

**Bug Fixes**
- Adds an autouse fixture in `tests/conftest.py` that wraps each test in `app_main_isolated()`, restoring the original module on exit if a reload occurred; tests that reload still get their reloaded app for the duration.
- Replaces the vacuous xfail'd meta-test with one asserting the swap doesn't survive the block, plus a probe run in a real pytest session that fails if the fixture is dropped or loses its `autouse` flag; the probe pins collection order because `pytest-randomly` shuffles the suite.
- Keeps the Embeddings workaround fixture with an updated rationale: removing it still perturbs four ordering-dependent tests that fail on provider authentication.

<sup>Written for commit 4108cb46151560c8dc33eb41547d95f2caf62c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

