### PR TITLE
docs: add Personal Context operator and developer guides

### DIFF
--- a/Docs/API-related/API_README.md
+++ b/Docs/API-related/API_README.md
@@ -8,7 +8,7 @@ Generative endpoints follow openai API spec where possible.
 See [API Design](API_Design.md) for more details.
 
 See also:
-- `Docs/API-related/Personal_Context_API.md` for the authenticated canonical profile API shared with Chatbook.
+- Personal Context: [API reference](Personal_Context_API.md), [operator guide](../User_Guides/Server/Personal_Context_Profile.md), and [developer guide](../Code_Documentation/Personal_Context_Developer_Guide.md).
 - `Docs/Code_Documentation/Ingestion_Pipeline_Audio.md` for the audio processing endpoint (`POST /api/v1/media/process-audios`).
 - `Docs/API-related/Email_Processing_API.md` for the email processing endpoint (`POST /api/v1/media/process-emails`) and email ingestion via `/media/add`.
 - `Docs/API-related/Reminder_Notifications_API.md` for reminder tasks, inbox notifications, SSE stream, and related env flags.

--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -65,5 +65,19 @@ profile in `purge_pending` until synchronization acknowledgment is implemented.
 All profile mutations return HTTP 409 with
 `detail.code = "profile_purge_pending"` while that barrier is pending.
 
