### PR TITLE
ci: measure the global coverage floor against application code only

### DIFF
--- a/.github/workflows/coverage-required.yml
+++ b/.github/workflows/coverage-required.yml
@@ -124,6 +124,25 @@ jobs:
             uv.lock
           extras: dev,multiplayer
 
+      # Scope note, measured 2026-09-01 on this exact selection:
+      #
+      #   total reported                        13.1%  (floor is 12%)
+      #   of the denominator, tldw_Server_API/tests/   26%
+      #   of the covered app lines, executed only
+      #     because app.main gets imported             72%
+      #
+      # The denominator no longer includes the test suite itself -- 229k
+      # statements this selection was never going to cover, which only made the
+      # percentage harder to reason about. Scoping to app/ moves the reported
+      # number to ~16.9% against the same floor.
+      #
+      # What remains is worth knowing before trusting this number: most of it is
+      # import-time execution, so it detects "the app stopped importing" far more
+      # reliably than it detects a drop in tested behaviour. Read a green result
+      # as that, not as "17% of the app is tested" -- the tests here exercise
+      # about 4.8%. Raising the floor toward the reported number would also
+      # penalise making imports lazy, which is a thing we deliberately do for
+      # startup time.
       - name: Run global coverage floor
         if: needs.changes.outputs.coverage_required == 'true'
         env:
@@ -135,7 +154,7 @@ jobs:
           pytest -q --disable-warnings -p pytest_cov -p pytest_asyncio.plugin \
             -m "not jobs and not e2e" \
             tldw_Server_API/tests/unit tldw_Server_API/tests/sanity_tests \
-            --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=12
+            --cov=tldw_Server_API/app --cov-report=xml --cov-report=term-missing --cov-fail-under=12
 
       - name: AuthNZ coverage floor
         if: needs.changes.outputs.coverage_required == 'true'

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -172,20 +172,30 @@ def test_global_coverage_floor_measures_only_application_code() -> None:
     ``--cov=tldw_Server_API`` also measured ``tldw_Server_API/tests`` -- 229k
     statements this selection never covers -- which quietly diluted the number.
     Widening the scope back would move the percentage without anything about the
-    code changing.
+    code changing, so the whole target set is checked rather than merely the
+    presence of the app target: adding a second ``--cov`` would dilute it just
+    as effectively.
+
+    Returns:
+        None.
     """
     workflow = _load(".github/workflows/coverage-required.yml")
     steps = workflow["jobs"]["coverage-required"]["steps"]
     run = _get_step(steps, "Run global coverage floor")["run"]
 
-    assert "--cov=tldw_Server_API/app" in run, (
-        "the global coverage floor no longer measures application code only. "
-        "Scoping it wider pulls the test suite into the denominator, which "
-        "changes the reported percentage without any change in what is tested."
+    tokens = run.split()
+    targets = {
+        token.split("=", 1)[1] if "=" in token else tokens[index + 1]
+        for index, token in enumerate(tokens)
+        if token == "--cov" or token.startswith("--cov=")
+    }
+
+    assert targets == {"tldw_Server_API/app"}, (
+        f"the global coverage floor measures {sorted(targets)}, not application "
+        "code alone. Any extra target pulls more statements into the "
+        "denominator, which moves the reported percentage without any change in "
+        "what is actually tested."
     )
-    assert "--cov=tldw_Server_API " not in run and not run.rstrip().endswith(
-        "--cov=tldw_Server_API"
-    ), "the unscoped --cov=tldw_Server_API target is back"
 
 
 def test_coverage_required_enforces_authnz_coverage_floor() -> None:

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -166,6 +166,28 @@ def test_coverage_required_uses_documented_global_floor() -> None:
     assert "--cov-fail-under=12" in coverage_step["run"]
 
 
+def test_global_coverage_floor_measures_only_application_code() -> None:
+    """The floor is a percentage, so what is in the denominator decides it.
+
+    ``--cov=tldw_Server_API`` also measured ``tldw_Server_API/tests`` -- 229k
+    statements this selection never covers -- which quietly diluted the number.
+    Widening the scope back would move the percentage without anything about the
+    code changing.
+    """
+    workflow = _load(".github/workflows/coverage-required.yml")
+    steps = workflow["jobs"]["coverage-required"]["steps"]
+    run = _get_step(steps, "Run global coverage floor")["run"]
+
+    assert "--cov=tldw_Server_API/app" in run, (
+        "the global coverage floor no longer measures application code only. "
+        "Scoping it wider pulls the test suite into the denominator, which "
+        "changes the reported percentage without any change in what is tested."
+    )
+    assert "--cov=tldw_Server_API " not in run and not run.rstrip().endswith(
+        "--cov=tldw_Server_API"
+    ), "the unscoped --cov=tldw_Server_API target is back"
+
+
 def test_coverage_required_enforces_authnz_coverage_floor() -> None:
     workflow = _load(".github/workflows/coverage-required.yml")
     steps = workflow["jobs"]["coverage-required"]["steps"]


### PR DESCRIPTION
Follow-up to #2847, which surfaced that the 12% global coverage floor was being met largely by accident. This fixes the half that is unambiguously wrong and documents the half that is a judgement call.

## The denominator included the test suite

`--cov=tldw_Server_API` also measured `tldw_Server_API/tests` — **229,278 statements, 26% of the total** — that this selection (`tests/unit` + `tests/sanity_tests`, 463 tests) was never going to cover. That dilutes the percentage for no benefit.

| | before | after |
|---|---|---|
| denominator | 895,534 statements | **663,824** |
| reported | 13.1% | **16.9%** |
| floor | 12% | 12% (unchanged) |

Nothing about the code or the tests changed. Verified by running the gate's exact command locally: `Required test coverage of 12% reached. Total coverage: 16.88%`.

## What scoping does not fix, and why the comment matters

Of the 112,031 covered app lines, **80,504 (72%) execute only because `app.main` gets imported**. The tests here exercise about **4.8%**.

That changes how a green result should be read: it means "the app still imports" far more reliably than "behaviour is still tested". The step now carries a comment saying so with the numbers, so nobody reads a green 17% as "17% of the app is tested".

I deliberately did **not** raise the floor toward the reported number. Doing so would make the gate bind on import-time execution, which means any change that makes an import lazy — something done deliberately for startup time, including in #2834 and #2847 — would trip it. That is the wrong incentive to encode in a required check.

## Guard

A contract test pins the scope, since widening it back would move the percentage with no change in what is tested. Mutation-tested: restoring `--cov=tldw_Server_API` fails it (1 failed / 42 passed).

`tests/CI/test_required_workflow_contracts.py`: 43 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The global coverage floor now measures `tldw_Server_API/app` instead of the entire `tldw_Server_API` package, excluding the test suite from the denominator so the 12% gate reflects application code only.

- Removing 229k test statements raises reported coverage from 13.1% to 16.9% against the unchanged 12% floor.
- The workflow comment explains that import-time execution dominates the result, so a green check is stronger evidence that the app imports than that behavior is tested; the floor remains unchanged to avoid penalizing lazy imports.
- A contract test requires the complete coverage target set to be exactly `tldw_Server_API/app`, preventing extra targets from diluting the percentage.

<sup>Written for commit e933ae2ac13e8337ed654c2e81908b2525489183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

