### PR TITLE
fix(db): index schema_once verify rows by column name, not position

### DIFF
--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -762,7 +762,10 @@ class CollectionsDatabase:
             "(?, ?, ?, ?, ?)",
             _COLLECTIONS_REQUIRED_TABLES,
         )
-        found = {row[0] for row in rows}
+        # QueryResult yields dict rows, so the column has to be named:
+        # row[0] raises KeyError, which ensure_once() swallows as "absent"
+        # and then replays the whole schema on every single call.
+        found = {row["name"] for row in rows}
         return found.issuperset(_COLLECTIONS_REQUIRED_TABLES)
 
     def _run_backend_bootstrap(self) -> None:

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -567,7 +567,10 @@ class WatchlistsDatabase:
             "(?, ?, ?, ?, ?, ?)",
             _WATCHLISTS_REQUIRED_TABLES,
         )
-        found = {row[0] for row in rows}
+        # QueryResult yields dict rows, so the column has to be named:
+        # row[0] raises KeyError, which ensure_once() swallows as "absent"
+        # and then replays the whole schema on every single call.
+        found = {row["name"] for row in rows}
         return found.issuperset(_WATCHLISTS_REQUIRED_TABLES)
 
     def _ensure_schema_deduplicated(self) -> None:

--- a/tldw_Server_API/app/core/DB_Management/schema_once.py
+++ b/tldw_Server_API/app/core/DB_Management/schema_once.py
@@ -129,7 +129,11 @@ def ensure_once(
             different tables, so one caller's setup cannot satisfy another's.
         path: Filesystem path or SQLite URI of the database. When it cannot be
             resolved to a real file the call falls through to ``ensure`` every
-            time, which is the safe direction.
+            time, which is the safe direction. Note that a database which does
+            not exist yet cannot be identified, and it is usually ``ensure``
+            itself that creates the file -- so for a brand new database the
+            first call does not memoize, the second does, and verification
+            starts on the third.
         ensure: The idempotent schema routine to run. It must set up schema
             only; see the module docstring.
         verify: Cheap check that the schema really is present, run on every

--- a/tldw_Server_API/tests/DB_Management/test_schema_once_callers.py
+++ b/tldw_Server_API/tests/DB_Management/test_schema_once_callers.py
@@ -1,0 +1,91 @@
+"""Every schema_once caller's verify callback must actually work.
+
+``ensure_once`` treats a verify callback that raises as "schema absent" and
+replays the setup. That is the safe direction, but it means a broken callback is
+invisible: nothing fails, the memo simply never holds and the optimisation
+quietly does nothing while the log fills with warnings.
+
+Two of the four callbacks shipped broken for exactly this reason. They read
+``row[0]``, but ``DatabaseBackend.execute()`` returns a ``QueryResult`` whose
+rows are dicts, so every call raised ``KeyError: 0``:
+
+    schema_once: verification failed for .../Media_DB_v2.db (0); re-running
+    schema setup
+
+These tests call each callback against a real database and require True, which
+is the one thing the failing-open design cannot tell us on its own.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.RPG_DB import RPGRepository
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
+
+
+@pytest.fixture()
+def _user_db_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point per-user database resolution at a scratch directory."""
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_collections_verify_reports_its_own_schema_as_present(_user_db_dir: Path) -> None:
+    """Construction sets the schema up, so the check must then agree."""
+    db = CollectionsDatabase.for_user(user_id=1)
+
+    assert db._collections_schema_present() is True
+
+
+@pytest.mark.unit
+def test_watchlists_verify_reports_its_own_schema_as_present(_user_db_dir: Path) -> None:
+    db = WatchlistsDatabase.for_user(user_id=1)
+
+    assert db._watchlists_schema_present() is True
+
+
+@pytest.mark.unit
+def test_scheduled_tasks_verify_reports_its_own_schema_as_present(
+    _user_db_dir: Path,
+) -> None:
+    db = ScheduledTasksDatabase.for_user(user_id=1)
+    db.ensure_schema()
+
+    assert db.schema_present() is True
+
+
+@pytest.mark.unit
+def test_rpg_verify_reports_its_own_schema_as_present() -> None:
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+    repo = RPGRepository.initialized(CharactersRAGDB(":memory:", "schema-once-test"))
+
+    assert repo._schema_present() is True
+
+
+@pytest.mark.unit
+def test_a_broken_verify_would_be_caught_here(_user_db_dir: Path) -> None:
+    """Pin the failure mode these tests exist for.
+
+    ``row[0]`` against a dict row is what shipped, and ensure_once swallowed it.
+    """
+    db = CollectionsDatabase.for_user(user_id=1)
+    rows = db._backend.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' LIMIT 1"
+    )
+    row = next(iter(rows))
+
+    assert isinstance(row, dict), (
+        "backend rows are no longer dicts; the verify callbacks index them by "
+        "column name and need revisiting"
+    )
+    with pytest.raises(KeyError):
+        row[0]