-Sync endpoints and device registration are intentionally outside this API and
-are introduced by the separate Personal Context synchronization contract.
+## REST and Sync-v2 boundary
+
+The authenticated REST API and Sync V2 are separate surfaces over the same
+canonical `PersonalContextService` and encrypted repository. Sync device
+registration, capability negotiation, bootstrap, and reviewed link completion
+remain under `/api/v1/sync` rather than `/api/v1/personal-context`.
+
+The shipped Sync V2 path supports capability negotiation, registered-device
+bootstrap, reviewed Chatbook link completion, and inbound Chatbook-originated
+manifest, scope, record, and proposal domains. Sync V2 also validates and
+materializes the `personal_context.purge` protocol domain, but the current
+linked flow has no end-to-end purge producer.
+
+REST edits are not published to linked clients.
+
+Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -1,0 +1,199 @@
+# Personal Context developer guide
+
+Personal Context is one canonical profile contract implemented by Chatbook and
+tldw_server. The server is an authenticated home peer: it owns an encrypted
+canonical copy for each user, exposes REST operations, and accepts linked
+Chatbook changes through Sync V2. The [Personal Context API
+reference](../API-related/Personal_Context_API.md) lists the REST surface; the
+[operator guide](../User_Guides/Server/Personal_Context_Profile.md) covers
+deployment and recovery workflows.
+
+The source-only architecture authorities are the [server
+design](https://github.com/rmusser01/tldw_server/blob/dev/Docs/Design/2026-08-30-personal-context-profile-server-design.md)
+and [Personal Context
+ADR](https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md).
+
+## Contract and trust boundary
+
+- The shared package is pinned to `tldw-profile-core==0.1.0`. Its models,
+  validation, fixtures, and canonical bytes are the application contract.
+- The live parity and canonical-fixture tests are the authority for the current
+  contract digest and exact canonical bytes. Do not copy a digest into
+  documentation or use a documented value as compatibility evidence.
+- Shared Core objects and Sync V2 envelopes are separate contracts. Change
+  canonical models in Shared Core first; change transport domains, routing, or
+  envelope behavior separately.
+- Authentication and user storage resolution precede profile lookup. Each
+  authenticated user has at most one manifest in that user's existing
+  `Personalization.db`.
+- The current Sync policy is `server_trusted_v1`. The authorized home server
+  can read syncable canonical content to validate and materialize it before
+  encrypting its copy at rest. This is not end-to-end encryption from the home
+  server.
+- A non-loopback deployment must put the authenticated API behind TLS/HTTPS so
+  credentials and profile content are protected in transit.
+
+### Shared contract
+
+<!-- shared-personal-context-contract:start -->
+- `tldw_profile_core` defines the versioned canonical profile object models, exact canonical bytes, interview/tool contracts, serialization, and validation used by both peers. Sync-v2 transport envelopes are a separate contract.
+- After a successful reviewed link, Chatbook and tldw_server converge on the same canonical manifest, scope, record, proposal, and version identities and bytes for eligible shared objects.
+- Sync V2 defines the `personal_context.manifest`, `personal_context.scope`, `personal_context.record`, `personal_context.proposal`, and content-free `personal_context.purge` domains. The current linked flow publishes eligible Chatbook-originated manifest, scope, record, and proposal changes; purge production and distribution are not wired end to end.
+- Each peer retains its own at-rest ciphertext and keys, local database rows, runtime permissions, conflict-review metadata, acknowledgement tracking, and other operational state.
+<!-- shared-personal-context-contract:end -->
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+## Storage, key custody, and encryption
+
+The server extends the authenticated user's `Personalization.db`; Sync storage
+is transport history and binding state, not the canonical application store.
+Immutable object versions, current heads, optimistic compare-and-set checks,
+semantic uniqueness, and purge fences remain behind the repository and service
+boundaries.
+
+The key hierarchy has three levels:
+
+1. The explicitly configured 32-byte server root key wraps independent random
+   per-profile encryption and integrity keys.
+2. The profile encryption key wraps a fresh random data-encryption key for each
+   immutable object version.
+3. That object key encrypts the canonical bytes with associated data binding
+   the profile, object type, object identity, version, and envelope schema.
+
+Missing, malformed, changed, or orphaned root/profile key material locks the
+profile and never causes replacement keys to be generated. Integrity is checked
+before canonical model parsing. Each peer owns its own at-rest keys and
+ciphertext; those keys are never synchronized.
+
+The server separately owns the Sync integrity key used to authenticate
+canonical transport bytes. During bootstrap, it wraps that key for the
+authenticated registered Chatbook device. The wrapped key record is Sync key
+distribution, not profile-content synchronization and not transfer of either
+peer's at-rest key custody.
+
+## Component ownership
+
+All paths below are relative to the repository root.
+
+| Component | Responsibility |
+| --- | --- |
+| `tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py` | Authenticated, per-user `PersonalContextService` dependency assembly and workspace ownership binding. |
+| `tldw_Server_API/app/api/v1/schemas/personal_context.py` | Strict HTTP request and bounded response schemas. |
+| `tldw_Server_API/app/api/v1/endpoints/personal_context.py` | REST-to-service translation and content-free error mapping. |
+| `tldw_Server_API/app/core/DB_Management/Personal_Context_Key_Store.py` | Real root/profile key-custody owner, including strict root-key loading and wrapped profile keys. |
+| `tldw_Server_API/app/core/Personalization/personal_context_key_provider.py` | Compatibility re-export of the database-owned key provider; it does not own custody. |
+| `tldw_Server_API/app/core/Personalization/personal_context_crypto.py` | Authenticated object envelopes and symmetric key-wrapping primitives. |
+| `tldw_Server_API/app/core/Personalization/personal_context_repository.py` | Stable service import for the database-owned repository that manages immutable versions, heads, and fences. |
+| `tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py` | Real canonical object SQL owner, including encryption, version/head CAS, semantic uniqueness, key rotation, and purge fencing. |
+| `tldw_Server_API/app/core/Personalization/personal_context_service.py` | Canonical authenticated business boundary for reads, mutations, bootstrap snapshots, inbound Sync projection, exports, and purge. |
+| `tldw_Server_API/app/core/Personalization/personal_context_export.py` | Explicit-confirmation plaintext export and passphrase-encrypted recovery export helpers. |
+| `tldw_Server_API/app/core/Personalization/personal_context_runtime_policy.py` | Encrypted server-local runtime enablement and workspace mapping models. |
+| `tldw_Server_API/app/core/Sync/v2/profile.py` | Capability-gated bootstrap, dataset binding, registered-device integrity-key wrapping, and reviewed link completion. |
+| `tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py` | Whole-object transport validation, HMAC verification, lineage checks, and encryption before Sync persistence. |
+| `tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py` | Inbound accepted-envelope projection through the authenticated owner service, with content-free failure/conflict outcomes. |
+
+Endpoints, agents, Sync code, migration or compatibility paths, and future
+publishers must never access Personal Context profile tables directly. They use
+`PersonalContextService`, which delegates durable invariants to the repository.
+
+## REST flow
+
+`authentication -> PersonalContextService -> encrypted repository -> response`
+
+The dependency resolves exactly one authenticated user's database and
+workspace-access check. The endpoint validates the HTTP shape, the service
+enforces profile authority and lifecycle rules, and the repository performs the
+encrypted transactional read or write. Expected version IDs provide optimistic
+concurrency; unknown and cross-user opaque IDs receive the same not-found
+response.
+
+REST runtime policy and exports are server-local operations. REST record and
+proposal mutations change the canonical server copy, but no server-origin
+publisher currently appends those edits to the linked Personal Context Sync
+streams.
+
+## Sync and bootstrap flow
+
+`capability negotiation -> registered device -> reviewed Chatbook plan -> snapshot/wrapped integrity key -> completion -> inbound validation/materialization`
+
+Sync V2 negotiates all five domains:
+
+- `personal_context.manifest`
+- `personal_context.scope`
+- `personal_context.record`
+- `personal_context.proposal`
+- `personal_context.purge`
+
+Bootstrap requires negotiated schema and quotas, an authorized registered
+device, server key custody, and a stable canonical snapshot. The server binds
+opaque profile/authority/generation state in the Sync dataset and returns the
+canonical snapshot with a device-wrapped server-owned integrity key. Chatbook
+reviews identity and semantic reconciliation before presenting the exact
+bootstrap cursor for completion. Upload remains blocked until that narrow
+completion transition succeeds.
+
+After linking, adapters authenticate canonical bytes, identity, schema,
+syncability, size, purge generation, and base lineage. Accepted envelopes are
+encrypted in Sync persistence and materialized through the per-user
+`PersonalContextService`; version divergence becomes generic content-free Sync
+conflict metadata.
+
+## Current limitations and conflict boundaries
+
+Reviewed first-link reconciliation handles first-link semantic collisions before completion.
+
+No dedicated post-link semantic-collision resolver exists.
+
+REST edits are not published to linked clients.
+
+Server purge does not publish the protocol purge envelope, and acknowledgement completion is absent.
+
+The `personal_context.purge` domain, adapter validation, and inbound service
+projection exist. The REST purge endpoint only advances the server-local
+canonical generation fence, deletes readable server bodies and runtime state,
+blocks later mutations, and leaves the profile in `purge_pending`. There is no
+shipped server producer/distributor for a purge envelope and no device
+acknowledgement-completion path.
+
+## Privacy and diagnostics
+
+Treat canonical profile bodies, semantic keys, proposal content, exports, and
+key material as secrets. Keep plaintext out of logs, diagnostics, Sync outbox
+or routing metadata, exception text, temporary artifacts, and unencrypted test
+fixtures. Persist only the minimum opaque routing and version metadata needed
+by each store. Tombstones and terminal proposal receipts must remain
+content-free.
+
+## Extension checklist
+
+1. Decide whether the change affects the shared contract or only one peer.
+2. Make shared canonical object changes in `tldw_profile_core` first; change Sync transport separately.
+3. Preserve canonical identities and explicit syncability.
+4. Route through the owning service; never access profile tables directly.
+5. Enforce authority, scope, expiry, visibility, and secret-rejection rules.
+6. Keep plaintext out of logs, diagnostics, outbox metadata, and unencrypted fixtures.
+7. Add parity/conformance coverage in both repositories.
+8. Add peer-specific migration, repository, service, API/UI, and recovery tests.
+9. Update the governing ADR for storage, ownership, encryption, Sync, or authority changes.
+10. Update both documentation sets whenever the shared contract changes.
+
+## Test map
+
+| Suite | Contract covered |
+| --- | --- |
+| `packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py` | Direct Shared Core public models, canonical serialization, schema export, semantic validation, and tool contract. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_contract.py` | Vendored package digest parity, supported Python floor, and cross-runtime canonical bytes/integrity fixture. This live suite, not a copied digest, is the compatibility authority. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py` | REST bounds, strict requests, typed conflicts, runtime, export confirmations, purge fencing, proposal pagination, and router registration. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py` | Independent wrapped profile keys, strict root-key handling, fail-closed locking, and absence of unwrapped keys at rest. |
+| `tldw_Server_API/tests/Personalization/integration/test_personal_context_composed_app.py` | Production route composition, modeled responses, authentication, and rate limiting. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py` | Capability/schema/quota gates, registered-device wrapping, stable reviewed bootstrap, binding, completion, pre-link upload blocking, idempotency, and privacy. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py` | Authorized inbound projection through the owning service and content-free conflict/failure mapping. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py` | Canonical transport integrity, optimistic lineage, encrypted Sync history, replay idempotency, pull visibility, and fail-closed key custody. |

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -166,11 +166,23 @@ acknowledgement-completion path.
 ## Privacy and diagnostics
 
 Treat canonical profile bodies, semantic keys, proposal content, exports, and
-key material as secrets. Keep plaintext out of logs, diagnostics, Sync outbox
-or routing metadata, exception text, temporary artifacts, and unencrypted test
-fixtures. Persist only the minimum opaque routing and version metadata needed
-by each store. Tombstones and terminal proposal receipts must remain
-content-free.
+key material as secrets. Never log canonical plaintext, durable at-rest
+ciphertext, key material, or raw cryptographic exception values. Never return
+internal ciphertext or raw cryptographic exception values. Authorized success
+responses and explicit exports may return only the requested canonical data;
+error and diagnostic boundaries translate cryptographic, key-custody,
+integrity, and storage failures into sanitized, stable, content-free error
+codes and messages without embedding raw exception values. An explicitly
+requested recovery export is a separate passphrase-encrypted export artifact,
+not exposure of internal at-rest ciphertext.
+
+Keep real or user-derived plaintext out of logs, diagnostics, Sync outbox or
+routing metadata, exception text, temporary artifacts, and unencrypted test
+fixtures. Deliberate synthetic canonical and conformance fixtures under Shared
+Core are permitted because they prove exact shared bytes; never populate them
+with production or user-derived content. Persist only the minimum opaque routing
+and version metadata needed by each store. Tombstones and terminal proposal
+receipts must remain content-free.
 
 ## Extension checklist
 
@@ -179,7 +191,7 @@ content-free.
 3. Preserve canonical identities and explicit syncability.
 4. Route through the owning service; never access profile tables directly.
 5. Enforce authority, scope, expiry, visibility, and secret-rejection rules.
-6. Keep plaintext out of logs, diagnostics, outbox metadata, and unencrypted fixtures.
+6. Keep plaintext, ciphertext, keys, and raw cryptographic exception values out of logs, diagnostics, and outbox metadata; never return internal ciphertext or raw cryptographic exception values; keep real or user-derived plaintext out of unencrypted fixtures, while permitting deliberate synthetic canonical/conformance fixtures in Shared Core.
 7. Add parity/conformance coverage in both repositories.
 8. Add peer-specific migration, repository, service, API/UI, and recovery tests.
 9. Update the governing ADR for storage, ownership, encryption, Sync, or authority changes.
@@ -191,8 +203,13 @@ content-free.
 | --- | --- |
 | `packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py` | Direct Shared Core public models, canonical serialization, schema export, semantic validation, and tool contract. |
 | `tldw_Server_API/tests/Personalization/test_personal_context_contract.py` | Vendored package digest parity, supported Python floor, and cross-runtime canonical bytes/integrity fixture. This live suite, not a copied digest, is the compatibility authority. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py` | Authentication before storage access and indistinguishable cross-user/unknown object responses. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_crypto.py` | Fresh object keys and nonces, associated-data binding, exact key sizes, and sanitized authentication failures. |
 | `tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py` | REST bounds, strict requests, typed conflicts, runtime, export confirmations, purge fencing, proposal pagination, and router registration. |
 | `tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py` | Independent wrapped profile keys, strict root-key handling, fail-closed locking, and absence of unwrapped keys at rest. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_repository.py` | Per-user schema and transactions, encrypted versions/heads, optimistic concurrency, content-free deletion, tamper detection, purge fences, and key rotation. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_service.py` | Service-owned authority, lifecycle, bootstrap, inbound Sync application, quotas, proposal review, export, and purge behavior. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_plaintext_canary.py` | Canonical bodies stay out of the database, sidecars, and logs; rejected content is shredded and integrity failures do not disclose plaintext. |
 | `tldw_Server_API/tests/Personalization/integration/test_personal_context_composed_app.py` | Production route composition, modeled responses, authentication, and rate limiting. |
 | `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py` | Capability/schema/quota gates, registered-device wrapping, stable reviewed bootstrap, binding, completion, pre-link upload blocking, idempotency, and privacy. |
 | `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py` | Authorized inbound projection through the owning service and content-free conflict/failure mapping. |

--- a/Docs/Code_Documentation/index.md
+++ b/Docs/Code_Documentation/index.md
@@ -34,7 +34,7 @@ Use the links below to jump to common areas, or the sidebar to browse all topics
 
 ## Chat & Knowledge
 - Chat Developer Guide: Chat_Developer_Guide.md
-- [Personal Context Profile](Personal_Context_Developer_Guide.md)
+- Personal Context Profile: Personal_Context_Developer_Guide.md
 - Chatbook Developer Guide: Chatbook_Developer_Guide.md
 - Meetings Developer Guide: Meetings_Developer_Guide.md
 

--- a/Docs/Code_Documentation/index.md
+++ b/Docs/Code_Documentation/index.md
@@ -34,6 +34,7 @@ Use the links below to jump to common areas, or the sidebar to browse all topics
 
 ## Chat & Knowledge
 - Chat Developer Guide: Chat_Developer_Guide.md
+- [Personal Context Profile](Personal_Context_Developer_Guide.md)
 - Chatbook Developer Guide: Chatbook_Developer_Guide.md
 - Meetings Developer Guide: Meetings_Developer_Guide.md
 

--- a/Docs/Published/API-related/API_README.md
+++ b/Docs/Published/API-related/API_README.md
@@ -8,7 +8,7 @@ Generative endpoints follow openai API spec where possible.
 See [API Design](API_Design.md) for more details.
 
 See also:
-- `Docs/API-related/Personal_Context_API.md` for the authenticated canonical profile API shared with Chatbook.
+- Personal Context: [API reference](Personal_Context_API.md), [operator guide](../User_Guides/Server/Personal_Context_Profile.md), and [developer guide](../Code_Documentation/Personal_Context_Developer_Guide.md).
 - `Docs/Code_Documentation/Ingestion_Pipeline_Audio.md` for the audio processing endpoint (`POST /api/v1/media/process-audios`).
 - `Docs/API-related/Email_Processing_API.md` for the email processing endpoint (`POST /api/v1/media/process-emails`) and email ingestion via `/media/add`.
 - `Docs/API-related/Reminder_Notifications_API.md` for reminder tasks, inbox notifications, SSE stream, and related env flags.

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -65,5 +65,19 @@ profile in `purge_pending` until synchronization acknowledgment is implemented.
 All profile mutations return HTTP 409 with
 `detail.code = "profile_purge_pending"` while that barrier is pending.
 
-Sync endpoints and device registration are intentionally outside this API and
-are introduced by the separate Personal Context synchronization contract.
+## REST and Sync-v2 boundary
+
+The authenticated REST API and Sync V2 are separate surfaces over the same
+canonical `PersonalContextService` and encrypted repository. Sync device
+registration, capability negotiation, bootstrap, and reviewed link completion
+remain under `/api/v1/sync` rather than `/api/v1/personal-context`.
+
+The shipped Sync V2 path supports capability negotiation, registered-device
+bootstrap, reviewed Chatbook link completion, and inbound Chatbook-originated
+manifest, scope, record, and proposal domains. Sync V2 also validates and
+materializes the `personal_context.purge` protocol domain, but the current
+linked flow has no end-to-end purge producer.
+
+REST edits are not published to linked clients.
+
+Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -1,0 +1,216 @@
+# Personal Context developer guide
+
+Personal Context is one canonical profile contract implemented by Chatbook and
+tldw_server. The server is an authenticated home peer: it owns an encrypted
+canonical copy for each user, exposes REST operations, and accepts linked
+Chatbook changes through Sync V2. The [Personal Context API
+reference](../API-related/Personal_Context_API.md) lists the REST surface; the
+[operator guide](../User_Guides/Server/Personal_Context_Profile.md) covers
+deployment and recovery workflows.
+
+The source-only architecture authorities are the [server
+design](https://github.com/rmusser01/tldw_server/blob/dev/Docs/Design/2026-08-30-personal-context-profile-server-design.md)
+and [Personal Context
+ADR](https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md).
+
+## Contract and trust boundary
+
+- The shared package is pinned to `tldw-profile-core==0.1.0`. Its models,
+  validation, fixtures, and canonical bytes are the application contract.
+- The live parity and canonical-fixture tests are the authority for the current
+  contract digest and exact canonical bytes. Do not copy a digest into
+  documentation or use a documented value as compatibility evidence.
+- Shared Core objects and Sync V2 envelopes are separate contracts. Change
+  canonical models in Shared Core first; change transport domains, routing, or
+  envelope behavior separately.
+- Authentication and user storage resolution precede profile lookup. Each
+  authenticated user has at most one manifest in that user's existing
+  `Personalization.db`.
+- The current Sync policy is `server_trusted_v1`. The authorized home server
+  can read syncable canonical content to validate and materialize it before
+  encrypting its copy at rest. This is not end-to-end encryption from the home
+  server.
+- A non-loopback deployment must put the authenticated API behind TLS/HTTPS so
+  credentials and profile content are protected in transit.
+
+### Shared contract
+
+<!-- shared-personal-context-contract:start -->
+- `tldw_profile_core` defines the versioned canonical profile object models, exact canonical bytes, interview/tool contracts, serialization, and validation used by both peers. Sync-v2 transport envelopes are a separate contract.
+- After a successful reviewed link, Chatbook and tldw_server converge on the same canonical manifest, scope, record, proposal, and version identities and bytes for eligible shared objects.
+- Sync V2 defines the `personal_context.manifest`, `personal_context.scope`, `personal_context.record`, `personal_context.proposal`, and content-free `personal_context.purge` domains. The current linked flow publishes eligible Chatbook-originated manifest, scope, record, and proposal changes; purge production and distribution are not wired end to end.
+- Each peer retains its own at-rest ciphertext and keys, local database rows, runtime permissions, conflict-review metadata, acknowledgement tracking, and other operational state.
+<!-- shared-personal-context-contract:end -->
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+## Storage, key custody, and encryption
+
+The server extends the authenticated user's `Personalization.db`; Sync storage
+is transport history and binding state, not the canonical application store.
+Immutable object versions, current heads, optimistic compare-and-set checks,
+semantic uniqueness, and purge fences remain behind the repository and service
+boundaries.
+
+The key hierarchy has three levels:
+
+1. The explicitly configured 32-byte server root key wraps independent random
+   per-profile encryption and integrity keys.
+2. The profile encryption key wraps a fresh random data-encryption key for each
+   immutable object version.
+3. That object key encrypts the canonical bytes with associated data binding
+   the profile, object type, object identity, version, and envelope schema.
+
+Missing, malformed, changed, or orphaned root/profile key material locks the
+profile and never causes replacement keys to be generated. Integrity is checked
+before canonical model parsing. Each peer owns its own at-rest keys and
+ciphertext; those keys are never synchronized.
+
+The server separately owns the Sync integrity key used to authenticate
+canonical transport bytes. During bootstrap, it wraps that key for the
+authenticated registered Chatbook device. The wrapped key record is Sync key
+distribution, not profile-content synchronization and not transfer of either
+peer's at-rest key custody.
+
+## Component ownership
+
+All paths below are relative to the repository root.
+
+| Component | Responsibility |
+| --- | --- |
+| `tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py` | Authenticated, per-user `PersonalContextService` dependency assembly and workspace ownership binding. |
+| `tldw_Server_API/app/api/v1/schemas/personal_context.py` | Strict HTTP request and bounded response schemas. |
+| `tldw_Server_API/app/api/v1/endpoints/personal_context.py` | REST-to-service translation and content-free error mapping. |
+| `tldw_Server_API/app/core/DB_Management/Personal_Context_Key_Store.py` | Real root/profile key-custody owner, including strict root-key loading and wrapped profile keys. |
+| `tldw_Server_API/app/core/Personalization/personal_context_key_provider.py` | Compatibility re-export of the database-owned key provider; it does not own custody. |
+| `tldw_Server_API/app/core/Personalization/personal_context_crypto.py` | Authenticated object envelopes and symmetric key-wrapping primitives. |
+| `tldw_Server_API/app/core/Personalization/personal_context_repository.py` | Stable service import for the database-owned repository that manages immutable versions, heads, and fences. |
+| `tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py` | Real canonical object SQL owner, including encryption, version/head CAS, semantic uniqueness, key rotation, and purge fencing. |
+| `tldw_Server_API/app/core/Personalization/personal_context_service.py` | Canonical authenticated business boundary for reads, mutations, bootstrap snapshots, inbound Sync projection, exports, and purge. |
+| `tldw_Server_API/app/core/Personalization/personal_context_export.py` | Explicit-confirmation plaintext export and passphrase-encrypted recovery export helpers. |
+| `tldw_Server_API/app/core/Personalization/personal_context_runtime_policy.py` | Encrypted server-local runtime enablement and workspace mapping models. |
+| `tldw_Server_API/app/core/Sync/v2/profile.py` | Capability-gated bootstrap, dataset binding, registered-device integrity-key wrapping, and reviewed link completion. |
+| `tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py` | Whole-object transport validation, HMAC verification, lineage checks, and encryption before Sync persistence. |
+| `tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py` | Inbound accepted-envelope projection through the authenticated owner service, with content-free failure/conflict outcomes. |
+
+Endpoints, agents, Sync code, migration or compatibility paths, and future
+publishers must never access Personal Context profile tables directly. They use
+`PersonalContextService`, which delegates durable invariants to the repository.
+
+## REST flow
+
+`authentication -> PersonalContextService -> encrypted repository -> response`
+
+The dependency resolves exactly one authenticated user's database and
+workspace-access check. The endpoint validates the HTTP shape, the service
+enforces profile authority and lifecycle rules, and the repository performs the
+encrypted transactional read or write. Expected version IDs provide optimistic
+concurrency; unknown and cross-user opaque IDs receive the same not-found
+response.
+
+REST runtime policy and exports are server-local operations. REST record and
+proposal mutations change the canonical server copy, but no server-origin
+publisher currently appends those edits to the linked Personal Context Sync
+streams.
+
+## Sync and bootstrap flow
+
+`capability negotiation -> registered device -> reviewed Chatbook plan -> snapshot/wrapped integrity key -> completion -> inbound validation/materialization`
+
+Sync V2 negotiates all five domains:
+
+- `personal_context.manifest`
+- `personal_context.scope`
+- `personal_context.record`
+- `personal_context.proposal`
+- `personal_context.purge`
+
+Bootstrap requires negotiated schema and quotas, an authorized registered
+device, server key custody, and a stable canonical snapshot. The server binds
+opaque profile/authority/generation state in the Sync dataset and returns the
+canonical snapshot with a device-wrapped server-owned integrity key. Chatbook
+reviews identity and semantic reconciliation before presenting the exact
+bootstrap cursor for completion. Upload remains blocked until that narrow
+completion transition succeeds.
+
+After linking, adapters authenticate canonical bytes, identity, schema,
+syncability, size, purge generation, and base lineage. Accepted envelopes are
+encrypted in Sync persistence and materialized through the per-user
+`PersonalContextService`; version divergence becomes generic content-free Sync
+conflict metadata.
+
+## Current limitations and conflict boundaries
+
+Reviewed first-link reconciliation handles first-link semantic collisions before completion.
+
+No dedicated post-link semantic-collision resolver exists.
+
+REST edits are not published to linked clients.
+
+Server purge does not publish the protocol purge envelope, and acknowledgement completion is absent.
+
+The `personal_context.purge` domain, adapter validation, and inbound service
+projection exist. The REST purge endpoint only advances the server-local
+canonical generation fence, deletes readable server bodies and runtime state,
+blocks later mutations, and leaves the profile in `purge_pending`. There is no
+shipped server producer/distributor for a purge envelope and no device
+acknowledgement-completion path.
+
+## Privacy and diagnostics
+
+Treat canonical profile bodies, semantic keys, proposal content, exports, and
+key material as secrets. Never log canonical plaintext, durable at-rest
+ciphertext, key material, or raw cryptographic exception values. Never return
+internal ciphertext or raw cryptographic exception values. Authorized success
+responses and explicit exports may return only the requested canonical data;
+error and diagnostic boundaries translate cryptographic, key-custody,
+integrity, and storage failures into sanitized, stable, content-free error
+codes and messages without embedding raw exception values. An explicitly
+requested recovery export is a separate passphrase-encrypted export artifact,
+not exposure of internal at-rest ciphertext.
+
+Keep real or user-derived plaintext out of logs, diagnostics, Sync outbox or
+routing metadata, exception text, temporary artifacts, and unencrypted test
+fixtures. Deliberate synthetic canonical and conformance fixtures under Shared
+Core are permitted because they prove exact shared bytes; never populate them
+with production or user-derived content. Persist only the minimum opaque routing
+and version metadata needed by each store. Tombstones and terminal proposal
+receipts must remain content-free.
+
+## Extension checklist
+
+1. Decide whether the change affects the shared contract or only one peer.
+2. Make shared canonical object changes in `tldw_profile_core` first; change Sync transport separately.
+3. Preserve canonical identities and explicit syncability.
+4. Route through the owning service; never access profile tables directly.
+5. Enforce authority, scope, expiry, visibility, and secret-rejection rules.
+6. Keep plaintext, ciphertext, keys, and raw cryptographic exception values out of logs, diagnostics, and outbox metadata; never return internal ciphertext or raw cryptographic exception values; keep real or user-derived plaintext out of unencrypted fixtures, while permitting deliberate synthetic canonical/conformance fixtures in Shared Core.
+7. Add parity/conformance coverage in both repositories.
+8. Add peer-specific migration, repository, service, API/UI, and recovery tests.
+9. Update the governing ADR for storage, ownership, encryption, Sync, or authority changes.
+10. Update both documentation sets whenever the shared contract changes.
+
+## Test map
+
+| Suite | Contract covered |
+| --- | --- |
+| `packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py` | Direct Shared Core public models, canonical serialization, schema export, semantic validation, and tool contract. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_contract.py` | Vendored package digest parity, supported Python floor, and cross-runtime canonical bytes/integrity fixture. This live suite, not a copied digest, is the compatibility authority. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py` | Authentication before storage access and indistinguishable cross-user/unknown object responses. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_crypto.py` | Fresh object keys and nonces, associated-data binding, exact key sizes, and sanitized authentication failures. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py` | REST bounds, strict requests, typed conflicts, runtime, export confirmations, purge fencing, proposal pagination, and router registration. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py` | Independent wrapped profile keys, strict root-key handling, fail-closed locking, and absence of unwrapped keys at rest. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_repository.py` | Per-user schema and transactions, encrypted versions/heads, optimistic concurrency, content-free deletion, tamper detection, purge fences, and key rotation. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_service.py` | Service-owned authority, lifecycle, bootstrap, inbound Sync application, quotas, proposal review, export, and purge behavior. |
+| `tldw_Server_API/tests/Personalization/test_personal_context_plaintext_canary.py` | Canonical bodies stay out of the database, sidecars, and logs; rejected content is shredded and integrity failures do not disclose plaintext. |
+| `tldw_Server_API/tests/Personalization/integration/test_personal_context_composed_app.py` | Production route composition, modeled responses, authentication, and rate limiting. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py` | Capability/schema/quota gates, registered-device wrapping, stable reviewed bootstrap, binding, completion, pre-link upload blocking, idempotency, and privacy. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py` | Authorized inbound projection through the owning service and content-free conflict/failure mapping. |
+| `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py` | Canonical transport integrity, optimistic lineage, encrypted Sync history, replay idempotency, pull visibility, and fail-closed key custody. |

--- a/Docs/Published/Code_Documentation/index.md
+++ b/Docs/Published/Code_Documentation/index.md
@@ -34,6 +34,7 @@ Use the links below to jump to common areas, or the sidebar to browse all topics
 
 ## Chat & Knowledge
 - Chat Developer Guide: Chat_Developer_Guide.md
+- Personal Context Profile: Personal_Context_Developer_Guide.md
 - Chatbook Developer Guide: Chatbook_Developer_Guide.md
 - Meetings Developer Guide: Meetings_Developer_Guide.md
 

--- a/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
@@ -1,0 +1,156 @@
+# Personal Context Profile on tldw_server
+
+## Purpose and product boundary
+
+tldw_server is the authenticated home peer and canonical server copy of a
+Personal Context Profile. [Chatbook is the current full profile editing and
+interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md).
+The server does not currently provide a complete standalone profile editor.
+
+A standalone Chatbook profile and an existing server profile are independent
+peers. They become one canonical linked profile only after the user reviews the
+reconciliation plan and link completion succeeds. Do not treat an upload or a
+matching account as proof that linking is complete.
+
+## Prerequisites and master-key setup
+
+Personal Context routes require successful server authentication with an API
+key or JWT. Authentication happens before the server resolves the current
+user's storage. Each authenticated user can have one manifest in that user's
+`Personalization.db`.
+
+Configure `TLDW_PERSONAL_CONTEXT_MASTER_KEY` before starting the server. Its
+value must be strict base64 that decodes to exactly 32 bytes. Generate a fresh
+random value with an installed Python 3.11 or newer interpreter:
+
+```bash
+python3 -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode("ascii"))'
+```
+
+On Windows PowerShell, use `py -3.11` instead of `python3` (or invoke another
+installed, supported Python interpreter explicitly).
+
+Store the output with your protected server secrets and make a secure backup
+before creating the first profile. A missing, malformed, or changed key fails
+closed: existing profile content becomes locked, and the server does not create
+replacement profile keys. Restore the exact original key from backup instead
+of attempting to create another profile.
+
+### Trust and transport boundary
+
+Personal Context Sync currently uses `server_trusted_v1`: the authorized home
+server can read syncable canonical profile content to validate and materialize
+it, then encrypts it at rest. Peer-local at-rest keys protect each peer's stored
+copy but are not end-to-end encryption from the authorized home server.
+
+For any non-loopback connection, expose the API only through authenticated
+TLS/HTTPS. Otherwise API keys or JWTs and profile content can cross plaintext
+transport. Follow the [production hardening checklist](Production_Hardening_Checklist.md)
+for reverse-proxy and TLS setup.
+
+## Setup and status workflow
+
+Endpoint request and response details are in the [Personal Context API
+reference](../../API-related/Personal_Context_API.md).
+
+1. Configure API-key or JWT authentication and the master key before the server
+   starts.
+2. Authenticate and call `GET /api/v1/personal-context/status`. Remediate a
+   `locked` or `unsupported` state before attempting writes. If the state is
+   `purge_pending`, stop: the profile is non-writable and has no current
+   completion path.
+3. Call `GET /api/v1/sync/capabilities` and confirm that Personal Context is
+   available with the required domains, schema version, and quotas. Do not
+   bypass capability negotiation.
+4. Inspect `GET /api/v1/personal-context/manifest`. If a server-side profile is
+   intentionally needed and none exists, `POST /api/v1/personal-context/manifest`
+   creates the one allowed manifest and its required global scope.
+5. With an active authenticated home server in Chatbook, open:
+   **Settings → Data & Privacy → My Profile → Server sync → Link to home server**.
+   Review any identity or semantic reconciliation and complete the link before
+   profile changes are uploaded.
+6. Use Chatbook to edit changes that are expected to travel through the current
+   linked Sync flow. The REST API remains useful for server inspection and
+   explicit server-local operations, but its ordinary edits are not a
+   server-to-Chatbook publication path.
+
+## What is shared
+
+<!-- shared-personal-context-contract:start -->
+- `tldw_profile_core` defines the versioned canonical profile object models, exact canonical bytes, interview/tool contracts, serialization, and validation used by both peers. Sync-v2 transport envelopes are a separate contract.
+- After a successful reviewed link, Chatbook and tldw_server converge on the same canonical manifest, scope, record, proposal, and version identities and bytes for eligible shared objects.
+- Sync V2 defines the `personal_context.manifest`, `personal_context.scope`, `personal_context.record`, `personal_context.proposal`, and content-free `personal_context.purge` domains. The current linked flow publishes eligible Chatbook-originated manifest, scope, record, and proposal changes; purge production and distribution are not wired end to end.
+- Each peer retains its own at-rest ciphertext and keys, local database rows, runtime permissions, conflict-review metadata, acknowledgement tracking, and other operational state.
+<!-- shared-personal-context-contract:end -->
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
+
+Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
+
+The versioned [Shared Core
+contract](https://github.com/rmusser01/tldw_server/tree/dev/packages/tldw_profile_core)
+is the compatibility boundary used by both peers.
+
+## Export, removal, and purge
+
+Profile exports contain sensitive personal context. Confirm the intended scope,
+destination, and access controls before exporting. Plaintext export requires
+the exact confirmation `EXPORT PLAINTEXT`. Recovery export requires `EXPORT
+RECOVERY` and enforces a minimum of 12 characters. That is only the validation
+minimum, not a strength recommendation: use a long, unique passphrase and store
+it separately from the exported envelope.
+
+Removing a local Chatbook copy is owned by Chatbook. The server rejects purge
+requests with `mode: local_copy` as `server_local_copy_unsupported`.
+
+`POST /api/v1/personal-context/purge` is a global, currently incomplete
+operation. It requires `mode: everywhere`, the current purge generation, and
+the exact confirmation `DELETE EVERYWHERE`. It advances a server-local purge
+fence, removes canonical bodies and server runtime state, blocks further
+profile mutations, and leaves the profile in `purge_pending`.
+
+The `personal_context.purge` protocol domain exists.
+
+The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.
+Reconnecting devices does not currently clear `purge_pending`, and the current
+server has no completion path for that state.
+
+## Troubleshooting
+
+| State | Cause | Safe next action | Current limit |
+| --- | --- | --- | --- |
+| **Profile locked** | The configured master key is missing, malformed, changed, or cannot decrypt stored key material. | Stop writes, preserve `Personalization.db`, restore the exact original key from secure backup, and restart before checking status again. | There is no server-side bypass or automatic key-recreation path for existing ciphertext. |
+| **Offline or queued** | A Chatbook change remains in its local outbox because the home peer is unreachable or authentication failed. | Keep the local data, restore connectivity and credentials, then retry Sync and inspect Chatbook's outbox/status. | The server cannot inspect a device-local queue until the device delivers it. |
+| **Capability not negotiated** | The peers do not share the required Personal Context domains, adapter/schema support, or readiness. | Upgrade or correctly configure the incompatible peer, then negotiate again. | There is no supported bypass; upload remains blocked until negotiation succeeds. |
+| **Version conflict** | Both peers changed the same canonical object from different base versions. | Preserve the conflict and inspect the generic Sync conflict status and metadata before making another edit. | No dedicated Personal Context post-link resolver or automatic completion path exists. |
+| **First-link semantic collision** | Different local and server record identities describe the same scope, kind, namespace, and subject during linking. | Compare the presented records in Chatbook's reviewed reconciliation and resolve them before completing the link. | This resolver is available only as part of reviewed first-link reconciliation. |
+| **Post-link semantic collision** | Different record identities describe the same semantic key after linking. | Preserve both sides and inspect generic Sync conflict status and metadata. | No dedicated Personal Context post-link semantic-collision resolver or completion path exists. |
+| **Purge pending** | The server purge fence advanced and ordinary profile mutations are blocked. | Preserve operational evidence and treat the profile as non-writable; do not recreate it or assume reconnecting clients will finish deletion. | The current server has no purge acknowledgement-completion path, and reconnecting devices does not clear the state. |
+
+Additional checks:
+
+- **Authentication failure:** verify the deployment's auth mode and provide a
+  valid `X-API-KEY` or bearer JWT for the intended user. The server cannot
+  expose profile status or recovery details before authentication succeeds.
+- **Missing or changed master key:** restore the exact key used when the profile
+  was created. Creating a new value is not rotation and cannot decrypt the
+  profile; no automatic recovery path exists.
+- **Schema or quota incompatibility:** use the content-free bootstrap error
+  details to compare required and available values, then upgrade the
+  incompatible peer or reduce unsupported requirements before retrying. Link
+  completion cannot bypass `personal_context_schema_incompatible` or
+  `personal_context_quota_incompatible`.
+- **REST edit absent from Chatbook:** ordinary server REST record and proposal
+  mutations are not published to linked clients. Preserve the server state,
+  avoid duplicating the record blindly, and use Chatbook for future edits that
+  must use the linked Sync path. Retrying Sync alone cannot publish the REST
+  mutation because no server-origin publication path currently exists.

--- a/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
@@ -4,7 +4,7 @@
 
 tldw_server is the authenticated home peer and canonical server copy of a
 Personal Context Profile. [Chatbook is the current full profile editing and
-interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md).
+interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs%2FUser_Guide%2Fsettings%2Fpersonal-context-profile.md).
 The server does not currently provide a complete standalone profile editor.
 
 A standalone Chatbook profile and an existing server profile are independent

--- a/Docs/Published/User_Guides/index.md
+++ b/Docs/Published/User_Guides/index.md
@@ -48,6 +48,7 @@ Common workflows:
 
 - **Find the right WebUI or extension page**: use the [WebUI and extension guide](WebUI/index.md) and [page and feature index](WebUI/Page_Feature_Index.md).
 - **Chat with models and characters**: use [Chat pages](WebUI_Extension/Chat_Pages.md), [Chat API documentation](../API-related/Chat_API_Documentation.md), [Character roleplay quickstart](WebUI_Extension/Character_Roleplay_Quickstart.md), [Character cards and character chat](Server/Character_Cards_User_Guide.md), and [Personas](Server/Personas_User_Guide.md).
+- **Set up and operate a Personal Context Profile**: use the [Personal Context Profile guide](Server/Personal_Context_Profile.md) for master-key setup, Chatbook linking, exports, and recovery boundaries.
 - **Add sources and media**: use [Media to RAG evals workflow](Server/Media_to_RAG_Evals_Workflow.md), [Web scraping and ingestion](Server/Web_Scraping_Ingestion_Guide.md), [Media ingest jobs API](../API-related/Media_Ingest_Jobs_API.md), and [Bulk conference playlist ingest](Bulk_Conference_Playlist_Ingest.md).
 - **Search and ask questions over knowledge**: use [RAG API guide](../API-related/RAG-API-Guide.md), [RAG production configuration](Server/RAG_Production_Configuration_Guide.md), and [Quick Chat Docs Assistant](WebUI_Extension/Quick_Chat_Docs_Assistant_Guide.md).
 - **Transcribe and generate speech**: use [Getting started with STT and TTS](WebUI_Extension/Getting-Started-STT_and_TTS.md), [Audio transcription API](../API-related/Audio_Transcription_API.md), [Native batch STT benchmark](STT_Benchmark_User_Guide.md), and [TTS getting started](WebUI_Extension/TTS_Getting_Started.md).
@@ -63,6 +64,7 @@ Start with the guide that matches the failing surface:
 
 - Setup and profile issues: [self-hosting profiles](../Getting_Started/README.md) and [troubleshooting](../Getting_Started/TROUBLESHOOTING.md).
 - Authentication and access issues: [Authentication setup](Server/Authentication_Setup.md), [Multi-user Postgres setup](Server/Multi-User_Postgres_Setup.md), and [Multi-user SQLite setup](Server/Multi-User_SQLite_Setup.md).
+- Personal Context issues: use the [Personal Context Profile guide](Server/Personal_Context_Profile.md) for locked profiles, Sync/link states, version conflicts, and purge-pending limitations.
 - Provider and model issues: [BYOK user guide](Server/BYOK_User_Guide.md), [OpenAI OAuth first-time setup](Server/OpenAI_OAuth_First_Time_Setup.md), [local LLM setup](Integrations_Experiments/Setting_up_a_local_LLM.md), and [Providers API documentation](../API-related/Providers_API_Documentation.md).
 - Media and ingestion issues: [Web scraping and ingestion](Server/Web_Scraping_Ingestion_Guide.md), [Media ingest jobs API](../API-related/Media_Ingest_Jobs_API.md), and [Chunking templates user guide](Server/Chunking_Templates_User_Guide.md).
 - Audio issues: [CPU audio setup](../Getting_Started/First_Time_Audio_Setup_CPU.md), [GPU or accelerated audio setup](../Getting_Started/First_Time_Audio_Setup_GPU_Accelerated.md), and [TTS setup guide](WebUI_Extension/TTS-SETUP-GUIDE.md).

--- a/Docs/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/User_Guides/Server/Personal_Context_Profile.md
@@ -21,17 +21,32 @@ user's storage. Each authenticated user can have one manifest in that user's
 
 Configure `TLDW_PERSONAL_CONTEXT_MASTER_KEY` before starting the server. Its
 value must be strict base64 that decodes to exactly 32 bytes. Generate a fresh
-random value with the Python standard library:
+random value with an installed Python 3.11 or newer interpreter:
 
 ```bash
 python3 -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode("ascii"))'
 ```
+
+On Windows PowerShell, use `py -3.11` instead of `python3` (or invoke another
+installed, supported Python interpreter explicitly).
 
 Store the output with your protected server secrets and make a secure backup
 before creating the first profile. A missing, malformed, or changed key fails
 closed: existing profile content becomes locked, and the server does not create
 replacement profile keys. Restore the exact original key from backup instead
 of attempting to create another profile.
+
+### Trust and transport boundary
+
+Personal Context Sync currently uses `server_trusted_v1`: the authorized home
+server can read syncable canonical profile content to validate and materialize
+it, then encrypts it at rest. Peer-local at-rest keys protect each peer's stored
+copy but are not end-to-end encryption from the authorized home server.
+
+For any non-loopback connection, expose the API only through authenticated
+TLS/HTTPS. Otherwise API keys or JWTs and profile content can cross plaintext
+transport. Follow the [production hardening checklist](Production_Hardening_Checklist.md)
+for reverse-proxy and TLS setup.
 
 ## Setup and status workflow
 
@@ -40,16 +55,20 @@ reference](../../API-related/Personal_Context_API.md).
 
 1. Configure API-key or JWT authentication and the master key before the server
    starts.
