### PR TITLE
fix(tests): restore Embeddings_Create after the optional-deps import test

### DIFF
--- a/tldw_Server_API/tests/Embeddings/conftest.py
+++ b/tldw_Server_API/tests/Embeddings/conftest.py
@@ -268,11 +268,30 @@ def _reset_app_lifecycle_state():
     the test that performed them (#2585). Removing this fixture leaves zero
     ``shutdown_in_progress`` responses in a full Embeddings run.
 
-    It stays because removing it still perturbs four orchestrator-parity tests,
-    which fail with a provider-authentication error that has nothing to do with
-    lifecycle state and pass in isolation either way. That is an ordering
-    dependency somewhere else in this suite; until it is understood, dropping
-    this fixture would trade one known-good state for an unknown one.
+    What it masked has shrunk to one test. The four orchestrator-parity failures
+    it used to hide were a separate leak -- test_embeddings_optional_deps_import
+    re-imported Embeddings_Create with its optional dependencies blocked and left
+    the degraded module in sys.modules -- and that is fixed at the source now.
+
+    Removing this fixture still costs exactly one test:
+
+        test_orchestrator_summary_endpoint_unauthorized   401 != 403
+
+    which is not a lifecycle failure either. The log shows AuthNZ settings being
+    re-initialized mid-run in multi_user mode, so the request arrives
+    unauthenticated (401) instead of authenticated-but-forbidden (403) -- an
+    auth-settings ordering dependency, a third class again. Run the file alone
+    and it passes.
+
+    Measured on a full Embeddings run with collection order pinned
+    (-p no:randomly), so the numbers are comparable:
+
+        dev, before the optional-deps fix          7 failed
+        with the fix, this fixture kept            3 failed
+        with the fix, this fixture removed         4 failed
+
+    The remaining three are pre-existing metrics failures unrelated to any of
+    this. So the fixture stays until the auth-settings dependency is understood.
     """
     from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
 

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_optional_deps_import.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_optional_deps_import.py
@@ -4,58 +4,68 @@ import builtins
 import importlib
 import sys
 
+import pytest
+
 MODULE_NAME = "tldw_Server_API.app.core.Embeddings.Embeddings_Server.Embeddings_Create"
 PACKAGE_NAME = "tldw_Server_API.app.core.Embeddings.Embeddings_Server"
 
 
-def test_embeddings_create_imports_without_optional_deps(monkeypatch):
+@pytest.mark.unit
+def test_embeddings_create_imports_without_optional_deps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Importing with onnxruntime and huggingface_hub blocked must still work.
 
-    The re-import is undone afterwards. Importing the module with those
-    dependencies blocked produces a *degraded* module object, and leaving it
-    behind hands that object to everything downstream: code that imported the
-    module earlier keeps the working one, code importing later gets the
-    degraded one, and the two disagree about what the module's functions are.
+    The re-import is undone before the test ends, and the assertions after the
+    scope prove it. Importing the module with those dependencies blocked
+    produces a *degraded* module object, and leaving it behind hands that object
+    to everything downstream: code that imported the module earlier keeps the
+    working one, code importing later gets the degraded one, and the two
+    disagree about what the module's functions are.
 
     Leaving it behind cost four unrelated orchestrator-parity tests, which
     failed with "Embedding provider authentication failed" -- a symptom with no
-    visible connection to optional imports. Both bindings are restored, because
-    importlib rebinds ``sys.modules`` *and* the attribute on the parent package.
+    visible connection to optional imports.
+
+    Both bindings are restored, because importlib rebinds ``sys.modules`` *and*
+    the attribute on the parent package, and both are asserted against the saved
+    original rather than merely against each other.
+
+    Returns:
+        None.
     """
     original = importlib.import_module(MODULE_NAME)
     package = importlib.import_module(PACKAGE_NAME)
 
-    # Recorded before the re-import so teardown puts the working module back.
-    monkeypatch.setitem(sys.modules, MODULE_NAME, original)
-    monkeypatch.setattr(package, "Embeddings_Create", original, raising=False)
-
     real_import = builtins.__import__
 
     def guarded_import(name, *args, **kwargs):
+        """Stand in for __import__, refusing the two optional dependencies."""
         if name.startswith(("onnxruntime", "huggingface_hub")):
             raise ImportError("blocked for test")
         return real_import(name, *args, **kwargs)
 
-    # Force a clean import so the module-level optional-dependency handling runs
-    # again under the block, rather than being served from the import cache.
-    sys.modules.pop(MODULE_NAME, None)
-    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    with monkeypatch.context() as blocked:
+        # Recorded before the re-import, so leaving this scope puts the working
+        # module back on both bindings.
+        blocked.setitem(sys.modules, MODULE_NAME, original)
+        blocked.setattr(package, "Embeddings_Create", original, raising=False)
+        blocked.setattr(builtins, "__import__", guarded_import)
 
-    module = importlib.import_module(MODULE_NAME)
+        # Force a clean import so the module-level optional-dependency handling
+        # runs again under the block instead of being served from the cache.
+        sys.modules.pop(MODULE_NAME, None)
+        module = importlib.import_module(MODULE_NAME)
 
-    assert module is not original, "the module was served from cache, not re-imported"
-    # Revision checks have to stay safe when huggingface_hub is unavailable.
-    module._ensure_hf_revision("dummy/model", "deadbeef")
+        assert module is not original, "served from cache, so nothing was re-imported"
+        # Revision checks have to stay safe when huggingface_hub is unavailable.
+        module._ensure_hf_revision("dummy/model", "deadbeef")
 
-
-def test_the_degraded_import_does_not_outlive_this_module(monkeypatch):
-    """Guard the restore above, which is the part that is easy to drop.
-
-    Runs after it in file order, and would fail if the re-import leaked.
-    """
-    assert sys.modules[MODULE_NAME] is importlib.import_module(MODULE_NAME)
-    package = importlib.import_module(PACKAGE_NAME)
-    assert package.Embeddings_Create is sys.modules[MODULE_NAME], (
-        "the parent package still points at a different module object than "
-        "sys.modules does; a re-import was not fully undone"
+    assert sys.modules[MODULE_NAME] is original, (
+        "the degraded module outlived this test, so every later import of "
+        "Embeddings_Create resolves to it"
+    )
+    assert package.Embeddings_Create is original, (
+        "the parent package still points at the degraded module; restoring "
+        "sys.modules alone is not enough, importlib rebinds both"
     )

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_optional_deps_import.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_optional_deps_import.py
@@ -1,25 +1,61 @@
+"""Embeddings_Create must import when its optional dependencies are absent."""
+
 import builtins
 import importlib
 import sys
 
+MODULE_NAME = "tldw_Server_API.app.core.Embeddings.Embeddings_Server.Embeddings_Create"
+PACKAGE_NAME = "tldw_Server_API.app.core.Embeddings.Embeddings_Server"
+
 
 def test_embeddings_create_imports_without_optional_deps(monkeypatch):
-    module_name = "tldw_Server_API.app.core.Embeddings.Embeddings_Server.Embeddings_Create"
+    """Importing with onnxruntime and huggingface_hub blocked must still work.
 
-    # Force a clean import
-    sys.modules.pop(module_name, None)
+    The re-import is undone afterwards. Importing the module with those
+    dependencies blocked produces a *degraded* module object, and leaving it
+    behind hands that object to everything downstream: code that imported the
+    module earlier keeps the working one, code importing later gets the
+    degraded one, and the two disagree about what the module's functions are.
+
+    Leaving it behind cost four unrelated orchestrator-parity tests, which
+    failed with "Embedding provider authentication failed" -- a symptom with no
+    visible connection to optional imports. Both bindings are restored, because
+    importlib rebinds ``sys.modules`` *and* the attribute on the parent package.
+    """
+    original = importlib.import_module(MODULE_NAME)
+    package = importlib.import_module(PACKAGE_NAME)
+
+    # Recorded before the re-import so teardown puts the working module back.
+    monkeypatch.setitem(sys.modules, MODULE_NAME, original)
+    monkeypatch.setattr(package, "Embeddings_Create", original, raising=False)
 
     real_import = builtins.__import__
 
     def guarded_import(name, *args, **kwargs):
-        if name.startswith("onnxruntime") or name.startswith("huggingface_hub"):
+        if name.startswith(("onnxruntime", "huggingface_hub")):
             raise ImportError("blocked for test")
         return real_import(name, *args, **kwargs)
 
+    # Force a clean import so the module-level optional-dependency handling runs
+    # again under the block, rather than being served from the import cache.
+    sys.modules.pop(MODULE_NAME, None)
     monkeypatch.setattr(builtins, "__import__", guarded_import)
 
-    mod = importlib.import_module(module_name)
-    assert mod is not None
+    module = importlib.import_module(MODULE_NAME)
 
-    # Ensure revision checks are safe when huggingface_hub is unavailable
-    mod._ensure_hf_revision("dummy/model", "deadbeef")
+    assert module is not original, "the module was served from cache, not re-imported"
+    # Revision checks have to stay safe when huggingface_hub is unavailable.
+    module._ensure_hf_revision("dummy/model", "deadbeef")
+
+
+def test_the_degraded_import_does_not_outlive_this_module(monkeypatch):
+    """Guard the restore above, which is the part that is easy to drop.
+
+    Runs after it in file order, and would fail if the re-import leaked.
+    """
+    assert sys.modules[MODULE_NAME] is importlib.import_module(MODULE_NAME)
+    package = importlib.import_module(PACKAGE_NAME)
+    assert package.Embeddings_Create is sys.modules[MODULE_NAME], (
+        "the parent package still points at a different module object than "
+        "sys.modules does; a re-import was not fully undone"
+    )


### PR DESCRIPTION
`test_embeddings_optional_deps_import` pops `Embeddings_Create` out of `sys.modules`, re-imports it with `onnxruntime` and `huggingface_hub` blocked, and leaves the result behind. That import produces a **degraded** module object, and `importlib` rebinds both `sys.modules` *and* the attribute on the parent package — so everything downstream gets the degraded module while code that imported earlier keeps the working one.

The cost was four orchestrator-parity tests failing with:

```
_EmbeddingProviderAuthenticationHTTPException: 502: Embedding provider authentication failed
```

which has no visible connection to optional imports, in a file that passes on its own. Found by bisecting the 41 files that precede it.

## Fix

Both bindings are recorded with `monkeypatch` before the re-import, so teardown puts the working module back. A second test in the same file asserts the restore held — that's the part that's easy to drop later.

## Numbers

Measured on full Embeddings runs with collection order pinned (`-p no:randomly`), which matters here: `pytest-randomly` is installed, and under a random order this suite reported 3 failures on dev while deterministically it reports 7. **Comparing runs of this suite without pinning the order says nothing.**

| | failures |
|---|---|
| dev | **7** |
| this PR | **3** |

The remaining three are pre-existing metrics failures, unrelated to any of this.

## The lifecycle-reset fixture stays

`tests/Embeddings/conftest.py::_reset_app_lifecycle_state` was previously documented as masking "four orchestrator-parity tests". That was this leak, and it's fixed at the source now. What the fixture still masks is one test:

```
test_orchestrator_summary_endpoint_unauthorized   401 != 403
```

Not lifecycle either — the log shows AuthNZ settings being re-initialized mid-run in `multi_user` mode, so the request arrives unauthenticated (401) rather than authenticated-but-forbidden (403). That's an auth-settings ordering dependency, a third distinct class, and chasing it doesn't belong in this PR. Its docstring now records the finding and the measured numbers so the next person starts from a lead rather than "unknown".

| configuration | failures |
|---|---|
| dev, before this fix | 7 |
| with fix, fixture kept | **3** ← this PR |
| with fix, fixture removed | 4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the working `Embeddings_Create` module after the optional-dependency import test replaces it with a degraded one. The leak caused four orchestrator-parity tests to fail with misleading authentication errors; the test now restores both module bindings before it ends.

**Test isolation**

- Scopes the blocked import with `monkeypatch.context()` and verifies both bindings match the saved original, so the check does not depend on test order.
- Keeps the lifecycle-reset fixture and documents the remaining auth-settings ordering dependency; pinned full Embeddings runs now report three pre-existing metrics failures instead of seven.

<sup>Written for commit a7a3e9a9d461d311f36b1d95eed529104c88ab00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