--- a/tldw_Server_API/tests/DB_Management/test_schema_once_callers.py
+++ b/tldw_Server_API/tests/DB_Management/test_schema_once_callers.py
@@ -1,27 +1,32 @@
-"""Every schema_once caller's verify callback must actually work.
+"""Every schema_once caller's verification must actually work.
 
 ``ensure_once`` treats a verify callback that raises as "schema absent" and
 replays the setup. That is the safe direction, but it means a broken callback is
-invisible: nothing fails, the memo simply never holds and the optimisation
+invisible: nothing fails, the memo simply never holds and the de-duplication
 quietly does nothing while the log fills with warnings.
 
 Two of the four callbacks shipped broken for exactly this reason. They read
 ``row[0]``, but ``DatabaseBackend.execute()`` returns a ``QueryResult`` whose
-rows are dicts, so every call raised ``KeyError: 0``:
+rows are dicts, so every call raised ``KeyError: 0``::
 
     schema_once: verification failed for .../Media_DB_v2.db (0); re-running
     schema setup
 
-These tests call each callback against a real database and require True, which
-is the one thing the failing-open design cannot tell us on its own.
+These tests drive each repository the way production does and assert that
+warning never appears -- the observable symptom, rather than the callbacks'
+return values, so a refactor that keeps the behaviour keeps the tests.
 """
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.RPG_DB import RPGRepository
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
@@ -29,63 +34,104 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
 )
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 
+VERIFICATION_FAILED = "schema_once: verification failed"
+
+
+@contextlib.contextmanager
+def _warnings() -> Iterator[list[str]]:
+    """Collect WARNING-level loguru messages emitted inside the block.
+
+    Yields:
+        The list of messages, filled as they are emitted.
+    """
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, format="{message}", level="WARNING")
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
 
 @pytest.fixture()
-def _user_db_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point per-user database resolution at a scratch directory."""
+def _sqlite_user_databases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Resolve per-user databases to SQLite files under a scratch directory.
+
+    The callbacks under test query ``sqlite_master``, so these repositories have
+    to be on SQLite; an ambient PostgreSQL content backend would send that query
+    to an engine that has no such table.
+
+    Returns:
+        The scratch directory holding the per-user databases.
+    """
     monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    monkeypatch.delenv("TLDW_CONTENT_DB_BACKEND", raising=False)
     return tmp_path
 
 
-@pytest.mark.unit
-def test_collections_verify_reports_its_own_schema_as_present(_user_db_dir: Path) -> None:
-    """Construction sets the schema up, so the check must then agree."""
-    db = CollectionsDatabase.for_user(user_id=1)
+# Three, not two. The first call for a database that does not exist yet cannot
+# stat it, so ``ensure_once`` declines to memoize and runs the setup directly --
+# the file only appears as a side effect of that first call. The second call
+# memoizes. Verification therefore first runs on the third, and a driver that
+# stops at two proves nothing.
+_ROUNDS = 3
 
-    assert db._collections_schema_present() is True
+
+def _collections(tmp_path: Path) -> None:
+    """Construct the repository the way a request does, repeatedly."""
+    for _ in range(_ROUNDS):
+        CollectionsDatabase.for_user(user_id=1)
 
 
-@pytest.mark.unit
-def test_watchlists_verify_reports_its_own_schema_as_present(_user_db_dir: Path) -> None:
+def _watchlists(tmp_path: Path) -> None:
+    """Ensure the schema through the entry point the FastAPI dependency uses."""
     db = WatchlistsDatabase.for_user(user_id=1)
+    for _ in range(_ROUNDS):
+        db.ensure_schema_once()
 
-    assert db._watchlists_schema_present() is True
 
-
-@pytest.mark.unit
-def test_scheduled_tasks_verify_reports_its_own_schema_as_present(
-    _user_db_dir: Path,
-) -> None:
+def _scheduled_tasks(tmp_path: Path) -> None:
+    """Set the schema up, then check it the way the control-plane service does."""
     db = ScheduledTasksDatabase.for_user(user_id=1)
     db.ensure_schema()
-
     assert db.schema_present() is True
 
 
-@pytest.mark.unit
-def test_rpg_verify_reports_its_own_schema_as_present() -> None:
-    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+def _rpg(tmp_path: Path) -> None:
+    """Build the repository repeatedly against one file-backed database.
 
