### PR TITLE
fix(tests): authenticate the Embeddings metrics tests, which never could pass

### DIFF
--- a/tldw_Server_API/tests/Embeddings/conftest.py
+++ b/tldw_Server_API/tests/Embeddings/conftest.py
@@ -215,6 +215,7 @@ def redis_client():
 # Lightweight app client + auth fixtures for property/unit tests in this package
 @pytest.fixture
 def test_client(disable_heavy_startup):
+    _overrides_before = dict(app.dependency_overrides)
     """Minimal TestClient with CSRF and auth header set.
 
     Scope: function - keeps isolation across property-based runs.
@@ -229,9 +230,14 @@ def test_client(disable_heavy_startup):
             client.headers["Authorization"] = f"Bearer {get_settings().SINGLE_USER_API_KEY}"
             yield client
     finally:
-        # Ensure dependency overrides do not leak across tests
+        # Restore, do not clear. These overrides live on the shared global app,
+        # so clear() removed entries this fixture never installed -- including
+        # the auth overrides another fixture had put there for the running test.
+        # Whichever test asked for ambient authentication next then got a 401,
+        # which is why the victim moved around between runs.
         try:
             app.dependency_overrides.clear()
+            app.dependency_overrides.update(_overrides_before)
         except Exception:
             _ = None
 

--- a/tldw_Server_API/tests/Embeddings/conftest.py
+++ b/tldw_Server_API/tests/Embeddings/conftest.py
@@ -215,11 +215,11 @@ def redis_client():
 # Lightweight app client + auth fixtures for property/unit tests in this package
 @pytest.fixture
 def test_client(disable_heavy_startup):
-    _overrides_before = dict(app.dependency_overrides)
     """Minimal TestClient with CSRF and auth header set.
 
     Scope: function - keeps isolation across property-based runs.
     """
+    _overrides_before = dict(app.dependency_overrides)
     try:
         csrf = "test-csrf"
         with TestClient(app) as client:

--- a/tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py
+++ b/tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py
@@ -7,7 +7,7 @@ from tldw_Server_API.app.main import app
 
 
 @pytest.mark.unit
-def test_metrics_text_contains_golden_subset():
+def test_metrics_text_contains_golden_subset(admin_user):
     client = TestClient(app)
     r = client.get("/api/v1/metrics/text")
     assert r.status_code == 200

--- a/tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py
+++ b/tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py
@@ -7,7 +7,17 @@ from tldw_Server_API.app.main import app
 
 
 @pytest.mark.unit
-def test_metrics_text_contains_golden_subset(admin_user):
+def test_metrics_text_contains_golden_subset(admin_user: object) -> None:
+    """The metrics endpoint must still expose every name in the golden list.
+
+    Args:
+        admin_user: Requested for its side effect -- it installs the auth
+            overrides. /api/v1/metrics/text requires authentication, and without
+            it this returns 401 rather than the metrics body.
+
+    Returns:
+        None.
+    """
     client = TestClient(app)
     r = client.get("/api/v1/metrics/text")
     assert r.status_code == 200

--- a/tldw_Server_API/tests/Embeddings/test_metrics_histograms_smoke.py
+++ b/tldw_Server_API/tests/Embeddings/test_metrics_histograms_smoke.py
@@ -1,8 +1,21 @@
-import os
+import pytest
 from fastapi.testclient import TestClient
 
 
-def test_metrics_exposes_new_histograms(admin_user, monkeypatch):
+@pytest.mark.unit
+def test_metrics_exposes_new_histograms(
+    admin_user: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Importing BaseWorker must register its histograms on the default registry.
+
+    Args:
+        admin_user: Requested for its side effect -- /api/v1/metrics/text
+            requires authentication and returns 401 without these overrides.
+        monkeypatch: Used to trim startup work.
+
+    Returns:
+        None.
+    """
 
 
      # Reduce startup work

--- a/tldw_Server_API/tests/Embeddings/test_metrics_histograms_smoke.py
+++ b/tldw_Server_API/tests/Embeddings/test_metrics_histograms_smoke.py
@@ -2,7 +2,7 @@ import os
 from fastapi.testclient import TestClient
 
 
-def test_metrics_exposes_new_histograms(monkeypatch):
+def test_metrics_exposes_new_histograms(admin_user, monkeypatch):
 
 
      # Reduce startup work

