### PR TITLE
test(embeddings): drop the lifecycle-reset fixture, which no longer does anything

### DIFF
--- a/tldw_Server_API/tests/Embeddings/conftest.py
+++ b/tldw_Server_API/tests/Embeddings/conftest.py
@@ -254,52 +254,6 @@ def regular_user():
 
 
 @pytest.fixture(autouse=True)
-def _reset_app_lifecycle_state():
-    """Clear stale lifecycle state on this conftest's pinned ``app``.
-
-    Kept, but no longer for the reason it was written. It was added for #2581
-    (46F -> 0F) because ``reload_app_main()`` permanently swapped
-    ``sys.modules["tldw_Server_API.app.main"]``, so the root conftest's reset
-    landed on the new app while the drained original -- the one every pinned
-    test still routed through -- stayed drained and 503'd every request.
-
-    Both halves of that are fixed now. The root reset covers every app that has
-    lifecycle state, not just the current module's, and reloads no longer outlive
-    the test that performed them (#2585). Removing this fixture leaves zero
-    ``shutdown_in_progress`` responses in a full Embeddings run.
-
-    What it masked has shrunk to one test. The four orchestrator-parity failures
-    it used to hide were a separate leak -- test_embeddings_optional_deps_import
-    re-imported Embeddings_Create with its optional dependencies blocked and left
-    the degraded module in sys.modules -- and that is fixed at the source now.
-
-    Removing this fixture still costs exactly one test:
-
-        test_orchestrator_summary_endpoint_unauthorized   401 != 403
-
-    which is not a lifecycle failure either. The log shows AuthNZ settings being
-    re-initialized mid-run in multi_user mode, so the request arrives
-    unauthenticated (401) instead of authenticated-but-forbidden (403) -- an
-    auth-settings ordering dependency, a third class again. Run the file alone
-    and it passes.
-
-    Measured on a full Embeddings run with collection order pinned
-    (-p no:randomly), so the numbers are comparable:
-
-        dev, before the optional-deps fix          7 failed
-        with the fix, this fixture kept            3 failed
-        with the fix, this fixture removed         4 failed
-
-    The remaining three are pre-existing metrics failures unrelated to any of
-    this. So the fixture stays until the auth-settings dependency is understood.
-    """
-    from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
-
-    reset_lifecycle_state(app)
-    yield
-
-
-@pytest.fixture(autouse=True)
 def _sanitize_jsonschema_module(monkeypatch):
     """Ensure sys.modules['jsonschema'] is a proper ModuleType when present.
 


### PR DESCRIPTION
Closes out the loose end left by #2852. The short version: the fixture is inert, and my reason for keeping it was based on too few runs.

## Why it existed, and why that is gone

Added for #2581, when `reload_app_main()` left a drained app behind and the root conftest reset the wrong object. Both halves are fixed — the root reset now covers every app with lifecycle state (#2847), and reloads no longer outlive their test (#2585 / #2850). The four orchestrator-parity failures it appeared to still mask were a different leak entirely, fixed at source in #2852.

## Why I kept it anyway, and why that was wrong

I ran the suite once with the fixture and once without, saw one extra failure without it, and concluded it was still load-bearing. One run per side is not enough in a suite this noisy. Three runs each way, collection order pinned:

| | failures |
|---|---|
| with the fixture | 3, **4**, 3 |
| without it | **4**, 3, 3 |

Same distribution. Both sides show the same three pre-existing metrics failures plus an occasional fourth — and the fourth is a **different test each time**:

- `test_stage_pause_resume_drain` — with the fixture
- `test_openai_oauth_401_retries_with_forced_refresh` — without it
- `test_stage_flag_metric_after_pause`, `test_orchestrator_summary_endpoint_unauthorized` — earlier runs

So the extra failure is a flake at roughly one run in three, not something the fixture prevents. I also bisected all 71 files preceding the supposed victim and found no ordering cause, which is what prompted repeating the runs.

## The flake is real and stays open

The tests that catch it are auth-shaped — a 401 where the request should be authenticated — or stage-control timing. That wants its own investigation. Keeping an inert fixture in place does not help with it, and its docstring claiming to guard against lifecycle leakage is now actively misleading.

`tests/Embeddings` still collects 697 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `_reset_app_lifecycle_state` fixture from `tests/Embeddings/conftest.py` — it no longer does anything.

The fixture was added for #2581 when `reload_app_main()` left a drained app behind, but both that leak and the orchestrator-parity failures it appeared to mask are fixed at the source (#2847, #2585/#2850, #2852). A single-run comparison made it look load-bearing, but three runs each way with collection order pinned show the same failure distribution: the extra failure is a flake (roughly one run in three) that hits a different test each time. The flake is real and remains open — the affected tests are auth-shaped or stage-control timing, and need their own investigation.

<sup>Written for commit ecd602372a4451eaf742e2e085bf00f74130453f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