-    repo = RPGRepository.initialized(CharactersRAGDB(":memory:", "schema-once-test"))
-
-    assert repo._schema_present() is True
-
-
-@pytest.mark.unit
-def test_a_broken_verify_would_be_caught_here(_user_db_dir: Path) -> None:
-    """Pin the failure mode these tests exist for.
-
-    ``row[0]`` against a dict row is what shipped, and ensure_once swallowed it.
+    A file is required: ``ensure_once`` never memoizes an in-memory database, so
+    an in-memory one would skip verification entirely and prove nothing.
     """
-    db = CollectionsDatabase.for_user(user_id=1)
-    rows = db._backend.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' LIMIT 1"
-    )
-    row = next(iter(rows))
+    db = CharactersRAGDB(str(tmp_path / "rpg.db"), "schema-once-test")
+    for _ in range(_ROUNDS):
+        RPGRepository.initialized(db)
 
-    assert isinstance(row, dict), (
-        "backend rows are no longer dicts; the verify callbacks index them by "
-        "column name and need revisiting"
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "scope",
+    ["collections", "watchlists", "scheduled_tasks", "rpg"],
+)
+def test_repeated_setup_never_reports_a_failed_verification(
+    scope: str, tmp_path: Path, _sqlite_user_databases: Path
+) -> None:
+    """A warning here means the memo is not holding and the DDL is replaying.
+
+    Returns:
+        None.
+    """
+    drivers: dict[str, Callable[[Path], None]] = {
+        "collections": _collections,
+        "watchlists": _watchlists,
+        "scheduled_tasks": _scheduled_tasks,
+        "rpg": _rpg,
+    }
+
+    with _warnings() as messages:
+        drivers[scope](tmp_path)
+
+    failed = [message for message in messages if VERIFICATION_FAILED in message]
+    assert not failed, (
+        f"{scope} could not verify its own schema, so ensure_once falls back to "
+        f"replaying the full setup on every call:\n  " + "\n  ".join(failed)
     )
-    with pytest.raises(KeyError):
-        row[0]


### PR DESCRIPTION
A defect in already-merged code (#2847), found because the `e2e-smoke (macos)` job on #2852 was full of this:

```
schema_once: verification failed for .../Media_DB_v2.db (0); re-running schema setup
```

repeating for the entire run.

## What is wrong

The Collections and Watchlists verify callbacks read `row[0]`, but `DatabaseBackend.execute()` returns a `QueryResult` whose rows are **dicts** (`result_rows = [dict(row) for row in rows]`). So every call raised `KeyError: 0` — and `str(KeyError(0))` is `'0'`, which is the `(0)` in the log.

`ensure_once` treats a raising callback as "schema absent", so the memo never held. Each call re-ran the full schema setup **and** paid an extra catalogue query on top. The optimisation those callbacks exist for — 61 DDL statements per request on watchlists, 85 on collections — was doing nothing on dev for those two repositories.

RPG and scheduled-tasks were unaffected: they read raw `sqlite3` rows, which do support positional access.

## I introduced this while fixing review feedback

The original version used `bool(list(rows))` and worked. `96fc20822c` — the commit addressing cubic's finding that verify checked only one table — rewrote it to build a set of names, which introduced the positional index. Dropping the local `try/except` in the same change (to satisfy `BLE001`) moved the failure from *silent* to *logged*, which is the only reason it was noticeable.

So the review feedback was right, my fix for it was wrong, and the linter fix is what made it visible.

## Why no test caught it

The callback **fails open by design** — a broken one degrades to "re-run the setup", which is correct behaviour, just slow. Nothing fails. That is the right safety direction and it is also why this was invisible.

The new tests call each of the four callbacks against a real database and require `True`, which is the one thing failing open cannot tell us. Plus one test pinning the failure mode itself: backend rows are dicts, and `row[0]` on them raises.

Mutation-tested: restoring `row[0]` fails 2 of the 5.

## Verification

Collections + Watchlists + DB_Management: **2339 passed**, 5 failed and 1 error — all six reproduce on a clean `origin/dev` worktree. **Zero** `schema_once` warnings, down from continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `schema_once` verification for Collections and Watchlists by reading the `name` column from dict rows instead of using positional access. This removes the verification warnings and prevents the full schema setup from running on every request.

- Regression tests exercise all four repository setup paths through their production entry points.
- Tests use file-backed SQLite databases and three setup rounds to cover verification after first-time database creation.
- Documents why a new database is not memoized until its second setup call.

<sup>Written for commit 8c55ff82924a800d92302e11d6f8c3b3abcc4ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