-2. Authenticate and call `GET /api/v1/personal-context/status`. Resolve
-   `locked`, `unsupported`, or `purge_pending` before attempting writes.
+2. Authenticate and call `GET /api/v1/personal-context/status`. Remediate a
+   `locked` or `unsupported` state before attempting writes. If the state is
+   `purge_pending`, stop: the profile is non-writable and has no current
+   completion path.
 3. Call `GET /api/v1/sync/capabilities` and confirm that Personal Context is
    available with the required domains, schema version, and quotas. Do not
    bypass capability negotiation.
 4. Inspect `GET /api/v1/personal-context/manifest`. If a server-side profile is
    intentionally needed and none exists, `POST /api/v1/personal-context/manifest`
    creates the one allowed manifest and its required global scope.
-5. From Chatbook, start the home-server link, review any identity or semantic
-   reconciliation, and complete the link before profile changes are uploaded.
+5. With an active authenticated home server in Chatbook, open:
+   **Settings → Data & Privacy → My Profile → Server sync → Link to home server**.
+   Review any identity or semantic reconciliation and complete the link before
+   profile changes are uploaded.
 6. Use Chatbook to edit changes that are expected to travel through the current
    linked Sync flow. The REST API remains useful for server inspection and
    explicit server-local operations, but its ordinary edits are not a