--- a/tldw_Server_API/tests/Embeddings/test_orchestrator_metrics_export.py
+++ b/tldw_Server_API/tests/Embeddings/test_orchestrator_metrics_export.py
@@ -1,4 +1,5 @@
 import re
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -47,8 +48,23 @@ def test_summary_failure_increments_counter(disable_heavy_startup, admin_user, m
 
 @pytest.mark.unit
 def test_sse_disconnect_increments_counter(
-    disable_heavy_startup, admin_user, redis_client, monkeypatch
-):
+    disable_heavy_startup: object,
+    admin_user: object,
+    redis_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing an SSE stream must be counted as a disconnect.
+
+    Args:
+        disable_heavy_startup: Requested for its side effect.
+        admin_user: Requested for its side effect -- the metrics read at the end
+            goes over HTTP and 401s without these auth overrides.
+        redis_client: Shared fake Redis, also used to drive the coroutine.
+        monkeypatch: Points the Redis factory at that fake.
+
+    Returns:
+        None.
+    """
      # Call the endpoint function directly and close its generator to trigger disconnect accounting
     from tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced import orchestrator_events
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User

--- a/tldw_Server_API/tests/Embeddings/test_orchestrator_metrics_export.py
+++ b/tldw_Server_API/tests/Embeddings/test_orchestrator_metrics_export.py
@@ -46,7 +46,9 @@ def test_summary_failure_increments_counter(disable_heavy_startup, admin_user, m
 
 
 @pytest.mark.unit
-def test_sse_disconnect_increments_counter(disable_heavy_startup, redis_client, monkeypatch):
+def test_sse_disconnect_increments_counter(
+    disable_heavy_startup, admin_user, redis_client, monkeypatch
+):
      # Call the endpoint function directly and close its generator to trigger disconnect accounting
     from tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced import orchestrator_events
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User


### PR DESCRIPTION
Three tests in `tests/Embeddings` request `/api/v1/metrics/text` through a bare `TestClient(app)` with **no credentials** and assert `200`. That endpoint requires authentication — a request with no `Authorization` header and no `X-API-KEY` only gets through on a single-user *session*, and otherwise `auth_principal_resolver` raises:

```
401 Not authenticated (provide Bearer token or X-API-KEY)
```

They fail run alone. They failed in every full-suite run.

## These were not what I thought they were

I had been carrying these as "three pre-existing metrics failures" — a separate, unrelated family from the intermittent failure in this suite. That was wrong, and I only found out by instrumenting `HTTPException` to attribute every 401 raise site to the test that failed. All three come from the *same resolver line* as the flaky one. One class, not two: some members deterministic, one intermittent.

Adding the `admin_user` fixture — which installs the auth overrides the rest of the suite already uses — fixes all three.

## Also, a real isolation bug

The `test_client` fixture cleared `app.dependency_overrides` wholesale on teardown. Those overrides live on the **shared global app**, so `clear()` removed entries the fixture never installed, including auth overrides another fixture had put there. It now restores the map it found.

**It did not fix the intermittent failure**, which is why I went looking at it. I am keeping the change because a fixture should not destroy state it did not create, but it should not be read as a fix for the flake.

## Results

Three full runs, collection order pinned:

| run | result |
|---|---|
| 1 | **679 passed, 0 failed** |
| 2 | 678 passed, 1 failed — `test_stage_pause_resume_drain` |
| 3 | **679 passed, 0 failed** |

Against a floor of **three failures on every previous run**.

## What is still open

The intermittent failure is unchanged and still unexplained. What I ruled out along the way, each with evidence: the lifecycle-reset fixture (#2857), `AUTH_MODE` / settings-mode poisoning (a probe over all 697 tests never once observed poisoned settings), a swallowed `get_settings()` failure in `auth_deps`, the user-DB-base `OSError`, and `test_orchestrator_summary_endpoint`'s `reset_settings()` cleanup.

What is established: it is always a spurious `401` on a test that authenticates via `admin_user`, the victim moves between runs (six distinct tests seen), victims pass in isolation, and it needs full-suite context. That is a much better starting point than "Embeddings is flaky", and it deserves its own issue rather than more of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Embeddings metrics tests that always failed because they requested `/api/v1/metrics/text` without credentials, and stops the `test_client` fixture from clearing shared dependency overrides it didn't install.

**Bug Fixes**
- Adds `admin_user` to the three tests that need it; they now pass alone and in the full suite.
- `test_client` now restores `app.dependency_overrides` instead of clearing it, so auth overrides installed by other fixtures survive teardown.
- Restores the `test_client` docstring displaced by the override snapshot and documents the side-effect `admin_user` dependency in the tests.

The intermittent 401 failure in the suite is unchanged and remains under investigation.

<sup>Written for commit 328dc24aad288b0bedd1bd5eba0437a13dbac82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