@@ -73,25 +92,22 @@ reference](../../API-related/Personal_Context_API.md).
 | Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
 | — | Conflict-review objects and acknowledgement tracking |
 
-The current flow accepts eligible Chatbook-originated manifest, scope, record/tombstone, and proposal changes.
-
 The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
 
 Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
 
-Compatibility comes from the versioned [Shared Core
+The versioned [Shared Core
 contract](https://github.com/rmusser01/tldw_server/tree/dev/packages/tldw_profile_core)
-and the server's [parity and conformance
-test](https://github.com/rmusser01/tldw_server/blob/dev/tldw_Server_API/tests/Personalization/test_personal_context_contract.py),
-not a digest copied into this guide.
+is the compatibility boundary used by both peers.
 
 ## Export, removal, and purge
 
 Profile exports contain sensitive personal context. Confirm the intended scope,
 destination, and access controls before exporting. Plaintext export requires
 the exact confirmation `EXPORT PLAINTEXT`. Recovery export requires `EXPORT
-RECOVERY` and a passphrase of at least 12 characters; protect the passphrase
-separately from the exported envelope.
+RECOVERY` and enforces a minimum of 12 characters. That is only the validation
+minimum, not a strength recommendation: use a long, unique passphrase and store
+it separately from the exported envelope.
 
 Removing a local Chatbook copy is owned by Chatbook. The server rejects purge
 requests with `mode: local_copy` as `server_local_copy_unsupported`.
@@ -102,8 +118,7 @@ the exact confirmation `DELETE EVERYWHERE`. It advances a server-local purge
 fence, removes canonical bodies and server runtime state, blocks further
 profile mutations, and leaves the profile in `purge_pending`.
 
-The `personal_context.purge` protocol domain exists, but this endpoint does not
-produce or distribute it.
+The `personal_context.purge` protocol domain exists.
 
 The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.
 Reconnecting devices does not currently clear `purge_pending`, and the current

--- a/Docs/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/User_Guides/Server/Personal_Context_Profile.md
@@ -1,0 +1,141 @@
+# Personal Context Profile on tldw_server
+
+## Purpose and product boundary
+
+tldw_server is the authenticated home peer and canonical server copy of a
+Personal Context Profile. [Chatbook is the current full profile editing and
+interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md).
+The server does not currently provide a complete standalone profile editor.
+
+A standalone Chatbook profile and an existing server profile are independent
+peers. They become one canonical linked profile only after the user reviews the
+reconciliation plan and link completion succeeds. Do not treat an upload or a
+matching account as proof that linking is complete.
+
+## Prerequisites and master-key setup
+
+Personal Context routes require successful server authentication with an API
+key or JWT. Authentication happens before the server resolves the current
+user's storage. Each authenticated user can have one manifest in that user's
+`Personalization.db`.
+
+Configure `TLDW_PERSONAL_CONTEXT_MASTER_KEY` before starting the server. Its
+value must be strict base64 that decodes to exactly 32 bytes. Generate a fresh
+random value with the Python standard library:
+
+```bash
+python3 -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode("ascii"))'
+```
+
+Store the output with your protected server secrets and make a secure backup
+before creating the first profile. A missing, malformed, or changed key fails
+closed: existing profile content becomes locked, and the server does not create
+replacement profile keys. Restore the exact original key from backup instead
+of attempting to create another profile.
+
+## Setup and status workflow
+
+Endpoint request and response details are in the [Personal Context API
+reference](../../API-related/Personal_Context_API.md).
+
+1. Configure API-key or JWT authentication and the master key before the server
+   starts.
+2. Authenticate and call `GET /api/v1/personal-context/status`. Resolve
+   `locked`, `unsupported`, or `purge_pending` before attempting writes.
+3. Call `GET /api/v1/sync/capabilities` and confirm that Personal Context is
+   available with the required domains, schema version, and quotas. Do not
+   bypass capability negotiation.
+4. Inspect `GET /api/v1/personal-context/manifest`. If a server-side profile is
+   intentionally needed and none exists, `POST /api/v1/personal-context/manifest`
+   creates the one allowed manifest and its required global scope.
+5. From Chatbook, start the home-server link, review any identity or semantic
+   reconciliation, and complete the link before profile changes are uploaded.
+6. Use Chatbook to edit changes that are expected to travel through the current
+   linked Sync flow. The REST API remains useful for server inspection and
+   explicit server-local operations, but its ordinary edits are not a
+   server-to-Chatbook publication path.
+
+## What is shared
+
+<!-- shared-personal-context-contract:start -->
+- `tldw_profile_core` defines the versioned canonical profile object models, exact canonical bytes, interview/tool contracts, serialization, and validation used by both peers. Sync-v2 transport envelopes are a separate contract.
+- After a successful reviewed link, Chatbook and tldw_server converge on the same canonical manifest, scope, record, proposal, and version identities and bytes for eligible shared objects.
+- Sync V2 defines the `personal_context.manifest`, `personal_context.scope`, `personal_context.record`, `personal_context.proposal`, and content-free `personal_context.purge` domains. The current linked flow publishes eligible Chatbook-originated manifest, scope, record, and proposal changes; purge production and distribution are not wired end to end.
+- Each peer retains its own at-rest ciphertext and keys, local database rows, runtime permissions, conflict-review metadata, acknowledgement tracking, and other operational state.
+<!-- shared-personal-context-contract:end -->
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+The current flow accepts eligible Chatbook-originated manifest, scope, record/tombstone, and proposal changes.
+
+The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
+
+Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
+
+Compatibility comes from the versioned [Shared Core
+contract](https://github.com/rmusser01/tldw_server/tree/dev/packages/tldw_profile_core)
+and the server's [parity and conformance
+test](https://github.com/rmusser01/tldw_server/blob/dev/tldw_Server_API/tests/Personalization/test_personal_context_contract.py),
+not a digest copied into this guide.
+
+## Export, removal, and purge
+
+Profile exports contain sensitive personal context. Confirm the intended scope,
+destination, and access controls before exporting. Plaintext export requires
+the exact confirmation `EXPORT PLAINTEXT`. Recovery export requires `EXPORT
+RECOVERY` and a passphrase of at least 12 characters; protect the passphrase
+separately from the exported envelope.
+
+Removing a local Chatbook copy is owned by Chatbook. The server rejects purge
+requests with `mode: local_copy` as `server_local_copy_unsupported`.
+
+`POST /api/v1/personal-context/purge` is a global, currently incomplete
+operation. It requires `mode: everywhere`, the current purge generation, and
+the exact confirmation `DELETE EVERYWHERE`. It advances a server-local purge
+fence, removes canonical bodies and server runtime state, blocks further
+profile mutations, and leaves the profile in `purge_pending`.
+
+The `personal_context.purge` protocol domain exists, but this endpoint does not
+produce or distribute it.
+
+The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.
+Reconnecting devices does not currently clear `purge_pending`, and the current
+server has no completion path for that state.
+
+## Troubleshooting
+
+| State | Cause | Safe next action | Current limit |
+| --- | --- | --- | --- |
+| **Profile locked** | The configured master key is missing, malformed, changed, or cannot decrypt stored key material. | Stop writes, preserve `Personalization.db`, restore the exact original key from secure backup, and restart before checking status again. | There is no server-side bypass or automatic key-recreation path for existing ciphertext. |
+| **Offline or queued** | A Chatbook change remains in its local outbox because the home peer is unreachable or authentication failed. | Keep the local data, restore connectivity and credentials, then retry Sync and inspect Chatbook's outbox/status. | The server cannot inspect a device-local queue until the device delivers it. |
+| **Capability not negotiated** | The peers do not share the required Personal Context domains, adapter/schema support, or readiness. | Upgrade or correctly configure the incompatible peer, then negotiate again. | There is no supported bypass; upload remains blocked until negotiation succeeds. |
+| **Version conflict** | Both peers changed the same canonical object from different base versions. | Preserve the conflict and inspect the generic Sync conflict status and metadata before making another edit. | No dedicated Personal Context post-link resolver or automatic completion path exists. |
+| **First-link semantic collision** | Different local and server record identities describe the same scope, kind, namespace, and subject during linking. | Compare the presented records in Chatbook's reviewed reconciliation and resolve them before completing the link. | This resolver is available only as part of reviewed first-link reconciliation. |
+| **Post-link semantic collision** | Different record identities describe the same semantic key after linking. | Preserve both sides and inspect generic Sync conflict status and metadata. | No dedicated Personal Context post-link semantic-collision resolver or completion path exists. |
+| **Purge pending** | The server purge fence advanced and ordinary profile mutations are blocked. | Preserve operational evidence and treat the profile as non-writable; do not recreate it or assume reconnecting clients will finish deletion. | The current server has no purge acknowledgement-completion path, and reconnecting devices does not clear the state. |
+
+Additional checks:
+
+- **Authentication failure:** verify the deployment's auth mode and provide a
+  valid `X-API-KEY` or bearer JWT for the intended user. The server cannot
+  expose profile status or recovery details before authentication succeeds.
+- **Missing or changed master key:** restore the exact key used when the profile
+  was created. Creating a new value is not rotation and cannot decrypt the
+  profile; no automatic recovery path exists.
+- **Schema or quota incompatibility:** use the content-free bootstrap error
+  details to compare required and available values, then upgrade the
+  incompatible peer or reduce unsupported requirements before retrying. Link
+  completion cannot bypass `personal_context_schema_incompatible` or
+  `personal_context_quota_incompatible`.
+- **REST edit absent from Chatbook:** ordinary server REST record and proposal
+  mutations are not published to linked clients. Preserve the server state,
+  avoid duplicating the record blindly, and use Chatbook for future edits that
+  must use the linked Sync path. Retrying Sync alone cannot publish the REST
+  mutation because no server-origin publication path currently exists.

--- a/Docs/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/User_Guides/Server/Personal_Context_Profile.md
@@ -4,7 +4,7 @@
 
 tldw_server is the authenticated home peer and canonical server copy of a
 Personal Context Profile. [Chatbook is the current full profile editing and
-interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md).
+interview interface](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs%2FUser_Guide%2Fsettings%2Fpersonal-context-profile.md).
 The server does not currently provide a complete standalone profile editor.
 
 A standalone Chatbook profile and an existing server profile are independent

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -48,6 +48,7 @@ Common workflows:
 
 - **Find the right WebUI or extension page**: use the [WebUI and extension guide](WebUI/index.md) and [page and feature index](WebUI/Page_Feature_Index.md).
 - **Chat with models and characters**: use [Chat pages](WebUI_Extension/Chat_Pages.md), [Chat API documentation](../API-related/Chat_API_Documentation.md), [Character roleplay quickstart](WebUI_Extension/Character_Roleplay_Quickstart.md), [Character cards and character chat](Server/Character_Cards_User_Guide.md), and [Personas](Server/Personas_User_Guide.md).
+- **Set up and operate a Personal Context Profile**: use the [Personal Context Profile guide](Server/Personal_Context_Profile.md) for master-key setup, Chatbook linking, exports, and recovery boundaries.
 - **Add sources and media**: use [Media to RAG evals workflow](Server/Media_to_RAG_Evals_Workflow.md), [Web scraping and ingestion](Server/Web_Scraping_Ingestion_Guide.md), [Media ingest jobs API](../API-related/Media_Ingest_Jobs_API.md), and [Bulk conference playlist ingest](Bulk_Conference_Playlist_Ingest.md).
 - **Search and ask questions over knowledge**: use [RAG API guide](../API-related/RAG-API-Guide.md), [RAG production configuration](Server/RAG_Production_Configuration_Guide.md), and [Quick Chat Docs Assistant](WebUI_Extension/Quick_Chat_Docs_Assistant_Guide.md).
 - **Transcribe and generate speech**: use [Getting started with STT and TTS](WebUI_Extension/Getting-Started-STT_and_TTS.md), [Audio transcription API](../API-related/Audio_Transcription_API.md), [Native batch STT benchmark](STT_Benchmark_User_Guide.md), and [TTS getting started](WebUI_Extension/TTS_Getting_Started.md).
@@ -63,6 +64,7 @@ Start with the guide that matches the failing surface:
 
 - Setup and profile issues: [self-hosting profiles](../Getting_Started/README.md) and [troubleshooting](../Getting_Started/TROUBLESHOOTING.md).
 - Authentication and access issues: [Authentication setup](Server/Authentication_Setup.md), [Multi-user Postgres setup](Server/Multi-User_Postgres_Setup.md), and [Multi-user SQLite setup](Server/Multi-User_SQLite_Setup.md).
+- Personal Context issues: use the [Personal Context Profile guide](Server/Personal_Context_Profile.md) for locked profiles, Sync/link states, version conflicts, and purge-pending limitations.
 - Provider and model issues: [BYOK user guide](Server/BYOK_User_Guide.md), [OpenAI OAuth first-time setup](Server/OpenAI_OAuth_First_Time_Setup.md), [local LLM setup](Integrations_Experiments/Setting_up_a_local_LLM.md), and [Providers API documentation](../API-related/Providers_API_Documentation.md).
 - Media and ingestion issues: [Web scraping and ingestion](Server/Web_Scraping_Ingestion_Guide.md), [Media ingest jobs API](../API-related/Media_Ingest_Jobs_API.md), and [Chunking templates user guide](Server/Chunking_Templates_User_Guide.md).
 - Audio issues: [CPU audio setup](../Getting_Started/First_Time_Audio_Setup_CPU.md), [GPU or accelerated audio setup](../Getting_Started/First_Time_Audio_Setup_GPU_Accelerated.md), and [TTS setup guide](WebUI_Extension/TTS-SETUP-GUIDE.md).

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
           - GPU or Accelerated Audio Setup: Getting_Started/First_Time_Audio_Setup_GPU_Accelerated.md
       - Admin and Operations:
           - Authentication Setup: User_Guides/Server/Authentication_Setup.md
+          - Personal Context Profile: User_Guides/Server/Personal_Context_Profile.md
           - Production Hardening: User_Guides/Server/Production_Hardening_Checklist.md
           - Organizations and Sharing: User_Guides/Server/Organizations_and_Sharing.md
           - BYOK User Guide: User_Guides/Server/BYOK_User_Guide.md
@@ -143,12 +144,14 @@ nav:
           - API Documentation Index: API-related/API_README.md
           - API Design: API-related/API_Design.md
           - API Tag Index: API-related/API_Tags_Index.md
+          - Personal Context API: API-related/Personal_Context_API.md
           - Providers API: API-related/Providers_API_Documentation.md
           - Character Chat Sessions API: API-related/Character_Chat_Sessions_API.md
           - Tools API: API-related/Tools_API_Documentation.md
           - Storage API: API-related/Storage_API_Documentation.md
       - Backend Code Guides:
           - Chat Developer Guide: Code_Documentation/Chat_Developer_Guide.md
+          - Personal Context Developer Guide: Code_Documentation/Personal_Context_Developer_Guide.md
           - Character Chat Code Guide: Code_Documentation/Guides/Character_Chat_Code_Guide.md
           - RAG Developer Guide: Code_Documentation/RAG-Developer-Guide.md
           - Embeddings Developer Guide: Code_Documentation/Embeddings-Developer-Guide.md

--- a/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
+++ b/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
@@ -676,7 +676,7 @@ Expected: generated output is committed and the worktree is clean before task cl
 
 - Modify: `backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md`
 
-- [ ] **Step 1: Complete all ACs and DoD items, record evidence, and mark Done as the final repository mutation**
+- [x] **Step 1: Complete all ACs and DoD items, record evidence, and mark Done as the final repository mutation**
 
 Run, replacing the bracketed evidence with the exact commands and results from Task 5. If any skip or blocker exists, replace `Known skips/blockers: none` with the actual list before running the second command that checks DoD item 6:
 

--- a/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
+++ b/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
@@ -418,12 +418,12 @@ git commit -m "docs: publish Personal Context guide navigation"
 Run:
 
 ```bash
+set -e -o pipefail
 git fetch origin dev
 git rebase origin/dev
 backlog task 13151 --plain
 rg -n "TASK-13151|Document Personal Context Profile server" \
   "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
-set -o pipefail
 profile_task_matches=$(
   {
     git for-each-ref --format='%(refname)' refs/heads refs/remotes |
@@ -570,6 +570,7 @@ Expected: selected tests pass.
 Run:
 
 ```bash
+set -e
 profile_operator_guide=Docs/User_Guides/Server/Personal_Context_Profile.md
 profile_developer_guide=Docs/Code_Documentation/Personal_Context_Developer_Guide.md
 profile_api_reference=Docs/API-related/Personal_Context_API.md

--- a/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
+++ b/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
@@ -1,0 +1,568 @@
+# Personal Context Profile Server Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish accurate tldw_server operator and developer documentation for Personal Context storage, APIs, and the currently shipped Sync-v2 boundary.
+
+**Architecture:** Add one operator guide and one developer guide, update the existing API reference where it has fallen behind merged Sync-v2 behavior, and expose all three through the curated MkDocs structure. Treat canonical `Docs/` files as source, regenerate `Docs/Published/` deterministically, and distinguish protocol support from missing server-origin publication and purge-acknowledgement workflows.
+
+**Tech Stack:** Markdown, MkDocs Material, Backlog.md, Git, GitHub, existing Python/pytest contract checks
+
+**Backlog task:** TASK-13151
+
+**Design specification:** `https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/superpowers/specs/2026-08-31-personal-context-documentation-design.md`
+
+---
+
+## File map
+
+**Create**
+
+- `Docs/User_Guides/Server/Personal_Context_Profile.md` — operator lifecycle, setup, Chatbook linking, API use, export, purge warning, and troubleshooting.
+- `Docs/Code_Documentation/Personal_Context_Developer_Guide.md` — shared contract, encrypted storage, service/API/Sync boundaries, current gaps, extension checklist, and test map.
+
+**Modify**
+
+- `Docs/API-related/Personal_Context_API.md` — preserve endpoint reference while correcting stale Sync wording and documenting publication/purge limits.
+- `Docs/User_Guides/index.md` — add common-workflow and troubleshooting links.
+- `Docs/Code_Documentation/index.md` — add the developer guide.
+- `Docs/API-related/API_README.md` — link the API/operator/developer guides.
+- `Docs/mkdocs.yml` — add User Wiki, API/contracts, and backend-guide entries.
+- `Docs/Published/**` — generated only by `Helper_Scripts/refresh_docs_published.sh`.
+- `Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md` — this executable plan.
+- `backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md` — plan, acceptance criteria, evidence, ADR result, and implementation notes.
+
+**Inspect but do not duplicate**
+
+- `Docs/Design/2026-08-30-personal-context-profile-server-design.md`
+- `backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md`
+- `Docs/Code_Documentation/Docs_Site_Guide.md`
+- `packages/tldw_profile_core/`
+- `tldw_Server_API/app/core/Personalization/personal_context_*.py`
+- `tldw_Server_API/app/core/Sync/v2/`
+
+## Cross-repository execution prerequisite
+
+Completed before server execution. The approved design is published at the stable Chatbook `dev` URL:
+
+`https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/superpowers/specs/2026-08-31-personal-context-documentation-design.md`
+
+The publication record is `TASK-27016`. PR [#2292](https://github.com/rmusser01/tldw_chatbook/pull/2292) published the reviewed design, and correction PR [#2294](https://github.com/rmusser01/tldw_chatbook/pull/2294) fixed its publication record. GitHub API verification on 2026-09-01 confirmed both PRs are merged and the specification is present on Chatbook `dev`.
+
+### Task 1: Rebase and establish merged server truth
+
+**Files:**
+
+- Inspect: all paths in the file map
+- Modify: `backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md`
+
+- [x] **Step 1: Rebase the isolated branch on current `dev`**
+
+Run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+```
+
+Expected: docs describe only code merged to `dev`, never unmerged follow-up branch behavior.
+
+- [x] **Step 2: Verify Backlog ownership, the reviewed specification, and workflow lessons**
+
+The spec-only Chatbook PR must be merged into `dev` before server execution so the cross-repository reference is stable. Run:
+
+```bash
+backlog task 13151 --plain
+rg -n "TASK-13151|Document Personal Context Profile server" \
+  "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+gh api -X GET repos/rmusser01/tldw_chatbook/contents/Docs/superpowers/specs/2026-08-31-personal-context-documentation-design.md \
+  -f ref=dev
+sed -n '1,240p' backlog/docs/lessons-testing-evidence.md
+sed -n '1,220p' backlog/docs/lessons-backlog-hygiene.md
+```
+
+Expected: TASK-13151 resolves to this documentation file and is assigned to `@codex`; the reviewed specification on Chatbook `dev` returns file metadata; no duplicate task ID appears. Repeat the task-resolution check after every rebase. Backlog MCP is not available in this repository, so use the Backlog CLI throughout.
+
+Run this all-ref/all-worktree collision sweep now and after the final rebase:
+
+```bash
+profile_task_matches=$(
+  {
+    git for-each-ref --format='%(refname)' refs/heads refs/remotes |
+      while IFS= read -r profile_ref; do
+        git grep -l '^id: TASK-13151$' "$profile_ref" -- 'backlog/tasks/*.md' 2>/dev/null || true
+      done | sed 's/^[^:]*://'
+    git worktree list --porcelain |
+      awk '$1 == "worktree" { sub(/^worktree /, ""); print }' |
+      while IFS= read -r profile_worktree; do
+        rg -l '^id: TASK-13151$' "$profile_worktree/backlog/tasks" 2>/dev/null || true
+      done
+  } | awk -F/ '{ print $NF }' | sort -u
+)
+printf '%s\n' "$profile_task_matches"
+test "$profile_task_matches" = "task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+```
+
+Expected: the only unique matching task filename is the intended TASK-13151 record.
+
+- [x] **Step 3: Confirm Shared Core pin and parity authority**
+
+Run:
+
+```bash
+rg -n "version = \"0\.1\.0\"" packages/tldw_profile_core/pyproject.toml
+rg -n "digest|parity|tldw_profile_core" \
+  tldw_Server_API/tests/Personalization/test_personal_context_contract.py \
+  backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md \
+  Docs/Design/2026-08-30-personal-context-profile-server-design.md
+```
+
+Expected: version `0.1.0` and current parity/digest authority are identifiable.
+
+- [x] **Step 4: Confirm current REST, Sync, and purge boundaries**
+
+Run:
+
+```bash
+rg -n "def (create_record|update_record|create_proposal|purge_profile)|/purge" \
+  tldw_Server_API/app/api/v1/endpoints/personal_context.py
+rg -n "personal_context\.(manifest|scope|record|proposal|purge)" \
+  tldw_Server_API/app/core/Sync/v2 tldw_Server_API/tests/Sync
+rg -n "purge_pending|synchronization acknowledgment|Sync endpoints" \
+  Docs/API-related/Personal_Context_API.md \
+  tldw_Server_API/app/core/Personalization \
+  tldw_Server_API/app/core/Sync/v2
+```
+
+Expected: five protocol domains plus bootstrap/inbound adapters exist; no ordinary REST-to-Sync publication seam or purge-envelope publication/acknowledgement completion is found.
+
+- [x] **Step 5: Record the plan and ADR result in TASK-13151**
+
+Run:
+
+```bash
+backlog task edit 13151 --plan $'1. Rebase and inventory merged behavior.\n2. Add server operator guide.\n3. Add developer guide and correct API reference.\n4. Add indexes and MkDocs navigation.\n5. Final rebase, regenerate curated docs, strict validation.\n6. Complete notes and open docs-only PR.\n\nADR required: no\nADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md\nReason: Documentation only; the existing Personal Context authority, Sync, and encryption ADR applies.'
+```
+
+- [x] **Step 6: Commit the plan and task metadata**
+
+Run:
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md \
+  "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+git commit -m "docs: plan server Personal Context guides"
+```
+
+### Task 2: Add the operator and user guide
+
+**Files:**
+
+- Create: `Docs/User_Guides/Server/Personal_Context_Profile.md`
+
+- [ ] **Step 1: Write purpose and product boundaries**
+
+State that tldw_server is the authenticated home peer/canonical server copy, Chatbook is the current full editing/interview UI, no complete standalone server profile editor exists, and standalone peers become one canonical linked profile only after reviewed reconciliation and link completion. Link:
+
+`https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md`
+
+- [ ] **Step 2: Document prerequisites and safe key setup**
+
+Cover successful API-key/JWT authentication; `TLDW_PERSONAL_CONTEXT_MASTER_KEY` as strict base64 for exactly 32 bytes; secure backup before profile creation; fail-closed behavior for missing/malformed/changed keys; and one manifest per authenticated user's `Personalization.db`. Include a standard-library generation example but no fixed key and no advice to commit it.
+
+- [ ] **Step 3: Add setup and status workflow**
+
+Document configuration before start, server status/capability confirmation, manifest inspection/creation when needed, reviewed linking from Chatbook before upload, and Chatbook editing for changes expected to use current linked Sync. Link endpoint details to `../../API-related/Personal_Context_API.md`.
+
+- [ ] **Step 4: Add current sync/non-sync matrix**
+
+Include this deliberately identical shared-contract block, with the markers retained so Chatbook can check it automatically:
+
+```markdown
+<!-- shared-personal-context-contract:start -->
+- `tldw_profile_core` defines the versioned canonical profile object models, exact canonical bytes, interview/tool contracts, serialization, and validation used by both peers. Sync-v2 transport envelopes are a separate contract.
+- After a successful reviewed link, Chatbook and tldw_server converge on the same canonical manifest, scope, record, proposal, and version identities and bytes for eligible shared objects.
+- Sync V2 defines the `personal_context.manifest`, `personal_context.scope`, `personal_context.record`, `personal_context.proposal`, and content-free `personal_context.purge` domains. The current linked flow publishes eligible Chatbook-originated manifest, scope, record, and proposal changes; purge production and distribution are not wired end to end.
+- Each peer retains its own at-rest ciphertext and keys, local database rows, runtime permissions, conflict-review metadata, acknowledgement tracking, and other operational state.
+<!-- shared-personal-context-contract:end -->
+```
+
+Follow it with this full matrix:
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+Then add these server-specific notes:
+
+- Current flow accepts eligible Chatbook-originated manifest, scope, record/tombstone, and proposal changes.
+- The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
+- Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
+
+- [ ] **Step 5: Document export, local removal, and purge accurately**
+
+Explain export confirmations/sensitivity; Chatbook ownership of local-copy removal; server rejection of `local_copy`; and `POST /purge` requiring `DELETE EVERYWHERE`, advancing a server-local fence, removing canonical bodies/runtime state, blocking mutations, and remaining `purge_pending`. State that the protocol purge domain exists but the endpoint does not publish it and acknowledgement completion is not wired. Do not promise reconnecting devices clears the state.
+
+- [ ] **Step 6: Add troubleshooting**
+
+Use these exact seven failure-state labels and give a cause, safe next action, and current product limit for each:
+
+1. **Profile locked**
+2. **Offline or queued**
+3. **Capability not negotiated**
+4. **Version conflict**
+5. **First-link semantic collision**
+6. **Post-link semantic collision**
+7. **Purge pending**
+
+Also cover authentication failure, missing/changed key, schema/quota incompatibility, and a REST edit absent from Chatbook. Explicitly state when no resolver or completion path exists.
+
+- [ ] **Step 7: Validate and commit**
+
+Run:
+
+```bash
+test -f Docs/API-related/Personal_Context_API.md
+rg -n "does not provide|not currently published|does not publish|purge_pending|not wired" \
+  Docs/User_Guides/Server/Personal_Context_Profile.md
+git diff --check -- Docs/User_Guides/Server/Personal_Context_Profile.md
+git add Docs/User_Guides/Server/Personal_Context_Profile.md
+git commit -m "docs: add Personal Context server operator guide"
+```
+
+### Task 3: Add developer guide and correct API reference
+
+**Files:**
+
+- Create: `Docs/Code_Documentation/Personal_Context_Developer_Guide.md`
+- Modify: `Docs/API-related/Personal_Context_API.md`
+
+- [ ] **Step 1: Write contract, ownership, and crypto sections**
+
+Cover `tldw-profile-core==0.1.0`, parity/digest authority, separate Sync envelopes, authenticated per-user `Personalization.db`, root/profile/object key hierarchy, fail-closed locked state, and peer-local at-rest keys versus wrapped server-owned Sync integrity key. Use stable GitHub links for source-only documents:
+
+- `https://github.com/rmusser01/tldw_server/blob/dev/Docs/Design/2026-08-30-personal-context-profile-server-design.md`
+- `https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md`
+
+- [ ] **Step 2: Add exact component map**
+
+Document:
+
+- `tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py` — authenticated service dependency
+- `tldw_Server_API/app/api/v1/schemas/personal_context.py` — HTTP schemas
+- `tldw_Server_API/app/api/v1/endpoints/personal_context.py` — REST translation
+- `tldw_Server_API/app/core/DB_Management/Personal_Context_Key_Store.py` — real root/profile key-custody owner
+- `tldw_Server_API/app/core/Personalization/personal_context_key_provider.py` — compatibility re-export, not the custody owner
+- `tldw_Server_API/app/core/Personalization/personal_context_crypto.py` — envelopes/wrapping
+- `tldw_Server_API/app/core/Personalization/personal_context_repository.py` — versions, heads, fences
+- `tldw_Server_API/app/core/Personalization/personal_context_service.py` — canonical business boundary
+- `tldw_Server_API/app/core/Personalization/personal_context_export.py` — exports
+- `tldw_Server_API/app/core/Personalization/personal_context_runtime_policy.py` — server-local runtime
+- `tldw_Server_API/app/core/Sync/v2/profile.py` — bootstrap, binding, key wrapping, completion
+- `tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py` — transport validation/encryption
+- `tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py` — inbound service projection
+
+State that endpoints, agents, Sync, and future publishers never access profile tables directly.
+
+- [ ] **Step 3: Document REST and Sync separately**
+
+REST:
+
+`authentication -> PersonalContextService -> encrypted repository -> response`
+
+Sync/bootstrap:
+
+`capability negotiation -> registered device -> reviewed Chatbook plan -> snapshot/wrapped integrity key -> completion -> inbound validation/materialization`
+
+Name all five domains and state current gaps: no REST mutation publication, no dedicated post-link resolver, and no purge envelope production/distribution/acknowledgement completion.
+
+Repeat the full boundary matrix in developer terms so every shared and peer-local category is explicit:
+
+| Shared through the current linked flow when eligible | Remains peer-local or is not currently published |
+| --- | --- |
+| Canonical manifest after successful reviewed linking | Peer-local at-rest encryption and recovery keys |
+| Required global and linked-workspace scope objects | Raw interview answers and unfinished drafts |
+| Records and tombstones whose controls permit synchronization | Runtime agent authority grants and tool availability |
+| Eligible proposals and their canonical review state | Device-only records or records marked non-syncable |
+| Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
+| — | Conflict-review objects and acknowledgement tracking |
+
+- [ ] **Step 4: Add the complete extension checklist and test map**
+
+Include all ten checklist items:
+
+1. Decide whether the change affects the shared contract or only one peer.
+2. Make shared canonical object changes in `tldw_profile_core` first; change Sync transport separately.
+3. Preserve canonical identities and explicit syncability.
+4. Route through the owning service; never access profile tables directly.
+5. Enforce authority, scope, expiry, visibility, and secret-rejection rules.
+6. Keep plaintext out of logs, diagnostics, outbox metadata, and unencrypted fixtures.
+7. Add parity/conformance coverage in both repositories.
+8. Add peer-specific migration, repository, service, API/UI, and recovery tests.
+9. Update the governing ADR for storage, ownership, encryption, Sync, or authority changes.
+10. Update both documentation sets whenever the shared contract changes.
+
+Map these exact suites:
+
+- `packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py`
+- `tldw_Server_API/tests/Personalization/test_personal_context_contract.py`
+- `tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py`
+- `tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py`
+- `tldw_Server_API/tests/Personalization/integration/test_personal_context_composed_app.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py`
+
+- [ ] **Step 5: Correct the API Sync boundary**
+
+Replace the blanket closing statement with `REST and Sync-v2 boundary`:
+
+- REST and Sync V2 are separate surfaces over the canonical service/repository.
+- Sync supports negotiation, bootstrap/link completion, and inbound Chatbook-originated domains.
+- REST edits are not published to linked clients.
+- Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.
+
+- [ ] **Step 6: Validate and commit**
+
+Run:
+
+```bash
+test -f packages/tldw_profile_core/pyproject.toml
+test -f tldw_Server_API/app/core/DB_Management/Personal_Context_Key_Store.py
+test -f tldw_Server_API/app/core/Personalization/personal_context_service.py
+test -f tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
+test -f tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py
+rg -n "not currently published|does not publish|no dedicated|acknowledgement" \
+  Docs/Code_Documentation/Personal_Context_Developer_Guide.md \
+  Docs/API-related/Personal_Context_API.md
+git diff --check -- Docs/Code_Documentation/Personal_Context_Developer_Guide.md Docs/API-related/Personal_Context_API.md
+git add Docs/Code_Documentation/Personal_Context_Developer_Guide.md Docs/API-related/Personal_Context_API.md
+git commit -m "docs: document Personal Context server internals"
+```
+
+### Task 4: Add indexes and MkDocs navigation
+
+**Files:**
+
+- Modify: `Docs/User_Guides/index.md`
+- Modify: `Docs/Code_Documentation/index.md`
+- Modify: `Docs/API-related/API_README.md`
+- Modify: `Docs/mkdocs.yml`
+- Inspect: `Docs/Code_Documentation/README.md`
+
+- [ ] **Step 1: Add discovery links**
+
+- Add Personal Context to user common workflows and troubleshooting.
+- Add `Personal Context Profile: Personal_Context_Developer_Guide.md` under Chat & Knowledge.
+- Replace the code-formatted API path with relative links to the API, operator, and developer guides.
+- Leave `Docs/Code_Documentation/README.md` unchanged unless its organization clearly requires an entry; record the decision.
+
+- [ ] **Step 2: Add concise MkDocs entries**
+
+- User Wiki > Admin and Operations: `Personal Context Profile`.
+- Developer Wiki > API and Contracts: `Personal Context API`.
+- Developer Wiki > Backend Code Guides: `Personal Context Developer Guide`.
+
+- [ ] **Step 3: Validate and commit**
+
+Run:
+
+```bash
+test -f Docs/User_Guides/Server/Personal_Context_Profile.md
+test -f Docs/API-related/Personal_Context_API.md
+test -f Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+rg -n "Personal Context" Docs/User_Guides/index.md Docs/Code_Documentation/index.md Docs/API-related/API_README.md Docs/mkdocs.yml
+git diff --check -- Docs/User_Guides/index.md Docs/Code_Documentation/index.md Docs/API-related/API_README.md Docs/mkdocs.yml
+git add Docs/User_Guides/index.md Docs/Code_Documentation/index.md Docs/API-related/API_README.md Docs/mkdocs.yml
+git commit -m "docs: publish Personal Context guide navigation"
+```
+
+### Task 5: Final rebase, generate, and strictly verify published docs
+
+**Files:**
+
+- Generate: `Docs/Published/**`
+- Verify: all changed canonical docs
+
+- [ ] **Step 1: Perform the final rebase before generation and task closeout**
+
+Run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+backlog task 13151 --plain
+rg -n "TASK-13151|Document Personal Context Profile server" \
+  "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+profile_task_matches=$(
+  {
+    git for-each-ref --format='%(refname)' refs/heads refs/remotes |
+      while IFS= read -r profile_ref; do
+        git grep -l '^id: TASK-13151$' "$profile_ref" -- 'backlog/tasks/*.md' 2>/dev/null || true
+      done | sed 's/^[^:]*://'
+    git worktree list --porcelain |
+      awk '$1 == "worktree" { sub(/^worktree /, ""); print }' |
+      while IFS= read -r profile_worktree; do
+        rg -l '^id: TASK-13151$' "$profile_worktree/backlog/tasks" 2>/dev/null || true
+      done
+  } | awk -F/ '{ print $NF }' | sort -u
+)
+printf '%s\n' "$profile_task_matches"
+test "$profile_task_matches" = "task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+```
+
+Expected: the branch is based on current `origin/dev`, and TASK-13151 still resolves to the intended task after the rebase. There must be no later rebase after the task is marked Done.
+
+- [ ] **Step 2: Refresh and stage the curated tree**
+
+Run:
+
+```bash
+bash Helper_Scripts/refresh_docs_published.sh
+git add Docs/Published
+```
+
+- [ ] **Step 3: Prove a second refresh is idempotent**
+
+Run:
+
+```bash
+bash Helper_Scripts/refresh_docs_published.sh
+git diff --exit-code -- Docs/Published
+git diff --check --cached
+```
+
+Expected: no unstaged generated diff and no whitespace errors in the staged generated output.
+
+- [ ] **Step 4: Run public/private and strict MkDocs checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/docs/check_public_private_boundary.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mkdocs build --strict -f Docs/mkdocs.yml
+```
+
+Expected: boundary check reports OK; MkDocs builds with zero warnings.
+
+- [ ] **Step 5: Run targeted Shared Core, endpoint, custody, composed-app, bootstrap, materializer, and transport tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q \
+  packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_contract.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py \
+  tldw_Server_API/tests/Personalization/integration/test_personal_context_composed_app.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py
+```
+
+Expected: selected tests pass.
+
+- [ ] **Step 6: Run claim, failure-state, source-link, and diff guards**
+
+Run:
+
+```bash
+rg -n "not currently published|does not publish|no dedicated Personal Context|not wired" \
+  Docs/User_Guides/Server/Personal_Context_Profile.md \
+  Docs/Code_Documentation/Personal_Context_Developer_Guide.md \
+  Docs/API-related/Personal_Context_API.md
+for profile_label in \
+  "Profile locked" \
+  "Offline or queued" \
+  "Capability not negotiated" \
+  "Version conflict" \
+  "First-link semantic collision" \
+  "Post-link semantic collision" \
+  "Purge pending"; do
+  rg -Fq "$profile_label" Docs/User_Guides/Server/Personal_Context_Profile.md || {
+    echo "Missing failure-state label: $profile_label"
+    exit 1
+  }
+done
+set +e
+rg -n '\]\((\.\./)+(Docs/)?(Design|backlog)/' \
+  Docs/Published/User_Guides/Server/Personal_Context_Profile.md \
+  Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+profile_link_guard_status=$?
+set -e
+if [ "$profile_link_guard_status" -eq 0 ]; then
+  echo "Unexpected source-only relative link in published docs"
+  exit 1
+elif [ "$profile_link_guard_status" -gt 1 ]; then
+  echo "Source-only link guard failed to execute"
+  exit "$profile_link_guard_status"
+else
+  echo "Published docs contain no source-only relative links"
+fi
+git diff --check origin/dev...HEAD
+git diff --check --cached
+git status --short
+git diff --stat origin/dev...HEAD
+git diff --stat --cached
+```
+
+Expected: limitations and all seven failure states are explicit; the expected no-match source-link guard succeeds; only task/plan/canonical/generated docs changed.
+
+- [ ] **Step 7: Commit generated output and recheck the committed diff**
+
+Run:
+
+```bash
+git commit -m "docs: refresh published Personal Context guides"
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: generated output is committed and the worktree is clean before task closeout.
+
+### Task 6: Close TASK-13151 and open the server PR
+
+**Files:**
+
+- Modify: `backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md`
+
+- [ ] **Step 1: Complete all ACs and DoD items, record evidence, and mark Done as the final repository mutation**
+
+Run, replacing the bracketed evidence with the exact commands and results from Task 5:
+
+```bash
+backlog task edit 13151 \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 \
+  --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --check-dod 5 --check-dod 6 \
+  --notes "Implemented the server Personal Context operator and developer guides, corrected API Sync wording, added discovery/navigation, regenerated published docs, and documented the exact shared-contract block, full boundary matrix, seven failure states, current limitations, and ten-item extension checklist. Verification: [exact Task 5 results]. ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: documentation only; the existing Personal Context authority, Sync, and encryption ADR applies. Bandit: not applicable because only documentation and task metadata changed. Lessons learned: [record a genuine lesson with its incident, or state none]." \
+  --final-summary "Published accurate Personal Context operator, API, architecture, Sync-boundary, and troubleshooting documentation with reproducible generated output." \
+  -s Done
+backlog task 13151 --plain
+git add "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+git diff --check --cached
+git commit -m "docs: close server Personal Context documentation task"
+```
+
+Expected: every AC and DoD item is checked, evidence and Implementation Notes are present, and TASK-13151 is Done. Do not rebase or modify repository files after this commit.
+
+- [ ] **Step 2: Push and open the PR against `dev`**
+
+Prepare `/tmp/personal-context-server-pr.md` with summary, current limitations, and exact evidence, then run:
+
+```bash
+git push -u origin codex/personal-context-documentation
+gh pr create --base dev --head codex/personal-context-documentation --title "docs: add Personal Context operator and developer guides" --body-file /tmp/personal-context-server-pr.md
+```
+
+Expected: a docs-only server PR against `dev`. Merge it before finalizing Chatbook's stable server links.
+
+- [ ] **Step 3: Satisfy the human-authored Change summary merge gate**
+
+After the PR is open, ask the requester to write the required `Change summary` in their own words, explaining both what changed and why these documentation choices were made. The generated PR body and any AI-authored draft do not satisfy this gate. Do not call the PR merge-ready or merge it until the requester has supplied that summary and all required checks/reviews are green.

--- a/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
+++ b/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
@@ -162,21 +162,21 @@ git commit -m "docs: plan server Personal Context guides"
 
 - Create: `Docs/User_Guides/Server/Personal_Context_Profile.md`
 
-- [ ] **Step 1: Write purpose and product boundaries**
+- [x] **Step 1: Write purpose and product boundaries**
 
 State that tldw_server is the authenticated home peer/canonical server copy, Chatbook is the current full editing/interview UI, no complete standalone server profile editor exists, and standalone peers become one canonical linked profile only after reviewed reconciliation and link completion. Link:
 
 `https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/settings/personal-context-profile.md`
 
-- [ ] **Step 2: Document prerequisites and safe key setup**
+- [x] **Step 2: Document prerequisites and safe key setup**
 
 Cover successful API-key/JWT authentication; `TLDW_PERSONAL_CONTEXT_MASTER_KEY` as strict base64 for exactly 32 bytes; secure backup before profile creation; fail-closed behavior for missing/malformed/changed keys; and one manifest per authenticated user's `Personalization.db`. Include a standard-library generation example but no fixed key and no advice to commit it.
 
-- [ ] **Step 3: Add setup and status workflow**
+- [x] **Step 3: Add setup and status workflow**
 
 Document configuration before start, server status/capability confirmation, manifest inspection/creation when needed, reviewed linking from Chatbook before upload, and Chatbook editing for changes expected to use current linked Sync. Link endpoint details to `../../API-related/Personal_Context_API.md`.
 
-- [ ] **Step 4: Add current sync/non-sync matrix**
+- [x] **Step 4: Add current sync/non-sync matrix**
 
 Include this deliberately identical shared-contract block, with the markers retained so Chatbook can check it automatically:
 
@@ -206,11 +206,11 @@ Then add these server-specific notes:
 - The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
 - Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
 
-- [ ] **Step 5: Document export, local removal, and purge accurately**
+- [x] **Step 5: Document export, local removal, and purge accurately**
 
 Explain export confirmations/sensitivity; Chatbook ownership of local-copy removal; server rejection of `local_copy`; and `POST /purge` requiring `DELETE EVERYWHERE`, advancing a server-local fence, removing canonical bodies/runtime state, blocking mutations, and remaining `purge_pending`. Include the exact sentence `The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.` Do not promise reconnecting devices clears the state.
 
-- [ ] **Step 6: Add troubleshooting**
+- [x] **Step 6: Add troubleshooting**
 
 Use these exact seven failure-state labels and give a cause, safe next action, and current product limit for each:
 
@@ -224,7 +224,7 @@ Use these exact seven failure-state labels and give a cause, safe next action, a
 
 Also cover authentication failure, missing/changed key, schema/quota incompatibility, and a REST edit absent from Chatbook. Explicitly state when no resolver or completion path exists.
 
-- [ ] **Step 7: Validate and commit**
+- [x] **Step 7: Validate and commit**
 
 Run:
 
@@ -251,14 +251,14 @@ git commit -m "docs: add Personal Context server operator guide"
 - Create: `Docs/Code_Documentation/Personal_Context_Developer_Guide.md`
 - Modify: `Docs/API-related/Personal_Context_API.md`
 
-- [ ] **Step 1: Write contract, ownership, and crypto sections**
+- [x] **Step 1: Write contract, ownership, and crypto sections**
 
 Cover `tldw-profile-core==0.1.0`, parity/digest authority, separate Sync envelopes, authenticated per-user `Personalization.db`, root/profile/object key hierarchy, fail-closed locked state, and peer-local at-rest keys versus wrapped server-owned Sync integrity key. Use stable GitHub links for source-only documents:
 
 - `https://github.com/rmusser01/tldw_server/blob/dev/Docs/Design/2026-08-30-personal-context-profile-server-design.md`
 - `https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md`
 
-- [ ] **Step 2: Add exact component map**
+- [x] **Step 2: Add exact component map**
 
 Document:
 
@@ -278,7 +278,7 @@ Document:
 
 State that endpoints, agents, Sync, and future publishers never access profile tables directly.
 
-- [ ] **Step 3: Document REST and Sync separately**
+- [x] **Step 3: Document REST and Sync separately**
 
 REST:
 
@@ -306,7 +306,7 @@ Repeat the full boundary matrix in developer terms so every shared and peer-loca
 | Exact canonical object identities, versions, and bytes for eligible shared objects | Local undo history, caches, ciphertext, database row identities, and other operational metadata |
 | — | Conflict-review objects and acknowledgement tracking |
 
-- [ ] **Step 4: Add the complete extension checklist and test map**
+- [x] **Step 4: Add the complete extension checklist and test map**
 
 Include all ten checklist items:
 
@@ -332,7 +332,7 @@ Map these exact suites:
 - `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py`
 - `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py`
 
-- [ ] **Step 5: Correct the API Sync boundary**
+- [x] **Step 5: Correct the API Sync boundary**
 
 Replace the blanket closing statement with `REST and Sync-v2 boundary`:
 
@@ -341,7 +341,7 @@ Replace the blanket closing statement with `REST and Sync-v2 boundary`:
 - REST edits are not published to linked clients.
 - Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.
 
-- [ ] **Step 6: Validate and commit**
+- [x] **Step 6: Validate and commit**
 
 Run:
 
@@ -379,20 +379,20 @@ git commit -m "docs: document Personal Context server internals"
 - Modify: `Docs/mkdocs.yml`
 - Inspect: `Docs/Code_Documentation/README.md`
 
-- [ ] **Step 1: Add discovery links**
+- [x] **Step 1: Add discovery links**
 
 - Add Personal Context to user common workflows and troubleshooting.
 - Add `Personal Context Profile: Personal_Context_Developer_Guide.md` under Chat & Knowledge.
 - Replace the code-formatted API path with relative links to the API, operator, and developer guides.
 - Leave `Docs/Code_Documentation/README.md` unchanged unless its organization clearly requires an entry; record the decision.
 
-- [ ] **Step 2: Add concise MkDocs entries**
+- [x] **Step 2: Add concise MkDocs entries**
 
 - User Wiki > Admin and Operations: `Personal Context Profile`.
 - Developer Wiki > API and Contracts: `Personal Context API`.
 - Developer Wiki > Backend Code Guides: `Personal Context Developer Guide`.
 
-- [ ] **Step 3: Validate and commit**
+- [x] **Step 3: Validate and commit**
 
 Run:
 
@@ -413,7 +413,7 @@ git commit -m "docs: publish Personal Context guide navigation"
 - Generate: `Docs/Published/**`
 - Verify: all changed canonical docs
 
-- [ ] **Step 1: Perform the final rebase before generation and task closeout**
+- [x] **Step 1: Perform the final rebase before generation and task closeout**
 
 Run:
 
@@ -502,7 +502,7 @@ fi
 
 Expected: the branch is based on current `origin/dev`; TASK-13151 still resolves uniquely; Shared Core, REST, Sync bootstrap/inbound, and purge boundaries still match the guides' source claims. Any new REST publication or purge-completion seam stops execution for re-inventory. There must be no later rebase after the task is marked Done.
 
-- [ ] **Step 2: Refresh and stage the curated tree**
+- [x] **Step 2: Refresh and stage the curated tree**
 
 Run:
 
@@ -511,7 +511,7 @@ bash Helper_Scripts/refresh_docs_published.sh
 git add Docs/Published
 ```
 
-- [ ] **Step 3: Prove a second refresh is idempotent**
+- [x] **Step 3: Prove a second refresh is idempotent**
 
 Run:
 
@@ -523,7 +523,7 @@ git diff --check --cached
 
 Expected: no unstaged generated diff and no whitespace errors in the staged generated output.
 
-- [ ] **Step 4: Run public/private and strict MkDocs checks**
+- [x] **Step 4: Run public/private and strict MkDocs checks**
 
 Run Steps 4 and 5 in the same shell. Select the checked host interpreter first, fall back to the worktree virtual environment, and fail if neither exists:
 
@@ -537,13 +537,14 @@ if [ ! -x "$profile_python" ]; then
   exit 1
 fi
 printf 'Using project Python: %s\n' "$profile_python"
+"$profile_python" Helper_Scripts/docs/check_top_guides_docs_path_hygiene.py
 "$profile_python" Helper_Scripts/docs/check_public_private_boundary.py
 "$profile_python" -m mkdocs build --strict -f Docs/mkdocs.yml
 ```
 
 Expected: boundary check reports OK; MkDocs builds with zero warnings.
 
-- [ ] **Step 5: Run targeted Shared Core, endpoint, custody, composed-app, bootstrap, materializer, and transport tests**
+- [x] **Step 5: Run targeted Shared Core, endpoint, custody, composed-app, bootstrap, materializer, and transport tests**
 
 Run:
 
@@ -565,7 +566,7 @@ test -x "${profile_python:-}" || {
 
 Expected: selected tests pass.
 
-- [ ] **Step 6: Run claim, failure-state, source-link, and diff guards**
+- [x] **Step 6: Run claim, failure-state, source-link, and diff guards**
 
 Run:
 
@@ -657,7 +658,7 @@ git diff --stat --cached
 
 Expected: each guide independently proves its required shared-contract and current-limit claims; the API independently proves REST publication and purge limits; all seven operator failure states are explicit; the expected no-match source-link guard succeeds; and the allowed-path assertion accepts only task/plan/canonical/generated docs.
 
-- [ ] **Step 7: Commit generated output and recheck the committed diff**
+- [x] **Step 7: Commit generated output and recheck the committed diff**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
+++ b/Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md
@@ -78,8 +78,9 @@ rg -n "TASK-13151|Document Personal Context Profile server" \
 gh api -X GET repos/rmusser01/tldw_chatbook/contents/Docs/superpowers/specs/2026-08-31-personal-context-documentation-design.md \
   -f ref=dev
 sed -n '1,240p' backlog/docs/lessons-testing-evidence.md
-sed -n '1,220p' backlog/docs/lessons-backlog-hygiene.md
 ```
+
+The Backlog hygiene lesson is not present in this server tree. It was consulted read-only from the source Chatbook checkout at `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/backlog/docs/lessons-backlog-hygiene.md`; it is recorded here as execution evidence, not as an in-repository command.
 
 Expected: TASK-13151 resolves to this documentation file and is assigned to `@codex`; the reviewed specification on Chatbook `dev` returns file metadata; no duplicate task ID appears. Repeat the task-resolution check after every rebase. Backlog MCP is not available in this repository, so use the Backlog CLI throughout.
 
@@ -207,7 +208,7 @@ Then add these server-specific notes:
 
 - [ ] **Step 5: Document export, local removal, and purge accurately**
 
-Explain export confirmations/sensitivity; Chatbook ownership of local-copy removal; server rejection of `local_copy`; and `POST /purge` requiring `DELETE EVERYWHERE`, advancing a server-local fence, removing canonical bodies/runtime state, blocking mutations, and remaining `purge_pending`. State that the protocol purge domain exists but the endpoint does not publish it and acknowledgement completion is not wired. Do not promise reconnecting devices clears the state.
+Explain export confirmations/sensitivity; Chatbook ownership of local-copy removal; server rejection of `local_copy`; and `POST /purge` requiring `DELETE EVERYWHERE`, advancing a server-local fence, removing canonical bodies/runtime state, blocking mutations, and remaining `purge_pending`. Include the exact sentence `The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.` Do not promise reconnecting devices clears the state.
 
 - [ ] **Step 6: Add troubleshooting**
 
@@ -229,8 +230,15 @@ Run:
 
 ```bash
 test -f Docs/API-related/Personal_Context_API.md
-rg -n "does not provide|not currently published|does not publish|purge_pending|not wired" \
-  Docs/User_Guides/Server/Personal_Context_Profile.md
+profile_operator_guide=Docs/User_Guides/Server/Personal_Context_Profile.md
+rg -Fq '<!-- shared-personal-context-contract:start -->' "$profile_operator_guide"
+rg -Fq '<!-- shared-personal-context-contract:end -->' "$profile_operator_guide"
+rg -Fq 'Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.' \
+  "$profile_operator_guide"
+rg -Fq 'The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.' \
+  "$profile_operator_guide"
+rg -Fq 'First-link semantic collision' "$profile_operator_guide"
+rg -Fq 'Post-link semantic collision' "$profile_operator_guide"
 git diff --check -- Docs/User_Guides/Server/Personal_Context_Profile.md
 git add Docs/User_Guides/Server/Personal_Context_Profile.md
 git commit -m "docs: add Personal Context server operator guide"
@@ -280,7 +288,12 @@ Sync/bootstrap:
 
 `capability negotiation -> registered device -> reviewed Chatbook plan -> snapshot/wrapped integrity key -> completion -> inbound validation/materialization`
 
-Name all five domains and state current gaps: no REST mutation publication, no dedicated post-link resolver, and no purge envelope production/distribution/acknowledgement completion.
+Name all five domains. Repeat the approved shared-contract statement between the exact `<!-- shared-personal-context-contract:start -->` and `<!-- shared-personal-context-contract:end -->` markers. Include these exact current-limit statements so validation can fail closed:
+
+- `REST edits are not published to linked clients.`
+- `Server purge does not publish the protocol purge envelope, and acknowledgement completion is absent.`
+- `Reviewed first-link reconciliation handles first-link semantic collisions before completion.`
+- `No dedicated post-link semantic-collision resolver exists.`
 
 Repeat the full boundary matrix in developer terms so every shared and peer-local category is explicit:
 
@@ -338,9 +351,19 @@ test -f tldw_Server_API/app/core/DB_Management/Personal_Context_Key_Store.py
 test -f tldw_Server_API/app/core/Personalization/personal_context_service.py
 test -f tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
 test -f tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py
-rg -n "not currently published|does not publish|no dedicated|acknowledgement" \
-  Docs/Code_Documentation/Personal_Context_Developer_Guide.md \
-  Docs/API-related/Personal_Context_API.md
+profile_developer_guide=Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+profile_api_reference=Docs/API-related/Personal_Context_API.md
+rg -Fq '<!-- shared-personal-context-contract:start -->' "$profile_developer_guide"
+rg -Fq '<!-- shared-personal-context-contract:end -->' "$profile_developer_guide"
+rg -Fq 'REST edits are not published to linked clients.' "$profile_developer_guide"
+rg -Fq 'Server purge does not publish the protocol purge envelope, and acknowledgement completion is absent.' \
+  "$profile_developer_guide"
+rg -Fq 'Reviewed first-link reconciliation handles first-link semantic collisions before completion.' \
+  "$profile_developer_guide"
+rg -Fq 'No dedicated post-link semantic-collision resolver exists.' "$profile_developer_guide"
+rg -Fq 'REST edits are not published to linked clients.' "$profile_api_reference"
+rg -Fq 'Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.' \
+  "$profile_api_reference"
 git diff --check -- Docs/Code_Documentation/Personal_Context_Developer_Guide.md Docs/API-related/Personal_Context_API.md
 git add Docs/Code_Documentation/Personal_Context_Developer_Guide.md Docs/API-related/Personal_Context_API.md
 git commit -m "docs: document Personal Context server internals"
@@ -400,24 +423,84 @@ git rebase origin/dev
 backlog task 13151 --plain
 rg -n "TASK-13151|Document Personal Context Profile server" \
   "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+set -o pipefail
 profile_task_matches=$(
   {
     git for-each-ref --format='%(refname)' refs/heads refs/remotes |
       while IFS= read -r profile_ref; do
-        git grep -l '^id: TASK-13151$' "$profile_ref" -- 'backlog/tasks/*.md' 2>/dev/null || true
+        if profile_ref_match=$(git grep -l '^id: TASK-13151$' "$profile_ref" -- 'backlog/tasks/*.md' 2>/dev/null); then
+          printf '%s\n' "$profile_ref_match"
+        else
+          profile_ref_status=$?
+          test "$profile_ref_status" -eq 1 || exit "$profile_ref_status"
+        fi
       done | sed 's/^[^:]*://'
     git worktree list --porcelain |
       awk '$1 == "worktree" { sub(/^worktree /, ""); print }' |
       while IFS= read -r profile_worktree; do
-        rg -l '^id: TASK-13151$' "$profile_worktree/backlog/tasks" 2>/dev/null || true
+        # Old or prunable worktrees without a Backlog task directory cannot hold this task.
+        if [ ! -d "$profile_worktree/backlog/tasks" ]; then
+          continue
+        fi
+        if profile_worktree_match=$(rg -l '^id: TASK-13151$' "$profile_worktree/backlog/tasks" 2>/dev/null); then
+          printf '%s\n' "$profile_worktree_match"
+        else
+          profile_worktree_status=$?
+          test "$profile_worktree_status" -eq 1 || exit "$profile_worktree_status"
+        fi
       done
   } | awk -F/ '{ print $NF }' | sort -u
-)
+) || {
+  echo "TASK-13151 collision sweep failed"
+  exit 1
+}
 printf '%s\n' "$profile_task_matches"
 test "$profile_task_matches" = "task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md"
+
+# Re-inventory merged behavior after the rebase and before generating docs.
+rg -q '^version = "0\.1\.0"$' packages/tldw_profile_core/pyproject.toml
+rg -q '^EXPECTED_CONTRACT_DIGEST = "[0-9a-f]{64}"$' \
+  tldw_Server_API/tests/Personalization/test_personal_context_contract.py
+rg -q '^def test_server_pins_exact_chatbook_profile_core_contract' \
+  tldw_Server_API/tests/Personalization/test_personal_context_contract.py
+test "$(rg -c '^@router\.(get|post|patch|delete)' tldw_Server_API/app/api/v1/endpoints/personal_context.py)" -eq 19
+for profile_rest_handler in create_record update_record create_proposal purge_profile; do
+  rg -q "^def ${profile_rest_handler}\\(" \
+    tldw_Server_API/app/api/v1/endpoints/personal_context.py
+done
+for profile_domain in \
+  personal_context.manifest \
+  personal_context.scope \
+  personal_context.record \
+  personal_context.proposal \
+  personal_context.purge; do
+  rg -Fq "\"$profile_domain\"" tldw_Server_API/app/core/Sync/v2/models.py
+done
+rg -q '^    def bootstrap_personal_context\(' tldw_Server_API/app/core/Sync/v2/profile.py
+rg -q '^class PersonalContextMaterializer' \
+  tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py
+rg -Fq 'PURGE_PENDING = "purge_pending"' \
+  tldw_Server_API/app/core/Personalization/personal_context_service.py
+if rg -n 'publish|outbox|enqueue|append_envelope|create_envelope' \
+  tldw_Server_API/app/api/v1/endpoints/personal_context.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py \
+  tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py; then
+  echo "Unexpected Personal Context REST-to-Sync publication seam"
+  exit 1
+fi
+if rg -n 'complete_.*purge|purge.*acknowledg|acknowledg.*purge' \
+  tldw_Server_API/app/api/v1/endpoints/personal_context.py \
+  tldw_Server_API/app/core/Personalization/personal_context_service.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py \
+  tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py; then
+  echo "Unexpected Personal Context purge acknowledgement completion seam"
+  exit 1
+fi
 ```
 
-Expected: the branch is based on current `origin/dev`, and TASK-13151 still resolves to the intended task after the rebase. There must be no later rebase after the task is marked Done.
+Expected: the branch is based on current `origin/dev`; TASK-13151 still resolves uniquely; Shared Core, REST, Sync bootstrap/inbound, and purge boundaries still match the guides' source claims. Any new REST publication or purge-completion seam stops execution for re-inventory. There must be no later rebase after the task is marked Done.
 
 - [ ] **Step 2: Refresh and stage the curated tree**
 
@@ -442,11 +525,20 @@ Expected: no unstaged generated diff and no whitespace errors in the staged gene
 
 - [ ] **Step 4: Run public/private and strict MkDocs checks**
 
-Run:
+Run Steps 4 and 5 in the same shell. Select the checked host interpreter first, fall back to the worktree virtual environment, and fail if neither exists:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/docs/check_public_private_boundary.py
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mkdocs build --strict -f Docs/mkdocs.yml
+profile_python=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python
+if [ ! -x "$profile_python" ]; then
+  profile_python=.venv/bin/python
+fi
+if [ ! -x "$profile_python" ]; then
+  echo "No executable project Python found at the host or worktree virtual environment"
+  exit 1
+fi
+printf 'Using project Python: %s\n' "$profile_python"
+"$profile_python" Helper_Scripts/docs/check_public_private_boundary.py
+"$profile_python" -m mkdocs build --strict -f Docs/mkdocs.yml
 ```
 
 Expected: boundary check reports OK; MkDocs builds with zero warnings.
@@ -456,7 +548,11 @@ Expected: boundary check reports OK; MkDocs builds with zero warnings.
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q \
+test -x "${profile_python:-}" || {
+  echo "profile_python is unavailable; run Task 5 Step 4 in this shell first"
+  exit 1
+}
+"$profile_python" -m pytest -q \
   packages/tldw_profile_core/tests/tldw_profile_core/test_public_contract.py \
   tldw_Server_API/tests/Personalization/test_personal_context_contract.py \
   tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py \
@@ -474,10 +570,28 @@ Expected: selected tests pass.
 Run:
 
 ```bash
-rg -n "not currently published|does not publish|no dedicated Personal Context|not wired" \
-  Docs/User_Guides/Server/Personal_Context_Profile.md \
-  Docs/Code_Documentation/Personal_Context_Developer_Guide.md \
-  Docs/API-related/Personal_Context_API.md
+profile_operator_guide=Docs/User_Guides/Server/Personal_Context_Profile.md
+profile_developer_guide=Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+profile_api_reference=Docs/API-related/Personal_Context_API.md
+for profile_shared_doc in "$profile_operator_guide" "$profile_developer_guide"; do
+  rg -Fq '<!-- shared-personal-context-contract:start -->' "$profile_shared_doc"
+  rg -Fq '<!-- shared-personal-context-contract:end -->' "$profile_shared_doc"
+done
+rg -Fq 'Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.' \
+  "$profile_operator_guide"
+rg -Fq 'The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.' \
+  "$profile_operator_guide"
+rg -Fq 'First-link semantic collision' "$profile_operator_guide"
+rg -Fq 'Post-link semantic collision' "$profile_operator_guide"
+rg -Fq 'REST edits are not published to linked clients.' "$profile_developer_guide"
+rg -Fq 'Server purge does not publish the protocol purge envelope, and acknowledgement completion is absent.' \
+  "$profile_developer_guide"
+rg -Fq 'Reviewed first-link reconciliation handles first-link semantic collisions before completion.' \
+  "$profile_developer_guide"
+rg -Fq 'No dedicated post-link semantic-collision resolver exists.' "$profile_developer_guide"
+rg -Fq 'REST edits are not published to linked clients.' "$profile_api_reference"
+rg -Fq 'Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.' \
+  "$profile_api_reference"
 for profile_label in \
   "Profile locked" \
   "Offline or queued" \
@@ -506,6 +620,33 @@ elif [ "$profile_link_guard_status" -gt 1 ]; then
 else
   echo "Published docs contain no source-only relative links"
 fi
+profile_changed_paths=$(
+  {
+    git diff --name-only origin/dev...HEAD
+    git diff --name-only
+    git diff --cached --name-only
+  } | sed '/^$/d' | sort -u
+)
+profile_unexpected_paths=$(
+  printf '%s\n' "$profile_changed_paths" | awk '
+    $0 == "Docs/API-related/API_README.md" { next }
+    $0 == "Docs/API-related/Personal_Context_API.md" { next }
+    $0 == "Docs/Code_Documentation/Personal_Context_Developer_Guide.md" { next }
+    $0 == "Docs/Code_Documentation/index.md" { next }
+    $0 == "Docs/User_Guides/Server/Personal_Context_Profile.md" { next }
+    $0 == "Docs/User_Guides/index.md" { next }
+    $0 == "Docs/mkdocs.yml" { next }
+    $0 == "Docs/superpowers/plans/2026-09-01-personal-context-documentation-server.md" { next }
+    $0 == "backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md" { next }
+    index($0, "Docs/Published/") == 1 { next }
+    NF { print }
+  '
+)
+if [ -n "$profile_unexpected_paths" ]; then
+  printf 'Unexpected changed paths:\n%s\n' "$profile_unexpected_paths"
+  exit 1
+fi
+printf 'Allowed changed paths:\n%s\n' "$profile_changed_paths"
 git diff --check origin/dev...HEAD
 git diff --check --cached
 git status --short
@@ -513,7 +654,7 @@ git diff --stat origin/dev...HEAD
 git diff --stat --cached
 ```
 
-Expected: limitations and all seven failure states are explicit; the expected no-match source-link guard succeeds; only task/plan/canonical/generated docs changed.
+Expected: each guide independently proves its required shared-contract and current-limit claims; the API independently proves REST publication and purge limits; all seven operator failure states are explicit; the expected no-match source-link guard succeeds; and the allowed-path assertion accepts only task/plan/canonical/generated docs.
 
 - [ ] **Step 7: Commit generated output and recheck the committed diff**
 
@@ -535,13 +676,14 @@ Expected: generated output is committed and the worktree is clean before task cl
 
 - [ ] **Step 1: Complete all ACs and DoD items, record evidence, and mark Done as the final repository mutation**
 
-Run, replacing the bracketed evidence with the exact commands and results from Task 5:
+Run, replacing the bracketed evidence with the exact commands and results from Task 5. If any skip or blocker exists, replace `Known skips/blockers: none` with the actual list before running the second command that checks DoD item 6:
 
 ```bash
 backlog task edit 13151 \
+  --notes "Implemented the server Personal Context operator and developer guides, corrected API Sync wording, added discovery/navigation, regenerated published docs, and documented the exact shared-contract block, full boundary matrix, seven failure states, current limitations, and ten-item extension checklist. Verification: [exact Task 5 results]. ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: documentation only; the existing Personal Context authority, Sync, and encryption ADR applies. Bandit: not applicable because only documentation and task metadata changed. Lessons learned: [record a genuine lesson with its incident, or state none]. Known skips/blockers: none."
+backlog task edit 13151 \
   --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 \
   --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --check-dod 5 --check-dod 6 \
-  --notes "Implemented the server Personal Context operator and developer guides, corrected API Sync wording, added discovery/navigation, regenerated published docs, and documented the exact shared-contract block, full boundary matrix, seven failure states, current limitations, and ten-item extension checklist. Verification: [exact Task 5 results]. ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: documentation only; the existing Personal Context authority, Sync, and encryption ADR applies. Bandit: not applicable because only documentation and task metadata changed. Lessons learned: [record a genuine lesson with its incident, or state none]." \
   --final-summary "Published accurate Personal Context operator, API, architecture, Sync-boundary, and troubleshooting documentation with reproducible generated output." \
   -s Done
 backlog task 13151 --plain

--- a/backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md
+++ b/backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13151
 title: Document Personal Context Profile server operations and architecture
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-01 14:47'
-updated_date: '2026-09-01 18:09'
+updated_date: '2026-09-02 03:05'
 labels: []
 dependencies: []
 references:
@@ -22,12 +22,12 @@ Publish accurate server operator and developer documentation for the canonical P
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An operator guide covers authentication, master-key setup, Chatbook linking, export, server purge behavior, and current operational limitations.
-- [ ] #2 A developer guide maps Shared Core parity, per-user storage, real key-custody ownership, services, API routes, Sync-v2 adapters, conflict metadata, purge fencing, the ten-item extension checklist, and targeted tests.
-- [ ] #3 The existing Personal Context API reference accurately distinguishes shipped Sync-v2 support from missing server-origin publication and purge acknowledgement.
-- [ ] #4 User, developer, and API indexes plus MkDocs navigation make the guides discoverable and cross-link stable Chatbook documentation.
-- [ ] #5 Generated published documentation is reproducible and strict MkDocs, endpoint, custody, bootstrap, materializer, composed-app, contract, link, and diff checks pass after the final rebase.
-- [ ] #6 Offline/queued, locked, incompatible, version-conflict, first-link semantic-collision, post-link semantic-collision, and purge-pending guidance is explicit and consistent with Chatbook.
+- [x] #1 An operator guide covers authentication, master-key setup, Chatbook linking, export, server purge behavior, and current operational limitations.
+- [x] #2 A developer guide maps Shared Core parity, per-user storage, real key-custody ownership, services, API routes, Sync-v2 adapters, conflict metadata, purge fencing, the ten-item extension checklist, and targeted tests.
+- [x] #3 The existing Personal Context API reference accurately distinguishes shipped Sync-v2 support from missing server-origin publication and purge acknowledgement.
+- [x] #4 User, developer, and API indexes plus MkDocs navigation make the guides discoverable and cross-link stable Chatbook documentation.
+- [x] #5 Generated published documentation is reproducible and strict MkDocs, endpoint, custody, bootstrap, materializer, composed-app, contract, link, and diff checks pass after the final rebase.
+- [x] #6 Offline/queued, locked, incompatible, version-conflict, first-link semantic-collision, post-link semantic-collision, and purge-pending guidance is explicit and consistent with Chatbook.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,12 +45,24 @@ ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encr
 Reason: Documentation only; the existing Personal Context authority, Sync, and encryption ADR applies.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the server Personal Context operator and developer guides, corrected the API REST/Sync-v2 boundary, added User/API/Developer indexes and MkDocs navigation, regenerated the six published counterparts, and documented the shared-contract block, full boundary matrix, exact seven failure-state labels, current limitations, and ten-item extension checklist. Fresh verification: origin/dev remained f7f368b76184e6bee4d97b66ab13b24692620c6d after the final pre-Done fetch, so no rebase was required; the fail-closed all-ref/all-worktree TASK-13151 sweep returned exactly one matching filename; merged truth confirmed Shared Core 0.1.0, the 64-hex digest/parity test, 19 REST route decorators, four named REST mutation/purge handlers, five Sync domains, bootstrap/materializer/purge_pending boundaries, and no REST-to-Sync publication or purge-acknowledgement completion seam. Helper_Scripts/refresh_docs_published.sh ran twice with zero second-run diff; six canonical/generated files matched byte-for-byte. Using /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python (Python 3.11.13), docs path hygiene passed, the public/private boundary reported OK, and strict MkDocs exited 0 with zero warnings. The exact eight-file targeted pytest suite collected 78 tests and finished 78 passed, 8 warnings in 20.10s. Both guides contained exactly one shared-contract marker pair; operator, developer, and API limit claims passed; all seven operator failure labels passed; the published source-only relative-link guard produced the expected no-match result; and the exact allowed 15-path scope, canonical/generated parity, cached/uncached diff checks, and clean worktree checks passed. Current limitations: the server has no complete standalone profile editor; linked Sync currently accepts eligible Chatbook-originated changes but ordinary server REST edits are not published; server purge does not publish a protocol purge envelope and acknowledgement completion is absent; no dedicated post-link semantic-collision resolver exists. ADR disposition: no new ADR; existing backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md applies. Bandit: not applicable because only documentation, generated documentation, plan, and task metadata changed. Lesson learned: Incident—check_top_guides_docs_path_hygiene.py interpreted the literal Docs/User_Guide path inside a valid external GitHub URL as a missing local server path. Evidence—encoding only those external blob-path slashes as %2F preserved the Chatbook dev target (GitHub API path Docs/User_Guide/settings/personal-context-profile.md, SHA 6f53a5d931bc8c0991580e61898a6e33f8612f33), while the fresh path-hygiene, strict MkDocs, source-link, and canonical/generated parity checks all passed. Known skips/blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Published accurate Personal Context operator, API, architecture, Sync-boundary, and troubleshooting documentation with reproducible generated output. The guides clearly separate canonical shared objects from peer-local state and explicitly document missing server-origin publication, purge-envelope acknowledgement completion, and post-link semantic-collision resolution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md
+++ b/backlog/tasks/task-13151 - Document-Personal-Context-Profile-server-operations-and-architecture.md
@@ -1,0 +1,56 @@
+---
+id: TASK-13151
+title: Document Personal Context Profile server operations and architecture
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-01 14:47'
+updated_date: '2026-09-01 18:09'
+labels: []
+dependencies: []
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/superpowers/specs/2026-08-31-personal-context-documentation-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Publish accurate server operator and developer documentation for the canonical Personal Context peer, authenticated API, encrypted storage, and current Sync-v2 boundaries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An operator guide covers authentication, master-key setup, Chatbook linking, export, server purge behavior, and current operational limitations.
+- [ ] #2 A developer guide maps Shared Core parity, per-user storage, real key-custody ownership, services, API routes, Sync-v2 adapters, conflict metadata, purge fencing, the ten-item extension checklist, and targeted tests.
+- [ ] #3 The existing Personal Context API reference accurately distinguishes shipped Sync-v2 support from missing server-origin publication and purge acknowledgement.
+- [ ] #4 User, developer, and API indexes plus MkDocs navigation make the guides discoverable and cross-link stable Chatbook documentation.
+- [ ] #5 Generated published documentation is reproducible and strict MkDocs, endpoint, custody, bootstrap, materializer, composed-app, contract, link, and diff checks pass after the final rebase.
+- [ ] #6 Offline/queued, locked, incompatible, version-conflict, first-link semantic-collision, post-link semantic-collision, and purge-pending guidance is explicit and consistent with Chatbook.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase and inventory merged behavior.
+2. Add server operator guide.
+3. Add developer guide and correct API reference.
+4. Add indexes and MkDocs navigation.
+5. Final rebase, regenerate curated docs, strict validation.
+6. Complete notes and open docs-only PR.
+
+ADR required: no
+ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
+Reason: Documentation only; the existing Personal Context authority, Sync, and encryption ADR applies.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Add an operator guide for server Personal Context authentication, master-key custody, reviewed Chatbook linking, export, purge behavior, and troubleshooting.
- Add a developer guide for the shared `tldw-profile-core` contract, encrypted per-user storage, API/service/repository ownership, Sync-v2 bootstrap and inbound materialization, extension rules, and targeted test map.
- Correct the existing API reference so REST and Sync-v2 behavior are not conflated, expose all three guides through the user/API/developer indexes and MkDocs navigation, and regenerate the curated `Docs/Published` copies.

## Current limitations

- The server does not provide a complete standalone Personal Context editor; Chatbook remains the full editing and interview UI.
- The current linked flow accepts eligible Chatbook-originated manifest, scope, record/tombstone, and proposal changes. Ordinary server REST record/proposal edits are not published to linked Chatbook clients.
- Server purge advances the local fence and remains `purge_pending`, but it does not publish the protocol purge envelope and acknowledgement completion is absent.
- Reviewed first-link reconciliation handles first-link semantic collisions before completion; there is no dedicated post-link semantic-collision resolver.

## Verification

- Final pre-closeout fetch confirmed `origin/dev` remained `f7f368b76184e6bee4d97b66ab13b24692620c6d`; no rebase was required. The fail-closed all-ref/all-worktree sweep found exactly one TASK-13151 file.
- Merged-truth inventory confirmed Shared Core `0.1.0`, the contract digest/parity guard, 19 REST route decorators, the four named mutation/purge handlers, all five Personal Context Sync domains, bootstrap/materializer/purge-pending boundaries, and no server REST publication or purge-acknowledgement completion seam.
- `Helper_Scripts/refresh_docs_published.sh` ran twice with zero second-run diff; six canonical/generated files matched byte-for-byte.
- Using `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python` (Python 3.11.13): docs path hygiene passed, the public/private boundary reported OK, and strict MkDocs exited 0 with zero warnings.
- The exact eight-file targeted suite collected 78 tests: **78 passed, 8 warnings in 20.10s**.
- Both guides contain exactly one shared-contract marker pair; operator, developer, and API limitation claims passed; all seven operator failure labels passed; the source-only relative-link guard returned the expected no-match result; and the final diff is exactly the approved 15 documentation/plan/task paths with clean cached and uncached diff checks.
- Bandit is not applicable because this PR changes only documentation, generated documentation, the implementation plan, and Backlog task metadata.

## Task and architecture decision

- TASK-13151 is Done with all 6 acceptance criteria and all 6 Definition of Done items complete.
- ADR disposition: no new ADR; existing `backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md` applies.

## Required human Change summary

This PR body is AI-authored and does **not** satisfy the server's human `Change summary` merge gate. The PR is not merge-ready until the requester supplies, in their own words, an explanation of both what changed and why these documentation choices were made.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operator and developer guides for Personal Context on the server, and corrects the API reference so REST and Sync-v2 behavior are no longer conflated.

- The operator guide covers authentication, master-key custody, Chatbook linking, export, and purge behavior.
- The developer guide maps the `tldw-profile-core` contract, encrypted per-user storage, service ownership, and the Sync-v2 boundary.
- All three guides are linked from the user/API/developer indexes and MkDocs navigation, and `Docs/Published` copies are regenerated.

<sup>Written for commit 55952ec134c0afc863307baa1403c3500936e19f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

