### PR TITLE
feat(mcp): Streamable HTTP and SSE external federation transports (mcp-unified 0.3.0)

### DIFF
--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -105,7 +105,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.1"
+python -m pip install "mcp-unified[gateway]~=0.3.0"
 ```
 
 For development tooling, install the optional development extras:

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -802,6 +802,12 @@ failures map to distinct reason codes (`auth_required`, `tls_failed`,
 `connect_failed`, `request_timeout`, `connection_closed`) so downstream
 clients can surface honest readiness states.
 
+Notes: URL transports are currently registry-only — the YAML/JSON config-file
+registry (`ExternalServerRegistryConfig`) still declares only `stdio` and
+`websocket`. Management responses redact `headers` values (`"***"`); rotate a
+token by patching `headers` with the new value. Credential headers over plain
+`http://` are refused for non-loopback hosts.
+
 ## 5. Add Credential Grants
 
 Credential grants are metadata that bind a profile, external server, credential

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -57,7 +57,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.1"
+python -m pip install "mcp-unified[gateway]~=0.3.0"
 ```
 
 From the repository root, when testing unpublished changes:
@@ -775,6 +775,32 @@ mcp-unified-gateway list-external-servers \
 
 The registry alone does not grant execution authority. A profile must also
 allow the server/tool path, and any required credentials must be granted.
+
+### Remote (URL-based) external servers
+
+Hosted MCP servers are registered the same way with a URL-based transport
+instead of a command. `streamable_http` targets a Streamable HTTP endpoint
+(one URL, JSON or SSE-framed responses, `mcp-session-id` session handling);
+`sse` targets the legacy HTTP+SSE pairing (persistent event stream plus a
+POST message endpoint).
+
+```json
+{
+  "id": "linear",
+  "name": "Linear MCP",
+  "transport": "streamable_http",
+  "url": "https://mcp.linear.app/mcp",
+  "headers": {"Authorization": "Bearer <token>"},
+  "enabled": true
+}
+```
+
+`headers` are static headers sent on every request (typically authorization).
+Per-call brokered credentials merge their `headers` into each tool call;
+brokered `env` values have no HTTP equivalent and are ignored. Connection
+failures map to distinct reason codes (`auth_required`, `tls_failed`,
+`connect_failed`, `request_timeout`, `connection_closed`) so downstream
+clients can surface honest readiness states.
 
 ## 5. Add Credential Grants
 

--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unified"
-version = "0.2.1"
+version = "0.3.0"
 description = "Standalone MCP Unified runtime and gateway package boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -105,7 +105,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.1"
+python -m pip install "mcp-unified[gateway]~=0.3.0"
 ```
 
 For development tooling, install the optional development extras:

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -802,6 +802,12 @@ failures map to distinct reason codes (`auth_required`, `tls_failed`,
 `connect_failed`, `request_timeout`, `connection_closed`) so downstream
 clients can surface honest readiness states.
 
+Notes: URL transports are currently registry-only — the YAML/JSON config-file
+registry (`ExternalServerRegistryConfig`) still declares only `stdio` and
+`websocket`. Management responses redact `headers` values (`"***"`); rotate a
+token by patching `headers` with the new value. Credential headers over plain
+`http://` are refused for non-loopback hosts.
+
 ## 5. Add Credential Grants
 
 Credential grants are metadata that bind a profile, external server, credential

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -57,7 +57,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.1"
+python -m pip install "mcp-unified[gateway]~=0.3.0"
 ```
 
 From the repository root, when testing unpublished changes:
@@ -775,6 +775,32 @@ mcp-unified-gateway list-external-servers \
 
 The registry alone does not grant execution authority. A profile must also
 allow the server/tool path, and any required credentials must be granted.
+
+### Remote (URL-based) external servers
+
+Hosted MCP servers are registered the same way with a URL-based transport
+instead of a command. `streamable_http` targets a Streamable HTTP endpoint
+(one URL, JSON or SSE-framed responses, `mcp-session-id` session handling);
+`sse` targets the legacy HTTP+SSE pairing (persistent event stream plus a
+POST message endpoint).
+
+```json
+{
+  "id": "linear",
+  "name": "Linear MCP",
+  "transport": "streamable_http",
+  "url": "https://mcp.linear.app/mcp",
+  "headers": {"Authorization": "Bearer <token>"},
+  "enabled": true
+}
+```
+
+`headers` are static headers sent on every request (typically authorization).
+Per-call brokered credentials merge their `headers` into each tool call;
+brokered `env` values have no HTTP equivalent and are ignored. Connection
+failures map to distinct reason codes (`auth_required`, `tls_failed`,
+`connect_failed`, `request_timeout`, `connection_closed`) so downstream
+clients can surface honest readiness states.
 
 ## 5. Add Credential Grants
 

--- a/apps/mcp-unified/src/mcp_unified/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/apps/mcp-unified/src/mcp_unified/federation/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/__init__.py
@@ -18,6 +18,12 @@ from .config_schema import (
     load_external_server_registry,
     parse_external_server_registry,
 )
+from .http_transport import (
+    HttpExternalTransportError,
+    SseExternalTransport,
+    StreamableHttpExternalTransport,
+    create_http_external_transport,
+)
 from .installers import ExternalServerInstaller, NullExternalServerInstaller
 from .manager import ExternalFederationManager
 from .models import (
@@ -39,6 +45,10 @@ from .stdio_transport import (
 from .transports import ExternalFederationTransport, FakeExternalTransport
 
 __all__ = [
+    "HttpExternalTransportError",
+    "SseExternalTransport",
+    "StreamableHttpExternalTransport",
+    "create_http_external_transport",
     "BrokeredExternalCredential",
     "ExternalAuthConfig",
     "ExternalAuthMode",

--- a/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
@@ -26,12 +26,19 @@ from mcp_unified.federation.resource_payloads import (
 from mcp_unified.storage.models import ExternalServerDefinition
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
+_MCP_PROTOCOL_VERSION_STREAMABLE = "2025-03-26"
 _CLIENT_INFO = {"name": "mcp_unified_external_federation", "version": "0.1.0"}
 _DEFAULT_CONNECT_TIMEOUT_S = 30.0
 _DEFAULT_REQUEST_TIMEOUT_S = 30.0
 _DEFAULT_HEALTH_TIMEOUT_S = 5.0
+_DEFAULT_CLOSE_TIMEOUT_S = 5.0
 _SESSION_HEADER = "mcp-session-id"
+_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 _ACCEPT_BOTH = "application/json, text/event-stream"
+_SENSITIVE_HEADER_NAMES = frozenset(
+    {"authorization", "proxy-authorization", "cookie", "x-api-key", "api-key"}
+)
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 class HttpExternalTransportError(RuntimeError):
@@ -146,8 +153,6 @@ async def _iter_sse_events(lines: AsyncIterator[str]) -> AsyncIterator[tuple[str
             event = value
         elif field == "data":
             data_lines.append(value)
-    if data_lines:
-        yield event, "\n".join(data_lines)
 
 
 class _HttpExternalTransportBase:
@@ -181,10 +186,19 @@ class _HttpExternalTransportBase:
         self._static_headers = {
             str(k): str(v) for k, v in (self._server.headers or {}).items()
         }
+        if scheme == "http":
+            host = (urlsplit(url).hostname or "").lower()
+            sensitive = {name.lower() for name in self._static_headers}
+            if sensitive & _SENSITIVE_HEADER_NAMES and host not in _LOOPBACK_HOSTS:
+                raise self._error(
+                    "Credential headers over plain http are only allowed to loopback",
+                    reason_code="insecure_url",
+                )
         self._connect_timeout_s = self._positive_timeout(connect_timeout_s, "connect_timeout_s")
         self._request_timeout_s = self._positive_timeout(request_timeout_s, "request_timeout_s")
         self._health_timeout_s = self._positive_timeout(health_timeout_s, "health_timeout_s")
         self._connect_lock = asyncio.Lock()
+        self._request_lock = asyncio.Lock()
         self._next_request_id = 1
         self._initialized = False
 
@@ -320,6 +334,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         )
         self._client: httpx.AsyncClient | None = None
         self._session_id: str | None = None
+        self._protocol_version: str | None = None
 
     async def connect(self) -> None:
         """Initialize an MCP session against the configured endpoint."""
@@ -335,15 +350,21 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
                 )
             )
             try:
-                await self._request(
+                response = await self._request(
                     "initialize",
                     {
-                        "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "protocolVersion": _MCP_PROTOCOL_VERSION_STREAMABLE,
                         "capabilities": {},
                         "clientInfo": _CLIENT_INFO,
                     },
                     timeout_s=self._connect_timeout_s,
                 )
+                result = response.get("result")
+                negotiated = (
+                    result.get("protocolVersion") if isinstance(result, dict) else None
+                )
+                if isinstance(negotiated, str) and negotiated.strip():
+                    self._protocol_version = negotiated.strip()
                 await self._notify("notifications/initialized", {})
             except Exception:
                 await self._close_client()
@@ -371,7 +392,8 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         if not checks["initialized"]:
             return checks
         try:
-            await self._request("ping", {}, timeout_s=self._health_timeout_s)
+            async with self._request_lock:
+                await self._request("ping", {}, timeout_s=self._health_timeout_s)
         except HttpExternalTransportError:
             self._initialized = False
             checks["connected"] = False
@@ -380,14 +402,16 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
 
     async def list_tools(self) -> list[ExternalToolDefinition]:
         """Discover and normalize upstream MCP tool definitions."""
-        await self._ensure_connected()
-        response = await self._request("tools/list", {})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("tools/list", {})
         return _normalize_tool_definitions(response.get("result"))
 
     async def list_resources(self) -> list[dict[str, Any]]:
         """Discover and normalize upstream MCP resource descriptors."""
-        await self._ensure_connected()
-        response = await self._request("resources/list", {})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("resources/list", {})
         return normalize_external_resource_list(response.get("result"))
 
     async def read_resource(self, uri: str, *, context: Any = None) -> dict[str, Any]:
@@ -401,8 +425,9 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             The normalized ``resources/read`` result payload.
         """
         del context
-        await self._ensure_connected()
-        response = await self._request("resources/read", {"uri": uri})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("resources/read", {"uri": uri})
         return normalize_external_resource_read(response.get("result"))
 
     async def call_tool(
@@ -428,33 +453,34 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             returned as ``is_error`` results rather than raised.
         """
         del context
-        await self._ensure_connected()
-        params: dict[str, Any] = {
-            "name": tool_name,
-            "arguments": deepcopy(arguments or {}),
-        }
-        response = await self._request(
-            "tools/call",
-            params,
-            raise_on_error=False,
-            extra_headers=self._runtime_auth_headers(runtime_auth),
-        )
+        async with self._request_lock:
+            await self._ensure_connected()
+            params: dict[str, Any] = {
+                "name": tool_name,
+                "arguments": deepcopy(arguments or {}),
+            }
+            response = await self._request(
+                "tools/call",
+                params,
+                raise_on_error=False,
+                extra_headers=self._runtime_auth_headers(runtime_auth),
+            )
         return self._tool_call_result(tool_name, response)
 
     async def _ensure_connected(self) -> None:
         if not self._initialized or self._client is None:
             await self.connect()
 
-    def _base_headers(self, extra_headers: dict[str, str] | None) -> dict[str, str]:
-        headers = {
-            "accept": _ACCEPT_BOTH,
-            "content-type": "application/json",
-            **self._static_headers,
-        }
+    def _base_headers(self, extra_headers: dict[str, str] | None) -> httpx.Headers:
+        headers = httpx.Headers(self._static_headers)
+        headers["accept"] = _ACCEPT_BOTH
+        headers["content-type"] = "application/json"
         if self._session_id:
             headers[_SESSION_HEADER] = self._session_id
-        if extra_headers:
-            headers.update(extra_headers)
+        if self._protocol_version:
+            headers[_PROTOCOL_VERSION_HEADER] = self._protocol_version
+        for name, value in (extra_headers or {}).items():
+            headers[name] = value
         return headers
 
     async def _request(
@@ -465,6 +491,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         timeout_s: float | None = None,
         raise_on_error: bool = True,
         extra_headers: dict[str, str] | None = None,
+        _retried: bool = False,
     ) -> dict[str, Any]:
         client = self._require_client(method)
         request_id = self._take_request_id()
@@ -475,31 +502,32 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             "params": deepcopy(params or {}),
         }
         encoded = self._encode_payload(payload, method)
+        effective_timeout = timeout_s or self._request_timeout_s
         try:
-            async with client.stream(
-                "POST",
-                self._url,
-                content=encoded,
-                headers=self._base_headers(extra_headers),
-                timeout=timeout_s or self._request_timeout_s,
-            ) as response:
-                if response.status_code == 404 and self._session_id:
-                    self._session_id = None
-                    self._initialized = False
-                if response.status_code >= 400:
-                    raise self._status_error(response.status_code, method)
-                session_id = response.headers.get(_SESSION_HEADER)
-                if session_id:
-                    self._session_id = session_id
-                content_type = response.headers.get("content-type", "")
-                if content_type.startswith("text/event-stream"):
-                    result = await self._read_sse_response(
-                        response, request_id, method
-                    )
-                else:
-                    body = await response.aread()
-                    result = self._decode_json_response(body, method)
-        except HttpExternalTransportError:
+            result = await asyncio.wait_for(
+                self._send_request(
+                    client, encoded, request_id, method, extra_headers, effective_timeout
+                ),
+                timeout=effective_timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            raise self._error(
+                f"External HTTP request timed out for method '{method}'",
+                reason_code="request_timeout",
+                method=method,
+            ) from exc
+        except HttpExternalTransportError as exc:
+            if exc.reason_code == "session_expired" and not _retried:
+                self._initialized = False
+                await self.connect()
+                return await self._request(
+                    method,
+                    params,
+                    timeout_s=timeout_s,
+                    raise_on_error=raise_on_error,
+                    extra_headers=extra_headers,
+                    _retried=True,
+                )
             raise
         except httpx.HTTPError as exc:
             raise self._transport_error(exc, method) from exc
@@ -511,6 +539,42 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
                 method=method,
             )
         return result
+
+    async def _send_request(
+        self,
+        client: httpx.AsyncClient,
+        encoded: bytes,
+        request_id: int,
+        method: str,
+        extra_headers: dict[str, str] | None,
+        effective_timeout: float,
+    ) -> dict[str, Any]:
+        async with client.stream(
+            "POST",
+            self._url,
+            content=encoded,
+            headers=self._base_headers(extra_headers),
+            timeout=effective_timeout,
+        ) as response:
+            if response.status_code == 404 and self._session_id:
+                self._session_id = None
+                self._initialized = False
+                raise self._error(
+                    "External HTTP session expired",
+                    reason_code="session_expired",
+                    method=method,
+                    details={"status": 404},
+                )
+            if response.status_code >= 400:
+                raise self._status_error(response.status_code, method)
+            session_id = response.headers.get(_SESSION_HEADER)
+            if session_id:
+                self._session_id = session_id
+            content_type = response.headers.get("content-type", "")
+            if content_type.startswith("text/event-stream"):
+                return await self._read_sse_response(response, request_id, method)
+            body = await response.aread()
+            return self._decode_json_response(body, method)
 
     async def _read_sse_response(
         self, response: httpx.Response, request_id: int, method: str
@@ -587,7 +651,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
                 await client.delete(
                     self._url,
                     headers={**self._static_headers, _SESSION_HEADER: self._session_id},
-                    timeout=self._request_timeout_s,
+                    timeout=_DEFAULT_CLOSE_TIMEOUT_S,
                 )
         self._session_id = None
         with contextlib.suppress(Exception):
@@ -655,7 +719,18 @@ class SseExternalTransport(_HttpExternalTransportBase):
                     self._read_endpoint_event(),
                     timeout=self._connect_timeout_s,
                 )
-                self._endpoint_url = urljoin(str(response.url), endpoint)
+                endpoint_url = urljoin(str(response.url), endpoint)
+                stream_parts = urlsplit(str(response.url))
+                endpoint_parts = urlsplit(endpoint_url)
+                if (
+                    endpoint_parts.scheme != stream_parts.scheme
+                    or endpoint_parts.netloc != stream_parts.netloc
+                ):
+                    raise self._error(
+                        "External SSE endpoint event points outside the stream origin",
+                        reason_code="invalid_endpoint",
+                    )
+                self._endpoint_url = endpoint_url
                 self._reader_task = asyncio.create_task(self._pump_events())
                 await self._request(
                     "initialize",
@@ -706,7 +781,8 @@ class SseExternalTransport(_HttpExternalTransportBase):
             self._initialized = False
             return checks
         try:
-            await self._request("ping", {}, timeout_s=self._health_timeout_s)
+            async with self._request_lock:
+                await self._request("ping", {}, timeout_s=self._health_timeout_s)
         except HttpExternalTransportError:
             self._initialized = False
             checks["connected"] = False
@@ -715,14 +791,16 @@ class SseExternalTransport(_HttpExternalTransportBase):
 
     async def list_tools(self) -> list[ExternalToolDefinition]:
         """Discover and normalize upstream MCP tool definitions."""
-        await self._ensure_connected()
-        response = await self._request("tools/list", {})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("tools/list", {})
         return _normalize_tool_definitions(response.get("result"))
 
     async def list_resources(self) -> list[dict[str, Any]]:
         """Discover and normalize upstream MCP resource descriptors."""
-        await self._ensure_connected()
-        response = await self._request("resources/list", {})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("resources/list", {})
         return normalize_external_resource_list(response.get("result"))
 
     async def read_resource(self, uri: str, *, context: Any = None) -> dict[str, Any]:
@@ -736,8 +814,9 @@ class SseExternalTransport(_HttpExternalTransportBase):
             The normalized ``resources/read`` result payload.
         """
         del context
-        await self._ensure_connected()
-        response = await self._request("resources/read", {"uri": uri})
+        async with self._request_lock:
+            await self._ensure_connected()
+            response = await self._request("resources/read", {"uri": uri})
         return normalize_external_resource_read(response.get("result"))
 
     async def call_tool(
@@ -763,17 +842,18 @@ class SseExternalTransport(_HttpExternalTransportBase):
             returned as ``is_error`` results rather than raised.
         """
         del context
-        await self._ensure_connected()
-        params: dict[str, Any] = {
-            "name": tool_name,
-            "arguments": deepcopy(arguments or {}),
-        }
-        response = await self._request(
-            "tools/call",
-            params,
-            raise_on_error=False,
-            extra_headers=self._runtime_auth_headers(runtime_auth),
-        )
+        async with self._request_lock:
+            await self._ensure_connected()
+            params: dict[str, Any] = {
+                "name": tool_name,
+                "arguments": deepcopy(arguments or {}),
+            }
+            response = await self._request(
+                "tools/call",
+                params,
+                raise_on_error=False,
+                extra_headers=self._runtime_auth_headers(runtime_auth),
+            )
         return self._tool_call_result(tool_name, response)
 
     async def _ensure_connected(self) -> None:

--- a/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import urljoin, urlsplit
 
 import httpx
+from loguru import logger
 
 from mcp_unified.federation.models import (
     BrokeredExternalCredential,
@@ -186,10 +187,11 @@ class _HttpExternalTransportBase:
         self._static_headers = {
             str(k): str(v) for k, v in (self._server.headers or {}).items()
         }
-        if scheme == "http":
-            host = (urlsplit(url).hostname or "").lower()
+        host = (urlsplit(url).hostname or "").lower()
+        self._plain_http_non_loopback = scheme == "http" and host not in _LOOPBACK_HOSTS
+        if self._plain_http_non_loopback:
             sensitive = {name.lower() for name in self._static_headers}
-            if sensitive & _SENSITIVE_HEADER_NAMES and host not in _LOOPBACK_HOSTS:
+            if sensitive & _SENSITIVE_HEADER_NAMES:
                 raise self._error(
                     "Credential headers over plain http are only allowed to loopback",
                     reason_code="insecure_url",
@@ -203,6 +205,7 @@ class _HttpExternalTransportBase:
         self._initialized = False
 
     def _take_request_id(self) -> int:
+        """Return the next monotonically increasing JSON-RPC request id."""
         request_id = self._next_request_id
         self._next_request_id += 1
         return request_id
@@ -215,6 +218,7 @@ class _HttpExternalTransportBase:
         method: str | None = None,
         details: dict[str, Any] | None = None,
     ) -> HttpExternalTransportError:
+        """Build a reason-coded transport error bound to this server id."""
         return HttpExternalTransportError(
             message,
             reason_code=reason_code,
@@ -224,6 +228,7 @@ class _HttpExternalTransportBase:
         )
 
     def _status_error(self, status: int, method: str | None) -> HttpExternalTransportError:
+        """Map an HTTP error status to a reason-coded transport error."""
         if status in (401, 403):
             return self._error(
                 "External HTTP server requires authorization",
@@ -241,22 +246,44 @@ class _HttpExternalTransportBase:
     def _transport_error(
         self, exc: httpx.HTTPError, method: str | None
     ) -> HttpExternalTransportError:
+        """Map an httpx transport failure to a reason-coded transport error."""
         return self._error(
             "External HTTP request failed",
             reason_code=_reason_code_for_transport_error(exc),
             method=method,
         )
 
-    @staticmethod
     def _runtime_auth_headers(
+        self,
         runtime_auth: BrokeredExternalCredential | None,
     ) -> dict[str, str]:
+        """Return brokered per-call headers, refusing credentials over plain http.
+
+        Args:
+            runtime_auth: Optional brokered credential resolved for this call.
+
+        Returns:
+            Header names/values to merge into the outgoing request.
+
+        Raises:
+            HttpExternalTransportError: ``insecure_url`` when a credential
+                header would be sent over plain http to a non-loopback host.
+        """
         if runtime_auth is None or not runtime_auth.headers:
             return {}
-        return {str(k): str(v) for k, v in runtime_auth.headers.items()}
+        headers = {str(k): str(v) for k, v in runtime_auth.headers.items()}
+        if self._plain_http_non_loopback:
+            sensitive = {name.lower() for name in headers}
+            if sensitive & _SENSITIVE_HEADER_NAMES:
+                raise self._error(
+                    "Brokered credential headers over plain http are only allowed to loopback",
+                    reason_code="insecure_url",
+                )
+        return headers
 
     @classmethod
     def _positive_timeout(cls, value: float, field_name: str) -> float:
+        """Validate that a timeout value is a finite positive number."""
         try:
             timeout = float(value)
         except (TypeError, ValueError) as exc:
@@ -273,6 +300,7 @@ class _HttpExternalTransportBase:
 
     @staticmethod
     def _encode_payload(payload: dict[str, Any], method: str) -> bytes:
+        """Encode a JSON-RPC payload, rejecting non-serializable requests."""
         try:
             return json.dumps(payload, separators=(",", ":")).encode("utf-8")
         except (TypeError, ValueError) as exc:
@@ -285,6 +313,7 @@ class _HttpExternalTransportBase:
     def _tool_call_result(
         self, tool_name: str, response: dict[str, Any]
     ) -> ExternalToolCallResult:
+        """Normalize a JSON-RPC tool response into an ExternalToolCallResult."""
         error = response.get("error")
         if isinstance(error, dict):
             message = error.get("message")
@@ -373,7 +402,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
 
     async def close(self) -> None:
         """Terminate the MCP session and release the HTTP client."""
-        async with self._connect_lock:
+        async with self._request_lock, self._connect_lock:
             await self._close_client()
 
     async def health_check(self) -> dict[str, bool]:
@@ -453,6 +482,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             returned as ``is_error`` results rather than raised.
         """
         del context
+        extra_headers = self._runtime_auth_headers(runtime_auth)
         async with self._request_lock:
             await self._ensure_connected()
             params: dict[str, Any] = {
@@ -463,15 +493,17 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
                 "tools/call",
                 params,
                 raise_on_error=False,
-                extra_headers=self._runtime_auth_headers(runtime_auth),
+                extra_headers=extra_headers,
             )
         return self._tool_call_result(tool_name, response)
 
     async def _ensure_connected(self) -> None:
+        """Connect (or reconnect) if the transport is not initialized."""
         if not self._initialized or self._client is None:
             await self.connect()
 
     def _base_headers(self, extra_headers: dict[str, str] | None) -> httpx.Headers:
+        """Build request headers: static first, protocol values winning, extras last."""
         headers = httpx.Headers(self._static_headers)
         headers["accept"] = _ACCEPT_BOTH
         headers["content-type"] = "application/json"
@@ -493,6 +525,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         extra_headers: dict[str, str] | None = None,
         _retried: bool = False,
     ) -> dict[str, Any]:
+        """Send one JSON-RPC request and return the correlated response payload."""
         client = self._require_client(method)
         request_id = self._take_request_id()
         payload = {
@@ -549,6 +582,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         extra_headers: dict[str, str] | None,
         effective_timeout: float,
     ) -> dict[str, Any]:
+        """POST one encoded request and read its JSON or SSE-framed response."""
         async with client.stream(
             "POST",
             self._url,
@@ -574,11 +608,19 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             if content_type.startswith("text/event-stream"):
                 return await self._read_sse_response(response, request_id, method)
             body = await response.aread()
-            return self._decode_json_response(body, method)
+            payload = self._decode_json_response(body, method)
+            if payload.get("id") != request_id:
+                raise self._error(
+                    "External HTTP response id does not match the request",
+                    reason_code="invalid_response",
+                    method=method,
+                )
+            return payload
 
     async def _read_sse_response(
         self, response: httpx.Response, request_id: int, method: str
     ) -> dict[str, Any]:
+        """Read an SSE-framed POST response until the matching id arrives."""
         async for _event, data in _iter_sse_events(response.aiter_lines()):
             try:
                 payload = json.loads(data)
@@ -593,6 +635,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         )
 
     def _decode_json_response(self, body: bytes, method: str) -> dict[str, Any]:
+        """Decode a JSON response body into a JSON-RPC object."""
         try:
             payload = json.loads(body.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -610,6 +653,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         return payload
 
     async def _notify(self, method: str, params: dict[str, Any]) -> None:
+        """POST one JSON-RPC notification, accepting any 2xx response."""
         client = self._require_client(method)
         payload = {
             "jsonrpc": "2.0",
@@ -630,6 +674,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
             raise self._status_error(response.status_code, method)
 
     def _require_client(self, method: str) -> httpx.AsyncClient:
+        """Return the live HTTP client or raise not_connected."""
         client = self._client
         if client is None:
             raise self._error(
@@ -640,6 +685,7 @@ class StreamableHttpExternalTransport(_HttpExternalTransportBase):
         return client
 
     async def _close_client(self) -> None:
+        """Send session DELETE (bounded), close the client, and reset state."""
         client = self._client
         self._client = None
         self._initialized = False
@@ -761,7 +807,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
 
     async def close(self) -> None:
         """Close the SSE stream, fail pending requests, and release the client."""
-        async with self._connect_lock:
+        async with self._request_lock, self._connect_lock:
             await self._teardown()
 
     async def health_check(self) -> dict[str, bool]:
@@ -842,6 +888,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
             returned as ``is_error`` results rather than raised.
         """
         del context
+        extra_headers = self._runtime_auth_headers(runtime_auth)
         async with self._request_lock:
             await self._ensure_connected()
             params: dict[str, Any] = {
@@ -852,18 +899,21 @@ class SseExternalTransport(_HttpExternalTransportBase):
                 "tools/call",
                 params,
                 raise_on_error=False,
-                extra_headers=self._runtime_auth_headers(runtime_auth),
+                extra_headers=extra_headers,
             )
         return self._tool_call_result(tool_name, response)
 
     async def _ensure_connected(self) -> None:
+        """Connect (or reconnect) if the transport is not initialized."""
         if not self._initialized or not self._reader_alive():
             await self.connect()
 
     def _reader_alive(self) -> bool:
+        """Return whether the background stream reader task is running."""
         return self._reader_task is not None and not self._reader_task.done()
 
     async def _read_endpoint_event(self) -> str:
+        """Consume stream events until the endpoint event arrives."""
         events = self._events
         if events is None:
             raise self._error(
@@ -879,6 +929,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
         )
 
     async def _pump_events(self) -> None:
+        """Route streamed JSON-RPC responses to their pending futures."""
         events = self._events
         if events is None:
             return
@@ -893,13 +944,18 @@ class SseExternalTransport(_HttpExternalTransportBase):
                 future = self._pending.pop(payload.get("id"), None)
                 if future is not None and not future.done():
                     future.set_result(payload)
-        except Exception:  # noqa: BLE001 - stream teardown races vary by backend.
-            pass
+        except Exception as exc:  # noqa: BLE001 - stream teardown races vary by backend.
+            logger.debug(
+                "External SSE stream reader ended for server {server_id}: {error_type}",
+                server_id=self.server_id,
+                error_type=type(exc).__name__,
+            )
         finally:
             self._initialized = False
             self._fail_pending("connection_closed")
 
     def _fail_pending(self, reason_code: str) -> None:
+        """Fail every pending request future with a reason-coded error."""
         pending = list(self._pending.values())
         self._pending.clear()
         for future in pending:
@@ -920,6 +976,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
         raise_on_error: bool = True,
         extra_headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
+        """Send one JSON-RPC request and return the correlated response payload."""
         request_id = self._take_request_id()
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
@@ -929,10 +986,15 @@ class SseExternalTransport(_HttpExternalTransportBase):
             "method": method,
             "params": deepcopy(params or {}),
         }
-        try:
+
+        async def _round_trip() -> dict[str, Any]:
+            """POST the payload, then await the stream-correlated response."""
             await self._post_payload(payload, method, extra_headers)
+            return await future
+
+        try:
             response = await asyncio.wait_for(
-                future, timeout=timeout_s or self._request_timeout_s
+                _round_trip(), timeout=timeout_s or self._request_timeout_s
             )
         except asyncio.TimeoutError as exc:
             raise self._error(
@@ -952,6 +1014,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
         return response
 
     async def _post_notification(self, method: str, params: dict[str, Any]) -> None:
+        """POST one JSON-RPC notification to the message endpoint."""
         payload = {
             "jsonrpc": "2.0",
             "method": method,
@@ -965,6 +1028,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
         method: str,
         extra_headers: dict[str, str] | None,
     ) -> None:
+        """POST one JSON-RPC payload to the resolved message endpoint."""
         client = self._client
         endpoint = self._endpoint_url
         if client is None or endpoint is None:
@@ -993,6 +1057,7 @@ class SseExternalTransport(_HttpExternalTransportBase):
             raise self._status_error(response.status_code, method)
 
     async def _teardown(self) -> None:
+        """Cancel the reader, close stream and client, and fail pending requests."""
         reader_task = self._reader_task
         self._reader_task = None
         if reader_task is not None:

--- a/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/http_transport.py
@@ -1,0 +1,969 @@
+"""Upstream Streamable HTTP and legacy SSE transports for external MCP servers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import math
+import ssl
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
+from mcp_unified.federation.resource_payloads import (
+    normalize_external_resource_list,
+    normalize_external_resource_read,
+)
+from mcp_unified.storage.models import ExternalServerDefinition
+
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+_CLIENT_INFO = {"name": "mcp_unified_external_federation", "version": "0.1.0"}
+_DEFAULT_CONNECT_TIMEOUT_S = 30.0
+_DEFAULT_REQUEST_TIMEOUT_S = 30.0
+_DEFAULT_HEALTH_TIMEOUT_S = 5.0
+_SESSION_HEADER = "mcp-session-id"
+_ACCEPT_BOTH = "application/json, text/event-stream"
+
+
+class HttpExternalTransportError(RuntimeError):
+    """Raised when an HTTP transport operation fails without exposing secrets."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        server_id: str | None = None,
+        method: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(f"{message} (reason_code={reason_code})")
+        self.reason_code = reason_code
+        self.server_id = server_id
+        self.method = method
+        self.details = deepcopy(details or {})
+
+
+def _reason_code_for_transport_error(exc: httpx.HTTPError) -> str:
+    """Map an httpx transport failure to a stable, secret-free reason code.
+
+    Args:
+        exc: The httpx error raised while sending a request or reading a response.
+
+    Returns:
+        One of ``"tls_failed"``, ``"connect_failed"``, ``"request_timeout"``, or
+        ``"connection_closed"``.
+    """
+    if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout)):
+        cause: BaseException | None = exc
+        while cause is not None:
+            if isinstance(cause, ssl.SSLError):
+                return "tls_failed"
+            cause = cause.__cause__ or cause.__context__
+        return "connect_failed"
+    if isinstance(exc, httpx.TimeoutException):
+        return "request_timeout"
+    return "connection_closed"
+
+
+def _normalize_tool_definitions(result: Any) -> list[ExternalToolDefinition]:
+    """Normalize a ``tools/list`` result into external tool definitions.
+
+    Args:
+        result: The raw ``result`` member of a ``tools/list`` JSON-RPC response.
+
+    Returns:
+        Valid tool definitions; rows without a usable name are dropped, and
+        malformed descriptions, schemas, and metadata fall back to safe defaults.
+    """
+    if isinstance(result, dict):
+        raw_tools = result.get("tools") or []
+    elif isinstance(result, list):
+        raw_tools = result
+    else:
+        raw_tools = []
+
+    tools: list[ExternalToolDefinition] = []
+    for item in raw_tools:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        description = item.get("description")
+        if not isinstance(description, str):
+            description = ""
+        input_schema = item.get("inputSchema")
+        if not isinstance(input_schema, dict):
+            input_schema = {"type": "object"}
+        metadata = item.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        tools.append(
+            ExternalToolDefinition(
+                name=name,
+                description=description,
+                input_schema=deepcopy(input_schema),
+                metadata=deepcopy(metadata),
+            )
+        )
+    return tools
+
+
+async def _iter_sse_events(lines: AsyncIterator[str]) -> AsyncIterator[tuple[str, str]]:
+    """Yield ``(event, data)`` pairs from a text/event-stream line iterator.
+
+    Args:
+        lines: Decoded lines of an SSE body, without line terminators.
+
+    Yields:
+        Each dispatched event as an ``(event_name, joined_data)`` tuple.
+    """
+    event = "message"
+    data_lines: list[str] = []
+    async for raw in lines:
+        line = raw.rstrip("\r")
+        if not line:
+            if data_lines:
+                yield event, "\n".join(data_lines)
+            event = "message"
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        field, _, value = line.partition(":")
+        value = value.removeprefix(" ")
+        if field == "event":
+            event = value
+        elif field == "data":
+            data_lines.append(value)
+    if data_lines:
+        yield event, "\n".join(data_lines)
+
+
+class _HttpExternalTransportBase:
+    """Shared plumbing for URL-targeted external MCP transports."""
+
+    transport_name = ""
+
+    def __init__(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        connect_timeout_s: float = _DEFAULT_CONNECT_TIMEOUT_S,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+        health_timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+    ) -> None:
+        self._server = server.model_copy(deep=True)
+        self.server_id = self._server.id
+        if self._server.transport != self.transport_name:
+            raise self._error(
+                "External HTTP transport received an unsupported server transport",
+                reason_code="unsupported_transport",
+            )
+        url = (self._server.url or "").strip()
+        scheme = urlsplit(url).scheme.lower()
+        if not url or scheme not in ("http", "https"):
+            raise self._error(
+                "External HTTP transport requires an http(s) url",
+                reason_code="invalid_url",
+            )
+        self._url = url
+        self._static_headers = {
+            str(k): str(v) for k, v in (self._server.headers or {}).items()
+        }
+        self._connect_timeout_s = self._positive_timeout(connect_timeout_s, "connect_timeout_s")
+        self._request_timeout_s = self._positive_timeout(request_timeout_s, "request_timeout_s")
+        self._health_timeout_s = self._positive_timeout(health_timeout_s, "health_timeout_s")
+        self._connect_lock = asyncio.Lock()
+        self._next_request_id = 1
+        self._initialized = False
+
+    def _take_request_id(self) -> int:
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        return request_id
+
+    def _error(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        method: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> HttpExternalTransportError:
+        return HttpExternalTransportError(
+            message,
+            reason_code=reason_code,
+            server_id=getattr(self, "server_id", None),
+            method=method,
+            details=details,
+        )
+
+    def _status_error(self, status: int, method: str | None) -> HttpExternalTransportError:
+        if status in (401, 403):
+            return self._error(
+                "External HTTP server requires authorization",
+                reason_code="auth_required",
+                method=method,
+                details={"status": status},
+            )
+        return self._error(
+            "External HTTP server returned an error status",
+            reason_code="upstream_http_error",
+            method=method,
+            details={"status": status},
+        )
+
+    def _transport_error(
+        self, exc: httpx.HTTPError, method: str | None
+    ) -> HttpExternalTransportError:
+        return self._error(
+            "External HTTP request failed",
+            reason_code=_reason_code_for_transport_error(exc),
+            method=method,
+        )
+
+    @staticmethod
+    def _runtime_auth_headers(
+        runtime_auth: BrokeredExternalCredential | None,
+    ) -> dict[str, str]:
+        if runtime_auth is None or not runtime_auth.headers:
+            return {}
+        return {str(k): str(v) for k, v in runtime_auth.headers.items()}
+
+    @classmethod
+    def _positive_timeout(cls, value: float, field_name: str) -> float:
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError) as exc:
+            raise HttpExternalTransportError(
+                f"External HTTP transport {field_name} must be a finite positive number",
+                reason_code="invalid_timeout",
+            ) from exc
+        if timeout <= 0 or not math.isfinite(timeout):
+            raise HttpExternalTransportError(
+                f"External HTTP transport {field_name} must be a finite positive number",
+                reason_code="invalid_timeout",
+            )
+        return timeout
+
+    @staticmethod
+    def _encode_payload(payload: dict[str, Any], method: str) -> bytes:
+        try:
+            return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise HttpExternalTransportError(
+                "External HTTP request is not JSON serializable",
+                reason_code="invalid_request",
+                method=method,
+            ) from exc
+
+    def _tool_call_result(
+        self, tool_name: str, response: dict[str, Any]
+    ) -> ExternalToolCallResult:
+        error = response.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if not isinstance(message, str) or not message:
+                message = "External MCP tool call failed"
+            return ExternalToolCallResult(
+                content=[{"type": "text", "text": message}],
+                is_error=True,
+                metadata={
+                    "server_id": self.server_id,
+                    "tool_name": tool_name,
+                    "reason_code": "upstream_error",
+                },
+            )
+        result = response.get("result")
+        if isinstance(result, dict):
+            content = result.get("content") if "content" in result else result
+            is_error = bool(result.get("isError"))
+        else:
+            content = result
+            is_error = False
+        return ExternalToolCallResult(
+            content=deepcopy(content),
+            is_error=is_error,
+            metadata={"server_id": self.server_id, "tool_name": tool_name},
+        )
+
+
+class StreamableHttpExternalTransport(_HttpExternalTransportBase):
+    """MCP Streamable HTTP transport: JSON-RPC POSTs against a single endpoint."""
+
+    transport_name = "streamable_http"
+
+    def __init__(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        connect_timeout_s: float = _DEFAULT_CONNECT_TIMEOUT_S,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+        health_timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+    ) -> None:
+        super().__init__(
+            server,
+            connect_timeout_s=connect_timeout_s,
+            request_timeout_s=request_timeout_s,
+            health_timeout_s=health_timeout_s,
+        )
+        self._client: httpx.AsyncClient | None = None
+        self._session_id: str | None = None
+
+    async def connect(self) -> None:
+        """Initialize an MCP session against the configured endpoint."""
+        if self._initialized and self._client is not None:
+            return
+        async with self._connect_lock:
+            if self._initialized and self._client is not None:
+                return
+            await self._close_client()
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    self._request_timeout_s, connect=self._connect_timeout_s
+                )
+            )
+            try:
+                await self._request(
+                    "initialize",
+                    {
+                        "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": _CLIENT_INFO,
+                    },
+                    timeout_s=self._connect_timeout_s,
+                )
+                await self._notify("notifications/initialized", {})
+            except Exception:
+                await self._close_client()
+                raise
+            self._initialized = True
+
+    async def close(self) -> None:
+        """Terminate the MCP session and release the HTTP client."""
+        async with self._connect_lock:
+            await self._close_client()
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return quick connectivity and initialization health indicators.
+
+        Returns:
+            Boolean checks: ``configured``, ``connected``, ``initialized``, and
+            ``spawns_process`` (always ``False`` for HTTP transports).
+        """
+        checks = {
+            "configured": True,
+            "connected": self._client is not None,
+            "initialized": self._initialized and self._client is not None,
+            "spawns_process": False,
+        }
+        if not checks["initialized"]:
+            return checks
+        try:
+            await self._request("ping", {}, timeout_s=self._health_timeout_s)
+        except HttpExternalTransportError:
+            self._initialized = False
+            checks["connected"] = False
+            checks["initialized"] = False
+        return checks
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Discover and normalize upstream MCP tool definitions."""
+        await self._ensure_connected()
+        response = await self._request("tools/list", {})
+        return _normalize_tool_definitions(response.get("result"))
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover and normalize upstream MCP resource descriptors."""
+        await self._ensure_connected()
+        response = await self._request("resources/list", {})
+        return normalize_external_resource_list(response.get("result"))
+
+    async def read_resource(self, uri: str, *, context: Any = None) -> dict[str, Any]:
+        """Read one upstream MCP resource.
+
+        Args:
+            uri: The upstream resource URI to read.
+            context: Unused; accepted for transport-protocol compatibility.
+
+        Returns:
+            The normalized ``resources/read`` result payload.
+        """
+        del context
+        await self._ensure_connected()
+        response = await self._request("resources/read", {"uri": uri})
+        return normalize_external_resource_read(response.get("result"))
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        """Execute one upstream MCP tool call.
+
+        Args:
+            tool_name: Upstream tool name to invoke.
+            arguments: JSON-serializable tool arguments.
+            context: Unused; accepted for transport-protocol compatibility.
+            runtime_auth: Optional brokered credential; its ``headers`` are merged
+                into this call's HTTP headers (``env`` has no HTTP equivalent and
+                is ignored).
+
+        Returns:
+            The normalized tool call result; upstream JSON-RPC errors are
+            returned as ``is_error`` results rather than raised.
+        """
+        del context
+        await self._ensure_connected()
+        params: dict[str, Any] = {
+            "name": tool_name,
+            "arguments": deepcopy(arguments or {}),
+        }
+        response = await self._request(
+            "tools/call",
+            params,
+            raise_on_error=False,
+            extra_headers=self._runtime_auth_headers(runtime_auth),
+        )
+        return self._tool_call_result(tool_name, response)
+
+    async def _ensure_connected(self) -> None:
+        if not self._initialized or self._client is None:
+            await self.connect()
+
+    def _base_headers(self, extra_headers: dict[str, str] | None) -> dict[str, str]:
+        headers = {
+            "accept": _ACCEPT_BOTH,
+            "content-type": "application/json",
+            **self._static_headers,
+        }
+        if self._session_id:
+            headers[_SESSION_HEADER] = self._session_id
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
+
+    async def _request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_s: float | None = None,
+        raise_on_error: bool = True,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        client = self._require_client(method)
+        request_id = self._take_request_id()
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": deepcopy(params or {}),
+        }
+        encoded = self._encode_payload(payload, method)
+        try:
+            async with client.stream(
+                "POST",
+                self._url,
+                content=encoded,
+                headers=self._base_headers(extra_headers),
+                timeout=timeout_s or self._request_timeout_s,
+            ) as response:
+                if response.status_code == 404 and self._session_id:
+                    self._session_id = None
+                    self._initialized = False
+                if response.status_code >= 400:
+                    raise self._status_error(response.status_code, method)
+                session_id = response.headers.get(_SESSION_HEADER)
+                if session_id:
+                    self._session_id = session_id
+                content_type = response.headers.get("content-type", "")
+                if content_type.startswith("text/event-stream"):
+                    result = await self._read_sse_response(
+                        response, request_id, method
+                    )
+                else:
+                    body = await response.aread()
+                    result = self._decode_json_response(body, method)
+        except HttpExternalTransportError:
+            raise
+        except httpx.HTTPError as exc:
+            raise self._transport_error(exc, method) from exc
+
+        if result.get("error") and raise_on_error:
+            raise self._error(
+                f"External HTTP request failed for method '{method}'",
+                reason_code="upstream_error",
+                method=method,
+            )
+        return result
+
+    async def _read_sse_response(
+        self, response: httpx.Response, request_id: int, method: str
+    ) -> dict[str, Any]:
+        async for _event, data in _iter_sse_events(response.aiter_lines()):
+            try:
+                payload = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict) and payload.get("id") == request_id:
+                return payload
+        raise self._error(
+            "External HTTP SSE response ended without a matching response",
+            reason_code="connection_closed",
+            method=method,
+        )
+
+    def _decode_json_response(self, body: bytes, method: str) -> dict[str, Any]:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise self._error(
+                "External HTTP response is not valid JSON",
+                reason_code="invalid_response",
+                method=method,
+            ) from exc
+        if not isinstance(payload, dict):
+            raise self._error(
+                "External HTTP response is not a JSON-RPC object",
+                reason_code="invalid_response",
+                method=method,
+            )
+        return payload
+
+    async def _notify(self, method: str, params: dict[str, Any]) -> None:
+        client = self._require_client(method)
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": deepcopy(params or {}),
+        }
+        encoded = self._encode_payload(payload, method)
+        try:
+            response = await client.post(
+                self._url,
+                content=encoded,
+                headers=self._base_headers(None),
+                timeout=self._request_timeout_s,
+            )
+        except httpx.HTTPError as exc:
+            raise self._transport_error(exc, method) from exc
+        if response.status_code >= 400:
+            raise self._status_error(response.status_code, method)
+
+    def _require_client(self, method: str) -> httpx.AsyncClient:
+        client = self._client
+        if client is None:
+            raise self._error(
+                "External HTTP transport is not connected",
+                reason_code="not_connected",
+                method=method,
+            )
+        return client
+
+    async def _close_client(self) -> None:
+        client = self._client
+        self._client = None
+        self._initialized = False
+        if client is None:
+            self._session_id = None
+            return
+        if self._session_id:
+            with contextlib.suppress(Exception):
+                await client.delete(
+                    self._url,
+                    headers={**self._static_headers, _SESSION_HEADER: self._session_id},
+                    timeout=self._request_timeout_s,
+                )
+        self._session_id = None
+        with contextlib.suppress(Exception):
+            await client.aclose()
+
+
+class SseExternalTransport(_HttpExternalTransportBase):
+    """Legacy MCP HTTP+SSE transport: persistent GET stream plus POSTed messages."""
+
+    transport_name = "sse"
+
+    def __init__(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        connect_timeout_s: float = _DEFAULT_CONNECT_TIMEOUT_S,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+        health_timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+    ) -> None:
+        super().__init__(
+            server,
+            connect_timeout_s=connect_timeout_s,
+            request_timeout_s=request_timeout_s,
+            health_timeout_s=health_timeout_s,
+        )
+        self._client: httpx.AsyncClient | None = None
+        self._stream_response: httpx.Response | None = None
+        self._events: AsyncIterator[tuple[str, str]] | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._endpoint_url: str | None = None
+        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+
+    async def connect(self) -> None:
+        """Open the SSE stream, resolve the message endpoint, and initialize."""
+        if self._initialized and self._reader_alive():
+            return
+        async with self._connect_lock:
+            if self._initialized and self._reader_alive():
+                return
+            await self._teardown()
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    self._request_timeout_s,
+                    connect=self._connect_timeout_s,
+                    read=None,
+                )
+            )
+            try:
+                request = self._client.build_request(
+                    "GET",
+                    self._url,
+                    headers={**self._static_headers, "accept": "text/event-stream"},
+                )
+                try:
+                    response = await self._client.send(request, stream=True)
+                except httpx.HTTPError as exc:
+                    raise self._transport_error(exc, "connect") from exc
+                if response.status_code >= 400:
+                    status = response.status_code
+                    await response.aclose()
+                    raise self._status_error(status, "connect")
+                self._stream_response = response
+                self._events = _iter_sse_events(response.aiter_lines())
+                endpoint = await asyncio.wait_for(
+                    self._read_endpoint_event(),
+                    timeout=self._connect_timeout_s,
+                )
+                self._endpoint_url = urljoin(str(response.url), endpoint)
+                self._reader_task = asyncio.create_task(self._pump_events())
+                await self._request(
+                    "initialize",
+                    {
+                        "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": _CLIENT_INFO,
+                    },
+                    timeout_s=self._connect_timeout_s,
+                )
+                await self._post_notification("notifications/initialized", {})
+            except HttpExternalTransportError:
+                await self._teardown()
+                raise
+            except asyncio.TimeoutError as exc:
+                await self._teardown()
+                raise self._error(
+                    "External SSE stream did not provide a message endpoint in time",
+                    reason_code="connect_timeout",
+                ) from exc
+            except httpx.HTTPError as exc:
+                await self._teardown()
+                raise self._transport_error(exc, "connect") from exc
+            except Exception:
+                await self._teardown()
+                raise
+            self._initialized = True
+
+    async def close(self) -> None:
+        """Close the SSE stream, fail pending requests, and release the client."""
+        async with self._connect_lock:
+            await self._teardown()
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return quick connectivity and initialization health indicators.
+
+        Returns:
+            Boolean checks: ``configured``, ``connected``, ``initialized``, and
+            ``spawns_process`` (always ``False`` for HTTP transports).
+        """
+        checks = {
+            "configured": True,
+            "connected": self._reader_alive(),
+            "initialized": self._initialized and self._reader_alive(),
+            "spawns_process": False,
+        }
+        if not checks["initialized"]:
+            self._initialized = False
+            return checks
+        try:
+            await self._request("ping", {}, timeout_s=self._health_timeout_s)
+        except HttpExternalTransportError:
+            self._initialized = False
+            checks["connected"] = False
+            checks["initialized"] = False
+        return checks
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Discover and normalize upstream MCP tool definitions."""
+        await self._ensure_connected()
+        response = await self._request("tools/list", {})
+        return _normalize_tool_definitions(response.get("result"))
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover and normalize upstream MCP resource descriptors."""
+        await self._ensure_connected()
+        response = await self._request("resources/list", {})
+        return normalize_external_resource_list(response.get("result"))
+
+    async def read_resource(self, uri: str, *, context: Any = None) -> dict[str, Any]:
+        """Read one upstream MCP resource.
+
+        Args:
+            uri: The upstream resource URI to read.
+            context: Unused; accepted for transport-protocol compatibility.
+
+        Returns:
+            The normalized ``resources/read`` result payload.
+        """
+        del context
+        await self._ensure_connected()
+        response = await self._request("resources/read", {"uri": uri})
+        return normalize_external_resource_read(response.get("result"))
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        """Execute one upstream MCP tool call.
+
+        Args:
+            tool_name: Upstream tool name to invoke.
+            arguments: JSON-serializable tool arguments.
+            context: Unused; accepted for transport-protocol compatibility.
+            runtime_auth: Optional brokered credential; its ``headers`` are merged
+                into this call's POST headers (``env`` has no HTTP equivalent and
+                is ignored).
+
+        Returns:
+            The normalized tool call result; upstream JSON-RPC errors are
+            returned as ``is_error`` results rather than raised.
+        """
+        del context
+        await self._ensure_connected()
+        params: dict[str, Any] = {
+            "name": tool_name,
+            "arguments": deepcopy(arguments or {}),
+        }
+        response = await self._request(
+            "tools/call",
+            params,
+            raise_on_error=False,
+            extra_headers=self._runtime_auth_headers(runtime_auth),
+        )
+        return self._tool_call_result(tool_name, response)
+
+    async def _ensure_connected(self) -> None:
+        if not self._initialized or not self._reader_alive():
+            await self.connect()
+
+    def _reader_alive(self) -> bool:
+        return self._reader_task is not None and not self._reader_task.done()
+
+    async def _read_endpoint_event(self) -> str:
+        events = self._events
+        if events is None:
+            raise self._error(
+                "External SSE stream is not connected",
+                reason_code="not_connected",
+            )
+        async for event, data in events:
+            if event == "endpoint" and data.strip():
+                return data.strip()
+        raise self._error(
+            "External SSE stream closed before providing a message endpoint",
+            reason_code="connection_closed",
+        )
+
+    async def _pump_events(self) -> None:
+        events = self._events
+        if events is None:
+            return
+        try:
+            async for _event, data in events:
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                future = self._pending.pop(payload.get("id"), None)
+                if future is not None and not future.done():
+                    future.set_result(payload)
+        except Exception:  # noqa: BLE001 - stream teardown races vary by backend.
+            pass
+        finally:
+            self._initialized = False
+            self._fail_pending("connection_closed")
+
+    def _fail_pending(self, reason_code: str) -> None:
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for future in pending:
+            if not future.done():
+                future.set_exception(
+                    self._error(
+                        "External SSE stream closed before the response arrived",
+                        reason_code=reason_code,
+                    )
+                )
+
+    async def _request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_s: float | None = None,
+        raise_on_error: bool = True,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        request_id = self._take_request_id()
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": deepcopy(params or {}),
+        }
+        try:
+            await self._post_payload(payload, method, extra_headers)
+            response = await asyncio.wait_for(
+                future, timeout=timeout_s or self._request_timeout_s
+            )
+        except asyncio.TimeoutError as exc:
+            raise self._error(
+                f"External SSE request timed out for method '{method}'",
+                reason_code="request_timeout",
+                method=method,
+            ) from exc
+        finally:
+            self._pending.pop(request_id, None)
+
+        if response.get("error") and raise_on_error:
+            raise self._error(
+                f"External SSE request failed for method '{method}'",
+                reason_code="upstream_error",
+                method=method,
+            )
+        return response
+
+    async def _post_notification(self, method: str, params: dict[str, Any]) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": deepcopy(params or {}),
+        }
+        await self._post_payload(payload, method, None)
+
+    async def _post_payload(
+        self,
+        payload: dict[str, Any],
+        method: str,
+        extra_headers: dict[str, str] | None,
+    ) -> None:
+        client = self._client
+        endpoint = self._endpoint_url
+        if client is None or endpoint is None:
+            raise self._error(
+                "External SSE transport is not connected",
+                reason_code="not_connected",
+                method=method,
+            )
+        headers = {
+            "content-type": "application/json",
+            **self._static_headers,
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        encoded = self._encode_payload(payload, method)
+        try:
+            response = await client.post(
+                endpoint,
+                content=encoded,
+                headers=headers,
+                timeout=self._request_timeout_s,
+            )
+        except httpx.HTTPError as exc:
+            raise self._transport_error(exc, method) from exc
+        if response.status_code >= 400:
+            raise self._status_error(response.status_code, method)
+
+    async def _teardown(self) -> None:
+        reader_task = self._reader_task
+        self._reader_task = None
+        if reader_task is not None:
+            reader_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await reader_task
+        stream_response = self._stream_response
+        self._stream_response = None
+        self._events = None
+        if stream_response is not None:
+            with contextlib.suppress(Exception):
+                await stream_response.aclose()
+        client = self._client
+        self._client = None
+        if client is not None:
+            with contextlib.suppress(Exception):
+                await client.aclose()
+        self._endpoint_url = None
+        self._initialized = False
+        self._fail_pending("connection_closed")
+
+
+def create_http_external_transport(
+    server: ExternalServerDefinition,
+) -> StreamableHttpExternalTransport | SseExternalTransport:
+    """Create a URL-targeted external transport for a supported server definition.
+
+    Args:
+        server: The stored external server definition to connect to.
+
+    Returns:
+        A Streamable HTTP or SSE transport matching ``server.transport``.
+
+    Raises:
+        HttpExternalTransportError: If the definition's transport is not a
+            supported HTTP transport.
+    """
+    if server.transport == "streamable_http":
+        return StreamableHttpExternalTransport(server)
+    if server.transport == "sse":
+        return SseExternalTransport(server)
+    raise HttpExternalTransportError(
+        "External server transport is not supported by the HTTP factory",
+        reason_code="unsupported_transport",
+        server_id=server.id,
+    )
+
+
+__all__ = [
+    "HttpExternalTransportError",
+    "SseExternalTransport",
+    "StreamableHttpExternalTransport",
+    "create_http_external_transport",
+]

--- a/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
@@ -642,6 +642,10 @@ def create_external_transport(
     """Create a package-owned external transport for a supported server definition."""
     if server.transport == "stdio":
         return StdioExternalTransport(server, process_policy=process_policy)
+    if server.transport in ("streamable_http", "sse"):
+        from mcp_unified.federation.http_transport import create_http_external_transport
+
+        return create_http_external_transport(server)
     raise StdioExternalTransportError(
         "External server transport is not supported by the package factory",
         reason_code="unsupported_transport",

--- a/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
@@ -27,6 +27,7 @@ from mcp_unified.federation.resource_payloads import (
     normalize_external_resource_list,
     normalize_external_resource_read,
 )
+from mcp_unified.federation.transports import ExternalFederationTransport
 from mcp_unified.storage.models import ExternalServerDefinition
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
@@ -638,7 +639,7 @@ def create_external_transport(
     server: ExternalServerDefinition,
     *,
     process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None,
-) -> StdioExternalTransport:
+) -> ExternalFederationTransport:
     """Create a package-owned external transport for a supported server definition."""
     if server.transport == "stdio":
         return StdioExternalTransport(server, process_policy=process_policy)

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_registry.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_registry.py
@@ -31,6 +31,7 @@ _PATCH_FIELDS = frozenset(
         "cwd",
         "env_allowlist",
         "credential_slots",
+        "headers",
         "metadata",
         "provenance",
         "enabled",
@@ -508,12 +509,21 @@ class GatewayExternalRegistryManager:
         *,
         reason_code: str,
     ) -> None:
-        if not server.enabled or server.transport != "websocket":
+        if not server.enabled:
             return
         scheme = urlparse(server.url or "").scheme
-        if scheme not in {"ws", "wss"}:
+        if server.transport == "websocket" and scheme not in {"ws", "wss"}:
             raise self._error(
                 "Enabled websocket external servers require ws:// or wss:// URLs",
+                reason_code=reason_code,
+                server_id=server.id,
+            )
+        if server.transport in {"streamable_http", "sse"} and scheme not in {
+            "http",
+            "https",
+        }:
+            raise self._error(
+                "Enabled HTTP external servers require http:// or https:// URLs",
                 reason_code=reason_code,
                 server_id=server.id,
             )
@@ -665,7 +675,10 @@ class GatewayExternalRegistryManager:
 
     @staticmethod
     def _dump_server(server: ExternalServerDefinition) -> dict[str, Any]:
-        return server.model_dump(mode="json")
+        payload = server.model_dump(mode="json")
+        if payload.get("headers"):
+            payload["headers"] = dict.fromkeys(payload["headers"], "***")
+        return payload
 
     @staticmethod
     def _error(

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
@@ -1671,6 +1671,7 @@ class GatewayExternalRuntimeManager:
             tuple(server.command),
             server.url,
             server.cwd,
+            tuple(sorted(server.headers.items())),
             tuple(server.env_allowlist),
             tuple(server.credential_slots),
         )

--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -222,10 +222,11 @@ class PatchExternalServerRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
-    transport: Literal["stdio", "websocket"] | None = None
+    transport: Literal["stdio", "websocket", "streamable_http", "sse"] | None = None
     command: list[str] | None = None
     url: str | None = None
     cwd: str | None = None
+    headers: dict[str, str] | None = None
     env_allowlist: list[str] | None = None
     credential_slots: list[str] | None = None
     metadata: dict[str, Any] | None = None

--- a/apps/mcp-unified/src/mcp_unified/storage/models.py
+++ b/apps/mcp-unified/src/mcp_unified/storage/models.py
@@ -139,10 +139,11 @@ class ExternalServerDefinition(BaseModel):
 
     id: str
     name: str
-    transport: Literal["stdio", "websocket"]
+    transport: Literal["stdio", "websocket", "streamable_http", "sse"]
     command: list[str] = Field(default_factory=list)
     url: str | None = None
     cwd: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
     env_allowlist: list[str] = Field(default_factory=list)
     credential_slots: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -158,7 +159,7 @@ class ExternalServerDefinition(BaseModel):
         """Treat explicit null list fields as omitted safe defaults."""
         return _copy_list(value)
 
-    @field_validator("metadata", "provenance", mode="before")
+    @field_validator("metadata", "provenance", "headers", mode="before")
     @classmethod
     def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
         """Treat explicit null mapping fields as omitted safe defaults."""
@@ -177,8 +178,8 @@ class ExternalServerDefinition(BaseModel):
             return self
         if self.transport == "stdio" and not self.command:
             raise ValueError("stdio transport requires a non-empty command")
-        if self.transport == "websocket" and not self.url:
-            raise ValueError("websocket transport requires a non-empty url")
+        if self.transport in ("websocket", "streamable_http", "sse") and not self.url:
+            raise ValueError(f"{self.transport} transport requires a non-empty url")
         return self
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py
@@ -792,3 +792,19 @@ async def test_gateway_external_registry_rejects_enabled_http_transport_non_http
             )
         )
     assert excinfo.value.reason_code == "invalid_external_server_request"
+
+
+def test_patch_request_model_accepts_http_transports_and_headers() -> None:
+    """The FastAPI patch body must expose the new URL transports and headers so rotation works end to end."""
+    from mcp_unified.gateway.fastapi import PatchExternalServerRequest
+
+    request = PatchExternalServerRequest.model_validate(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.linear.example.test/mcp",
+            "headers": {"Authorization": "Bearer rotated"},
+        }
+    )
+    assert request.transport == "streamable_http"
+    assert request.headers == {"Authorization": "Bearer rotated"}
+    assert PatchExternalServerRequest.model_validate({"transport": "sse"}).transport == "sse"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py
@@ -729,3 +729,66 @@ async def test_gateway_external_registry_delete_ungranted_server_succeeds_and_au
         "external_server.deleted"
     ]
     assert audit_store.events[0].payload == {"server_id": "search"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_external_registry_redacts_header_values_in_responses() -> None:
+    store = InMemoryExternalRegistryStore()
+    manager = _manager(store)
+
+    created = await manager.create_server(
+        _server(
+            id="linear",
+            transport="streamable_http",
+            url="https://mcp.linear.example.test/mcp",
+            headers={"Authorization": "Bearer secret-token"},
+        )
+    )
+    assert created["server"]["headers"] == {"Authorization": "***"}
+
+    shown = await manager.show_server("linear")
+    assert shown["server"]["headers"] == {"Authorization": "***"}
+
+    listed = await manager.list_servers()
+    assert listed["servers"][0]["headers"] == {"Authorization": "***"}
+
+    stored = await store.get_server("linear")
+    assert stored.headers == {"Authorization": "Bearer secret-token"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_external_registry_patches_headers() -> None:
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(
+                id="linear",
+                transport="streamable_http",
+                url="https://mcp.linear.example.test/mcp",
+                headers={"Authorization": "Bearer old-token"},
+            )
+        ]
+    )
+    manager = _manager(store)
+
+    payload = await manager.patch_server(
+        "linear", {"headers": {"Authorization": "Bearer new-token"}}
+    )
+    assert payload["server"]["headers"] == {"Authorization": "***"}
+
+    stored = await store.get_server("linear")
+    assert stored.headers == {"Authorization": "Bearer new-token"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_external_registry_rejects_enabled_http_transport_non_http_url() -> None:
+    manager = _manager(InMemoryExternalRegistryStore())
+
+    with pytest.raises(GatewayExternalRegistryManagementError) as excinfo:
+        await manager.create_server(
+            _server(
+                id="bad",
+                transport="streamable_http",
+                url="wss://bad.example.test/mcp",
+            )
+        )
+    assert excinfo.value.reason_code == "invalid_external_server_request"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -1987,3 +1987,17 @@ async def test_external_runtime_installer_operation_failures_are_wrapped(
             expected_function,
         ]
     assert "do-not-leak" not in json.dumps(fake_logger.error_calls, sort_keys=True)
+
+
+def test_runtime_signature_detects_header_changes() -> None:
+    """A headers-only change must alter the reconcile signature so patched tokens restart transports."""
+    base = ExternalServerDefinition(
+        id="linear",
+        name="Linear",
+        transport="streamable_http",
+        url="https://mcp.linear.example.test/mcp",
+        headers={"Authorization": "Bearer old"},
+    )
+    rotated = base.model_copy(update={"headers": {"Authorization": "Bearer new"}})
+    assert GatewayExternalRuntimeManager._definition_changed(base, rotated)
+    assert not GatewayExternalRuntimeManager._definition_changed(base, base.model_copy(deep=True))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
 import pytest
 import uvicorn
+
+_Receive = Callable[[], Awaitable[dict[str, Any]]]
+_Send = Callable[[dict[str, Any]], Awaitable[None]]
+_Scope = dict[str, Any]
 from mcp_unified.federation.http_transport import (
     HttpExternalTransportError,
     SseExternalTransport,
@@ -23,6 +28,7 @@ _SESSION_ID = "stub-session-123"
 
 
 def _tool_rows() -> list[dict[str, Any]]:
+    """Return stub tool rows, including malformed ones that pin normalization."""
     return [
         {
             "name": "docs.search",
@@ -36,6 +42,7 @@ def _tool_rows() -> list[dict[str, Any]]:
 
 
 def _dispatch(message: dict[str, Any], headers: dict[str, str]) -> dict[str, Any] | None:
+    """Dispatch one stub JSON-RPC message and build its response payload."""
     request_id = message.get("id")
     method = message.get("method")
     params = message.get("params") or {}
@@ -95,7 +102,8 @@ def _dispatch(message: dict[str, Any], headers: dict[str, str]) -> dict[str, Any
     }
 
 
-async def _read_body(receive) -> bytes:
+async def _read_body(receive: _Receive) -> bytes:
+    """Collect a full ASGI request body."""
     body = b""
     while True:
         event = await receive()
@@ -104,7 +112,13 @@ async def _read_body(receive) -> bytes:
             return body
 
 
-async def _send_json(send, status: int, payload: Any, extra_headers: list[tuple[bytes, bytes]] | None = None) -> None:
+async def _send_json(
+    send: _Send,
+    status: int,
+    payload: Any,
+    extra_headers: list[tuple[bytes, bytes]] | None = None,
+) -> None:
+    """Send a JSON ASGI response with optional extra headers."""
     data = json.dumps(payload).encode("utf-8")
     headers = [(b"content-type", b"application/json")] + list(extra_headers or [])
     await send({"type": "http.response.start", "status": status, "headers": headers})
@@ -121,11 +135,14 @@ class StreamableHttpStub:
         auth_required: bool = False,
         keepalive_forever: bool = False,
         expire_session_once: bool = False,
+        wrong_response_id: bool = False,
     ) -> None:
+        """Configure stub behavior flags and recording state."""
         self.sse_responses = sse_responses
         self.auth_required = auth_required
         self.keepalive_forever = keepalive_forever
         self.expire_session_once = expire_session_once
+        self.wrong_response_id = wrong_response_id
         self.seen_methods: list[str] = []
         self.delete_count = 0
         self.init_params: dict[str, Any] | None = None
@@ -134,7 +151,8 @@ class StreamableHttpStub:
         self._in_flight = 0
         self.max_in_flight = 0
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        """Handle one ASGI request for the stub server."""
         assert scope["type"] == "http"
         headers = {k.decode(): v.decode() for k, v in scope["headers"]}
         if scope["method"] == "DELETE":
@@ -187,6 +205,9 @@ class StreamableHttpStub:
                 except Exception:  # noqa: BLE001 - client disconnects vary by backend.
                     return
         payload = _dispatch(message, headers)
+        if self.wrong_response_id and message.get("method") != "initialize":
+            payload = dict(payload or {})
+            payload["id"] = 999_999
         extra = []
         if message.get("method") == "initialize":
             extra.append((b"mcp-session-id", _SESSION_ID.encode()))
@@ -207,14 +228,19 @@ class StreamableHttpStub:
 class SseStub:
     """Minimal legacy HTTP+SSE MCP server: GET stream + POST message endpoint."""
 
-    def __init__(self, *, endpoint_data: str = "/messages") -> None:
+    def __init__(
+        self, *, endpoint_data: str = "/messages", post_drips_forever: bool = False
+    ) -> None:
+        """Configure stub behavior flags and recording state."""
         self._queue: asyncio.Queue[str] = asyncio.Queue()
         self.endpoint_data = endpoint_data
+        self.post_drips_forever = post_drips_forever
         self.seen_methods: list[str] = []
         self._in_flight = 0
         self.max_in_flight = 0
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        """Handle one ASGI request for the stub server."""
         assert scope["type"] == "http"
         if scope["method"] == "GET":
             await send({
@@ -258,6 +284,25 @@ class SseStub:
         finally:
             self._in_flight -= 1
         payload = _dispatch(message, headers)
+        if self.post_drips_forever and message.get("method") not in (
+            "initialize",
+            "notifications/initialized",
+        ):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            })
+            try:
+                while True:
+                    await send({
+                        "type": "http.response.body",
+                        "body": b"drip",
+                        "more_body": True,
+                    })
+                    await asyncio.sleep(0.1)
+            except Exception:  # noqa: BLE001 - client disconnects vary by backend.
+                return
         if payload is not None:
             frame = "event: message\ndata: " + json.dumps(payload, separators=(",", ":")) + "\n\n"
             await self._queue.put(frame)
@@ -265,7 +310,8 @@ class SseStub:
         await send({"type": "http.response.body", "body": b""})
 
     @staticmethod
-    async def _wait_disconnect(receive) -> None:
+    async def _wait_disconnect(receive: _Receive) -> None:
+        """Wait until the ASGI client disconnects."""
         while True:
             event = await receive()
             if event["type"] == "http.disconnect":
@@ -273,7 +319,8 @@ class SseStub:
 
 
 @asynccontextmanager
-async def _run_stub(app):
+async def _run_stub(app: Callable[..., Awaitable[None]]):
+    """Serve an ASGI stub on an ephemeral port for the test body."""
     config = uvicorn.Config(
         app,
         host="127.0.0.1",
@@ -297,6 +344,7 @@ async def _run_stub(app):
 
 
 def _http_server_definition(url: str, *, transport: str = "streamable_http", **overrides: Any) -> ExternalServerDefinition:
+    """Build a URL-transport server definition with overrides."""
     payload: dict[str, Any] = {
         "id": "srv-http",
         "name": "Stub HTTP",
@@ -308,13 +356,17 @@ def _http_server_definition(url: str, *, transport: str = "streamable_http", **o
 
 
 class TestServerDefinitionHttpTransports:
+    """Model-level pins for the URL transports."""
+
     def test_accepts_streamable_http_and_sse_with_url(self) -> None:
+        """Accepts streamable http and sse with url."""
         for transport in ("streamable_http", "sse"):
             definition = _http_server_definition("https://example.com/mcp", transport=transport)
             assert definition.transport == transport
             assert definition.url == "https://example.com/mcp"
 
     def test_requires_url_for_http_transports(self) -> None:
+        """Requires url for http transports."""
         for transport in ("streamable_http", "sse"):
             with pytest.raises(ValueError):
                 ExternalServerDefinition(
@@ -323,8 +375,11 @@ class TestServerDefinitionHttpTransports:
 
 
 class TestStreamableHttpTransport:
+    """Behavior pins for the Streamable HTTP transport."""
+
     @pytest.mark.asyncio
     async def test_connect_initializes_and_lists_tools_with_session(self) -> None:
+        """Connect initializes and lists tools with session."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -348,6 +403,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_call_tool_success_and_upstream_error(self) -> None:
+        """Call tool success and upstream error."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -367,6 +423,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_call_tool_merges_runtime_auth_headers(self) -> None:
+        """Call tool merges runtime auth headers."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -386,6 +443,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_static_definition_headers_satisfy_auth(self) -> None:
+        """Static definition headers satisfy auth."""
         stub = StreamableHttpStub(auth_required=True)
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -400,6 +458,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_auth_required_maps_reason_code(self) -> None:
+        """Auth required maps reason code."""
         stub = StreamableHttpStub(auth_required=True)
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -414,6 +473,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_sse_framed_post_responses_are_parsed(self) -> None:
+        """Sse framed post responses are parsed."""
         stub = StreamableHttpStub(sse_responses=True)
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -427,6 +487,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_resources_round_trip(self) -> None:
+        """Resources round trip."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -442,6 +503,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_health_check_pings(self) -> None:
+        """Health check pings."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -462,6 +524,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_connect_failure_maps_reason_code(self) -> None:
+        """Connect failure maps reason code."""
         import socket
 
         probe = socket.socket()
@@ -481,6 +544,7 @@ class TestStreamableHttpTransport:
         assert excinfo.value.reason_code == "connect_failed"
 
     def test_constructor_rejects_mismatched_definition(self) -> None:
+        """Constructor rejects mismatched definition."""
         definition = ExternalServerDefinition(
             id="srv", name="Stdio", transport="stdio", command=["echo"]
         )
@@ -489,6 +553,7 @@ class TestStreamableHttpTransport:
         assert excinfo.value.reason_code == "unsupported_transport"
 
     def test_constructor_rejects_non_http_url(self) -> None:
+        """Constructor rejects non http url."""
         definition = _http_server_definition("ftp://example.com/mcp")
         with pytest.raises(HttpExternalTransportError) as excinfo:
             StreamableHttpExternalTransport(definition)
@@ -496,6 +561,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_sse_framed_response_is_bounded_by_request_timeout(self) -> None:
+        """Sse framed response is bounded by request timeout."""
         from time import monotonic
 
         stub = StreamableHttpStub(keepalive_forever=True)
@@ -510,10 +576,11 @@ class TestStreamableHttpTransport:
             finally:
                 await transport.close()
         assert excinfo.value.reason_code == "request_timeout"
-        assert monotonic() - started < 5.0
+        assert monotonic() - started < 20.0
 
     @pytest.mark.asyncio
     async def test_requests_are_serialized(self) -> None:
+        """Requests are serialized."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -530,6 +597,7 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_expired_session_reinitializes_and_retries_once(self) -> None:
+        """Expired session reinitializes and retries once."""
         stub = StreamableHttpStub()
         async with _run_stub(stub) as url:
             transport = StreamableHttpExternalTransport(
@@ -545,6 +613,7 @@ class TestStreamableHttpTransport:
         assert stub.initialize_count == 2
 
     def test_authorization_over_plain_http_requires_loopback(self) -> None:
+        """Authorization over plain http requires loopback."""
         definition = _http_server_definition(
             "http://example.com/mcp", headers={"Authorization": "Bearer token"}
         )
@@ -552,7 +621,44 @@ class TestStreamableHttpTransport:
             StreamableHttpExternalTransport(definition)
         assert excinfo.value.reason_code == "insecure_url"
 
+    @pytest.mark.asyncio
+    async def test_json_response_with_mismatched_id_is_rejected(self) -> None:
+        """Json response with mismatched id is rejected."""
+        stub = StreamableHttpStub(wrong_response_id=True)
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                with pytest.raises(HttpExternalTransportError) as excinfo:
+                    await transport.list_tools()
+            finally:
+                await transport.close()
+        assert excinfo.value.reason_code == "invalid_response"
+
+    @pytest.mark.asyncio
+    async def test_brokered_credentials_over_plain_http_require_loopback(self) -> None:
+        """Brokered credentials over plain http require loopback."""
+        transport = StreamableHttpExternalTransport(
+            _http_server_definition("http://203.0.113.5/mcp"),
+            connect_timeout_s=0.5,
+            request_timeout_s=0.5,
+        )
+        try:
+            with pytest.raises(HttpExternalTransportError) as excinfo:
+                await transport.call_tool(
+                    "auth.echo",
+                    {},
+                    runtime_auth=BrokeredExternalCredential(
+                        headers={"Authorization": "Bearer brokered"}
+                    ),
+                )
+        finally:
+            await transport.close()
+        assert excinfo.value.reason_code == "insecure_url"
+
     def test_transport_error_reason_codes(self) -> None:
+        """Transport error reason codes."""
         import ssl
 
         from mcp_unified.federation.http_transport import _reason_code_for_transport_error
@@ -565,6 +671,7 @@ class TestStreamableHttpTransport:
         assert _reason_code_for_transport_error(httpx.RemoteProtocolError("eof")) == "connection_closed"
 
     def test_factory_dispatches_streamable_http(self) -> None:
+        """Factory dispatches streamable http."""
         transport = create_external_transport(
             _http_server_definition("https://example.com/mcp")
         )
@@ -574,8 +681,11 @@ class TestStreamableHttpTransport:
 
 
 class TestSseTransport:
+    """Behavior pins for the legacy HTTP+SSE transport."""
+
     @pytest.mark.asyncio
     async def test_connect_and_list_tools_via_stream(self) -> None:
+        """Connect and list tools via stream."""
         stub = SseStub()
         async with _run_stub(stub) as url:
             transport = SseExternalTransport(
@@ -591,6 +701,7 @@ class TestSseTransport:
 
     @pytest.mark.asyncio
     async def test_call_tool_with_runtime_auth(self) -> None:
+        """Call tool with runtime auth."""
         stub = SseStub()
         async with _run_stub(stub) as url:
             transport = SseExternalTransport(
@@ -613,6 +724,7 @@ class TestSseTransport:
 
     @pytest.mark.asyncio
     async def test_health_check_and_server_gone(self) -> None:
+        """Health check and server gone."""
         stub = SseStub()
         async with _run_stub(stub) as url:
             transport = SseExternalTransport(
@@ -640,6 +752,7 @@ class TestSseTransport:
 
     @pytest.mark.asyncio
     async def test_cross_origin_endpoint_event_is_rejected(self) -> None:
+        """Cross origin endpoint event is rejected."""
         stub = SseStub(endpoint_data="http://attacker.example.com/steal")
         async with _run_stub(stub) as url:
             transport = SseExternalTransport(
@@ -657,6 +770,7 @@ class TestSseTransport:
 
     @pytest.mark.asyncio
     async def test_requests_are_serialized(self) -> None:
+        """Requests are serialized."""
         stub = SseStub()
         async with _run_stub(stub) as url:
             transport = SseExternalTransport(
@@ -671,7 +785,27 @@ class TestSseTransport:
                 await transport.close()
         assert stub.max_in_flight == 1
 
+    @pytest.mark.asyncio
+    async def test_dripping_post_response_is_bounded_by_request_timeout(self) -> None:
+        """Dripping post response is bounded by request timeout."""
+        from time import monotonic
+
+        stub = SseStub(post_drips_forever=True)
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"), request_timeout_s=1.0
+            )
+            started = monotonic()
+            try:
+                with pytest.raises(HttpExternalTransportError) as excinfo:
+                    await transport.call_tool("docs.search", {"q": "x"})
+            finally:
+                await transport.close()
+        assert excinfo.value.reason_code == "request_timeout"
+        assert monotonic() - started < 20.0
+
     def test_factory_dispatches_sse(self) -> None:
+        """Factory dispatches sse."""
         transport = create_external_transport(
             _http_server_definition("https://example.com/sse", transport="sse")
         )
@@ -680,11 +814,15 @@ class TestSseTransport:
 
 
 class TestSseEventParser:
+    """Edge-case pins for the shared SSE event parser."""
+
     @pytest.mark.asyncio
     async def test_parser_edge_cases(self) -> None:
+        """Parser edge cases."""
         from mcp_unified.federation.http_transport import _iter_sse_events
 
         async def lines():
+            """Yield the synthetic SSE lines under test."""
             for line in [
                 ": comment ignored",
                 "data: first",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
@@ -114,11 +114,25 @@ async def _send_json(send, status: int, payload: Any, extra_headers: list[tuple[
 class StreamableHttpStub:
     """Minimal Streamable HTTP MCP server: one endpoint, JSON or SSE responses."""
 
-    def __init__(self, *, sse_responses: bool = False, auth_required: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        sse_responses: bool = False,
+        auth_required: bool = False,
+        keepalive_forever: bool = False,
+        expire_session_once: bool = False,
+    ) -> None:
         self.sse_responses = sse_responses
         self.auth_required = auth_required
+        self.keepalive_forever = keepalive_forever
+        self.expire_session_once = expire_session_once
         self.seen_methods: list[str] = []
         self.delete_count = 0
+        self.init_params: dict[str, Any] | None = None
+        self.protocol_version_headers: list[str | None] = []
+        self.initialize_count = 0
+        self._in_flight = 0
+        self.max_in_flight = 0
 
     async def __call__(self, scope, receive, send) -> None:
         assert scope["type"] == "http"
@@ -134,13 +148,44 @@ class StreamableHttpStub:
             return
         message = json.loads(body)
         self.seen_methods.append(message.get("method"))
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            self._in_flight -= 1
         if message.get("id") is None:
             await send({"type": "http.response.start", "status": 202, "headers": []})
             await send({"type": "http.response.body", "body": b""})
             return
-        if message.get("method") != "initialize" and headers.get("mcp-session-id") != _SESSION_ID:
-            await _send_json(send, 400, {"error": "missing session"})
-            return
+        if message.get("method") == "initialize":
+            self.init_params = message.get("params") or {}
+            self.initialize_count += 1
+        else:
+            self.protocol_version_headers.append(headers.get("mcp-protocol-version"))
+            if headers.get("mcp-session-id") != _SESSION_ID:
+                await _send_json(send, 400, {"error": "missing session"})
+                return
+            if self.expire_session_once:
+                self.expire_session_once = False
+                await _send_json(send, 404, {"error": "session expired"})
+                return
+            if self.keepalive_forever:
+                await send({
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream")],
+                })
+                try:
+                    while True:
+                        await send({
+                            "type": "http.response.body",
+                            "body": b": keepalive\n\n",
+                            "more_body": True,
+                        })
+                        await asyncio.sleep(0.1)
+                except Exception:  # noqa: BLE001 - client disconnects vary by backend.
+                    return
         payload = _dispatch(message, headers)
         extra = []
         if message.get("method") == "initialize":
@@ -162,9 +207,12 @@ class StreamableHttpStub:
 class SseStub:
     """Minimal legacy HTTP+SSE MCP server: GET stream + POST message endpoint."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, endpoint_data: str = "/messages") -> None:
         self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self.endpoint_data = endpoint_data
         self.seen_methods: list[str] = []
+        self._in_flight = 0
+        self.max_in_flight = 0
 
     async def __call__(self, scope, receive, send) -> None:
         assert scope["type"] == "http"
@@ -176,7 +224,7 @@ class SseStub:
             })
             await send({
                 "type": "http.response.body",
-                "body": b"event: endpoint\ndata: /messages\n\n",
+                "body": f"event: endpoint\ndata: {self.endpoint_data}\n\n".encode(),
                 "more_body": True,
             })
             disconnect = asyncio.create_task(self._wait_disconnect(receive))
@@ -203,6 +251,12 @@ class SseStub:
         body = await _read_body(receive)
         message = json.loads(body)
         self.seen_methods.append(message.get("method"))
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            self._in_flight -= 1
         payload = _dispatch(message, headers)
         if payload is not None:
             frame = "event: message\ndata: " + json.dumps(payload, separators=(",", ":")) + "\n\n"
@@ -282,6 +336,8 @@ class TestStreamableHttpTransport:
             finally:
                 await transport.close()
         assert stub.seen_methods[:2] == ["initialize", "notifications/initialized"]
+        assert stub.init_params["protocolVersion"] == "2025-03-26"
+        assert stub.protocol_version_headers[-1] == "2024-11-05"
         assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
         assert tools[0].description == "Search docs"
         assert tools[0].input_schema["properties"]["q"]["type"] == "string"
@@ -406,8 +462,14 @@ class TestStreamableHttpTransport:
 
     @pytest.mark.asyncio
     async def test_connect_failure_maps_reason_code(self) -> None:
+        import socket
+
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        closed_port = probe.getsockname()[1]
+        probe.close()
         transport = StreamableHttpExternalTransport(
-            _http_server_definition("http://127.0.0.1:9"),
+            _http_server_definition(f"http://127.0.0.1:{closed_port}"),
             connect_timeout_s=2.0,
             request_timeout_s=2.0,
         )
@@ -431,6 +493,64 @@ class TestStreamableHttpTransport:
         with pytest.raises(HttpExternalTransportError) as excinfo:
             StreamableHttpExternalTransport(definition)
         assert excinfo.value.reason_code == "invalid_url"
+
+    @pytest.mark.asyncio
+    async def test_sse_framed_response_is_bounded_by_request_timeout(self) -> None:
+        from time import monotonic
+
+        stub = StreamableHttpStub(keepalive_forever=True)
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=1.0
+            )
+            started = monotonic()
+            try:
+                with pytest.raises(HttpExternalTransportError) as excinfo:
+                    await transport.list_tools()
+            finally:
+                await transport.close()
+        assert excinfo.value.reason_code == "request_timeout"
+        assert monotonic() - started < 5.0
+
+    @pytest.mark.asyncio
+    async def test_requests_are_serialized(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                await asyncio.gather(
+                    *(transport.call_tool("docs.search", {"q": str(i)}) for i in range(5))
+                )
+            finally:
+                await transport.close()
+        assert stub.max_in_flight == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_session_reinitializes_and_retries_once(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                stub.expire_session_once = True
+                tools = await transport.list_tools()
+            finally:
+                await transport.close()
+        assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+        assert stub.initialize_count == 2
+
+    def test_authorization_over_plain_http_requires_loopback(self) -> None:
+        definition = _http_server_definition(
+            "http://example.com/mcp", headers={"Authorization": "Bearer token"}
+        )
+        with pytest.raises(HttpExternalTransportError) as excinfo:
+            StreamableHttpExternalTransport(definition)
+        assert excinfo.value.reason_code == "insecure_url"
 
     def test_transport_error_reason_codes(self) -> None:
         import ssl
@@ -518,9 +638,70 @@ class TestSseTransport:
         finally:
             await transport.close()
 
+    @pytest.mark.asyncio
+    async def test_cross_origin_endpoint_event_is_rejected(self) -> None:
+        stub = SseStub(endpoint_data="http://attacker.example.com/steal")
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"),
+                connect_timeout_s=3.0,
+                request_timeout_s=3.0,
+            )
+            try:
+                with pytest.raises(HttpExternalTransportError) as excinfo:
+                    await transport.connect()
+            finally:
+                await transport.close()
+        assert excinfo.value.reason_code == "invalid_endpoint"
+        assert stub.seen_methods == []
+
+    @pytest.mark.asyncio
+    async def test_requests_are_serialized(self) -> None:
+        stub = SseStub()
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                await asyncio.gather(
+                    *(transport.call_tool("docs.search", {"q": str(i)}) for i in range(5))
+                )
+            finally:
+                await transport.close()
+        assert stub.max_in_flight == 1
+
     def test_factory_dispatches_sse(self) -> None:
         transport = create_external_transport(
             _http_server_definition("https://example.com/sse", transport="sse")
         )
         assert isinstance(transport, SseExternalTransport)
         assert transport.transport_name == "sse"
+
+
+class TestSseEventParser:
+    @pytest.mark.asyncio
+    async def test_parser_edge_cases(self) -> None:
+        from mcp_unified.federation.http_transport import _iter_sse_events
+
+        async def lines():
+            for line in [
+                ": comment ignored",
+                "data: first",
+                "data: second",
+                "",
+                "event: custom\r",
+                "data: with-cr\r",
+                "\r",
+                "data:no-space",
+                "",
+                "data: truncated tail without dispatch",
+            ]:
+                yield line
+
+        events = [item async for item in _iter_sse_events(lines())]
+        assert events == [
+            ("message", "first\nsecond"),
+            ("custom", "with-cr"),
+            ("message", "no-space"),
+        ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_external_transport.py
@@ -1,0 +1,526 @@
+"""Live-socket tests for the package Streamable HTTP and SSE MCP transports."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from mcp_unified.federation.http_transport import (
+    HttpExternalTransportError,
+    SseExternalTransport,
+    StreamableHttpExternalTransport,
+)
+from mcp_unified.federation.models import BrokeredExternalCredential
+from mcp_unified.federation.stdio_transport import create_external_transport
+from mcp_unified.storage import ExternalServerDefinition
+
+_SESSION_ID = "stub-session-123"
+
+
+def _tool_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "docs.search",
+            "description": "Search docs",
+            "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}},
+            "metadata": {"category": "read"},
+        },
+        {"name": "docs.defaulted", "description": 7, "inputSchema": "bad", "metadata": []},
+        {"name": 42, "description": "invalid"},
+    ]
+
+
+def _dispatch(message: dict[str, Any], headers: dict[str, str]) -> dict[str, Any] | None:
+    request_id = message.get("id")
+    method = message.get("method")
+    params = message.get("params") or {}
+    if request_id is None:
+        return None
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"protocolVersion": "2024-11-05", "serverInfo": {"name": "stub-http"}},
+        }
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"pong": True}}
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": _tool_rows()}}
+    if method == "tools/call":
+        name = params.get("name")
+        if name == "boom":
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32000, "message": "tool exploded"},
+            }
+        if name == "auth.echo":
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [{"type": "text", "text": headers.get("authorization", "")}],
+                    "isError": False,
+                },
+            }
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "content": [{"type": "text", "text": json.dumps(params.get("arguments") or {})}],
+                "isError": False,
+            },
+        }
+    if method == "resources/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"resources": [{"uri": "res://a", "name": "A"}]},
+        }
+    if method == "resources/read":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"contents": [{"uri": params.get("uri"), "text": "hello"}]},
+        }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": f"unknown method {method}"},
+    }
+
+
+async def _read_body(receive) -> bytes:
+    body = b""
+    while True:
+        event = await receive()
+        body += event.get("body", b"")
+        if not event.get("more_body"):
+            return body
+
+
+async def _send_json(send, status: int, payload: Any, extra_headers: list[tuple[bytes, bytes]] | None = None) -> None:
+    data = json.dumps(payload).encode("utf-8")
+    headers = [(b"content-type", b"application/json")] + list(extra_headers or [])
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": data})
+
+
+class StreamableHttpStub:
+    """Minimal Streamable HTTP MCP server: one endpoint, JSON or SSE responses."""
+
+    def __init__(self, *, sse_responses: bool = False, auth_required: bool = False) -> None:
+        self.sse_responses = sse_responses
+        self.auth_required = auth_required
+        self.seen_methods: list[str] = []
+        self.delete_count = 0
+
+    async def __call__(self, scope, receive, send) -> None:
+        assert scope["type"] == "http"
+        headers = {k.decode(): v.decode() for k, v in scope["headers"]}
+        if scope["method"] == "DELETE":
+            self.delete_count += 1
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+            return
+        body = await _read_body(receive)
+        if self.auth_required and not headers.get("authorization"):
+            await _send_json(send, 401, {"error": "auth required"})
+            return
+        message = json.loads(body)
+        self.seen_methods.append(message.get("method"))
+        if message.get("id") is None:
+            await send({"type": "http.response.start", "status": 202, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+            return
+        if message.get("method") != "initialize" and headers.get("mcp-session-id") != _SESSION_ID:
+            await _send_json(send, 400, {"error": "missing session"})
+            return
+        payload = _dispatch(message, headers)
+        extra = []
+        if message.get("method") == "initialize":
+            extra.append((b"mcp-session-id", _SESSION_ID.encode()))
+        if self.sse_responses:
+            data = (
+                "event: message\ndata: " + json.dumps(payload, separators=(",", ":")) + "\n\n"
+            ).encode("utf-8")
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/event-stream")] + extra,
+            })
+            await send({"type": "http.response.body", "body": data})
+            return
+        await _send_json(send, 200, payload, extra)
+
+
+class SseStub:
+    """Minimal legacy HTTP+SSE MCP server: GET stream + POST message endpoint."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self.seen_methods: list[str] = []
+
+    async def __call__(self, scope, receive, send) -> None:
+        assert scope["type"] == "http"
+        if scope["method"] == "GET":
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/event-stream")],
+            })
+            await send({
+                "type": "http.response.body",
+                "body": b"event: endpoint\ndata: /messages\n\n",
+                "more_body": True,
+            })
+            disconnect = asyncio.create_task(self._wait_disconnect(receive))
+            try:
+                while True:
+                    getter = asyncio.create_task(self._queue.get())
+                    done, _ = await asyncio.wait(
+                        {getter, disconnect}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    if disconnect in done:
+                        getter.cancel()
+                        return
+                    frame = getter.result()
+                    await send({
+                        "type": "http.response.body",
+                        "body": frame.encode("utf-8"),
+                        "more_body": True,
+                    })
+            finally:
+                disconnect.cancel()
+            return
+        # POST /messages
+        headers = {k.decode(): v.decode() for k, v in scope["headers"]}
+        body = await _read_body(receive)
+        message = json.loads(body)
+        self.seen_methods.append(message.get("method"))
+        payload = _dispatch(message, headers)
+        if payload is not None:
+            frame = "event: message\ndata: " + json.dumps(payload, separators=(",", ":")) + "\n\n"
+            await self._queue.put(frame)
+        await send({"type": "http.response.start", "status": 202, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    @staticmethod
+    async def _wait_disconnect(receive) -> None:
+        while True:
+            event = await receive()
+            if event["type"] == "http.disconnect":
+                return
+
+
+@asynccontextmanager
+async def _run_stub(app):
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=0,
+        log_level="error",
+        lifespan="off",
+        timeout_graceful_shutdown=1,
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    try:
+        while not server.started:
+            if task.done():
+                task.result()
+            await asyncio.sleep(0.01)
+        port = server.servers[0].sockets[0].getsockname()[1]
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        await task
+
+
+def _http_server_definition(url: str, *, transport: str = "streamable_http", **overrides: Any) -> ExternalServerDefinition:
+    payload: dict[str, Any] = {
+        "id": "srv-http",
+        "name": "Stub HTTP",
+        "transport": transport,
+        "url": url,
+    }
+    payload.update(overrides)
+    return ExternalServerDefinition(**payload)
+
+
+class TestServerDefinitionHttpTransports:
+    def test_accepts_streamable_http_and_sse_with_url(self) -> None:
+        for transport in ("streamable_http", "sse"):
+            definition = _http_server_definition("https://example.com/mcp", transport=transport)
+            assert definition.transport == transport
+            assert definition.url == "https://example.com/mcp"
+
+    def test_requires_url_for_http_transports(self) -> None:
+        for transport in ("streamable_http", "sse"):
+            with pytest.raises(ValueError):
+                ExternalServerDefinition(
+                    id="srv", name="No URL", transport=transport
+                )
+
+
+class TestStreamableHttpTransport:
+    @pytest.mark.asyncio
+    async def test_connect_initializes_and_lists_tools_with_session(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                tools = await transport.list_tools()
+            finally:
+                await transport.close()
+        assert stub.seen_methods[:2] == ["initialize", "notifications/initialized"]
+        assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+        assert tools[0].description == "Search docs"
+        assert tools[0].input_schema["properties"]["q"]["type"] == "string"
+        assert tools[1].description == ""
+        assert tools[1].input_schema == {"type": "object"}
+        assert tools[1].metadata == {}
+        assert stub.delete_count == 1
+
+    @pytest.mark.asyncio
+    async def test_call_tool_success_and_upstream_error(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                ok = await transport.call_tool("docs.search", {"q": "x"})
+                bad = await transport.call_tool("boom", {})
+            finally:
+                await transport.close()
+        assert ok.is_error is False
+        assert json.loads(ok.content[0]["text"]) == {"q": "x"}
+        assert ok.metadata["server_id"] == "srv-http"
+        assert bad.is_error is True
+        assert bad.metadata["reason_code"] == "upstream_error"
+        assert "tool exploded" in bad.content[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_merges_runtime_auth_headers(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                result = await transport.call_tool(
+                    "auth.echo",
+                    {},
+                    runtime_auth=BrokeredExternalCredential(
+                        headers={"Authorization": "Bearer brokered-token"}
+                    ),
+                )
+            finally:
+                await transport.close()
+        assert result.content[0]["text"] == "Bearer brokered-token"
+
+    @pytest.mark.asyncio
+    async def test_static_definition_headers_satisfy_auth(self) -> None:
+        stub = StreamableHttpStub(auth_required=True)
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url, headers={"Authorization": "Bearer static"}),
+                request_timeout_s=5.0,
+            )
+            try:
+                await transport.connect()
+            finally:
+                await transport.close()
+        assert stub.seen_methods[0] == "initialize"
+
+    @pytest.mark.asyncio
+    async def test_auth_required_maps_reason_code(self) -> None:
+        stub = StreamableHttpStub(auth_required=True)
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                with pytest.raises(HttpExternalTransportError) as excinfo:
+                    await transport.connect()
+            finally:
+                await transport.close()
+        assert excinfo.value.reason_code == "auth_required"
+
+    @pytest.mark.asyncio
+    async def test_sse_framed_post_responses_are_parsed(self) -> None:
+        stub = StreamableHttpStub(sse_responses=True)
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                tools = await transport.list_tools()
+            finally:
+                await transport.close()
+        assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+
+    @pytest.mark.asyncio
+    async def test_resources_round_trip(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                resources = await transport.list_resources()
+                read = await transport.read_resource("res://a")
+            finally:
+                await transport.close()
+        assert resources[0]["uri"] == "res://a"
+        assert read["contents"][0]["text"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_health_check_pings(self) -> None:
+        stub = StreamableHttpStub()
+        async with _run_stub(stub) as url:
+            transport = StreamableHttpExternalTransport(
+                _http_server_definition(url), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                checks = await transport.health_check()
+            finally:
+                await transport.close()
+        assert checks == {
+            "configured": True,
+            "connected": True,
+            "initialized": True,
+            "spawns_process": False,
+        }
+        assert "ping" in stub.seen_methods
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_maps_reason_code(self) -> None:
+        transport = StreamableHttpExternalTransport(
+            _http_server_definition("http://127.0.0.1:9"),
+            connect_timeout_s=2.0,
+            request_timeout_s=2.0,
+        )
+        try:
+            with pytest.raises(HttpExternalTransportError) as excinfo:
+                await transport.connect()
+        finally:
+            await transport.close()
+        assert excinfo.value.reason_code == "connect_failed"
+
+    def test_constructor_rejects_mismatched_definition(self) -> None:
+        definition = ExternalServerDefinition(
+            id="srv", name="Stdio", transport="stdio", command=["echo"]
+        )
+        with pytest.raises(HttpExternalTransportError) as excinfo:
+            StreamableHttpExternalTransport(definition)
+        assert excinfo.value.reason_code == "unsupported_transport"
+
+    def test_constructor_rejects_non_http_url(self) -> None:
+        definition = _http_server_definition("ftp://example.com/mcp")
+        with pytest.raises(HttpExternalTransportError) as excinfo:
+            StreamableHttpExternalTransport(definition)
+        assert excinfo.value.reason_code == "invalid_url"
+
+    def test_transport_error_reason_codes(self) -> None:
+        import ssl
+
+        from mcp_unified.federation.http_transport import _reason_code_for_transport_error
+
+        assert _reason_code_for_transport_error(httpx.ConnectError("boom")) == "connect_failed"
+        tls_exc = httpx.ConnectError("boom")
+        tls_exc.__cause__ = ssl.SSLError("bad handshake")
+        assert _reason_code_for_transport_error(tls_exc) == "tls_failed"
+        assert _reason_code_for_transport_error(httpx.ReadTimeout("slow")) == "request_timeout"
+        assert _reason_code_for_transport_error(httpx.RemoteProtocolError("eof")) == "connection_closed"
+
+    def test_factory_dispatches_streamable_http(self) -> None:
+        transport = create_external_transport(
+            _http_server_definition("https://example.com/mcp")
+        )
+        assert isinstance(transport, StreamableHttpExternalTransport)
+        assert transport.server_id == "srv-http"
+        assert transport.transport_name == "streamable_http"
+
+
+class TestSseTransport:
+    @pytest.mark.asyncio
+    async def test_connect_and_list_tools_via_stream(self) -> None:
+        stub = SseStub()
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"), request_timeout_s=5.0
+            )
+            try:
+                await transport.connect()
+                tools = await transport.list_tools()
+            finally:
+                await transport.close()
+        assert stub.seen_methods[:2] == ["initialize", "notifications/initialized"]
+        assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_with_runtime_auth(self) -> None:
+        stub = SseStub()
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"), request_timeout_s=5.0
+            )
+            try:
+                result = await transport.call_tool(
+                    "auth.echo",
+                    {},
+                    runtime_auth=BrokeredExternalCredential(
+                        headers={"Authorization": "Bearer sse-token"}
+                    ),
+                )
+                boom = await transport.call_tool("boom", {})
+            finally:
+                await transport.close()
+        assert result.content[0]["text"] == "Bearer sse-token"
+        assert boom.is_error is True
+        assert boom.metadata["reason_code"] == "upstream_error"
+
+    @pytest.mark.asyncio
+    async def test_health_check_and_server_gone(self) -> None:
+        stub = SseStub()
+        async with _run_stub(stub) as url:
+            transport = SseExternalTransport(
+                _http_server_definition(url, transport="sse"),
+                connect_timeout_s=3.0,
+                request_timeout_s=3.0,
+            )
+            try:
+                await transport.connect()
+                checks = await transport.health_check()
+                assert checks == {
+                    "configured": True,
+                    "connected": True,
+                    "initialized": True,
+                    "spawns_process": False,
+                }
+            finally:
+                pass
+        # server torn down: further calls must raise, not hang
+        try:
+            with pytest.raises(HttpExternalTransportError):
+                await transport.call_tool("docs.search", {"q": "x"})
+        finally:
+            await transport.close()
+
+    def test_factory_dispatches_sse(self) -> None:
+        transport = create_external_transport(
+            _http_server_definition("https://example.com/sse", transport="sse")
+        )
+        assert isinstance(transport, SseExternalTransport)
+        assert transport.transport_name == "sse"


### PR DESCRIPTION
## Why

mcp-unified's federation layer could only reach upstream MCP servers it spawns as local processes (`stdio`); the entire hosted-MCP ecosystem (Linear, Sentry, Notion, and every other URL-served MCP endpoint) was unreachable. This is the server half of tldw_chatbook's TASK-25900 / ADR-111 Option C: transports live in the package the chatbook already pins, chatbook then only does wiring.

## What

**Two new package-owned transports** in `apps/mcp-unified/src/mcp_unified/federation/http_transport.py`, both implementing the `ExternalFederationTransport` contract with stdio-parity semantics (same tools/list normalization, upstream tool errors as `is_error` results, same health_check keys, secret-free reason-coded exceptions):

- `StreamableHttpExternalTransport` — MCP Streamable HTTP (2025-03-26): JSON-RPC POSTs against one endpoint, handles both `application/json` and `text/event-stream` response bodies, `mcp-session-id` capture/propagation, `MCP-Protocol-Version` echo, DELETE session teardown, and transparent reinitialize+retry on 404 session expiry.
- `SseExternalTransport` — legacy HTTP+SSE: persistent GET stream, endpoint-event resolution **pinned to the stream origin**, response correlation by request id, pending requests failed on stream loss.

**Model/registry changes:**
- `ExternalServerDefinition`: transports `streamable_http`/`sse` (url required) + static `headers` field (auth for hosted servers).
- Gateway management: `headers` patchable (token rotation), header **values redacted (`"***"`) in every list/show/create/patch response** while the store keeps real values; enabled URL-transport servers require `http(s)://` URLs.
- `create_external_transport` dispatches to the new factory; stdio/websocket behavior untouched.

**Failure honesty** (distinct reason codes for downstream readiness states): `auth_required` (401/403), `tls_failed` (`ssl.SSLError` in the cause chain), `connect_failed`, `request_timeout`, `connection_closed`, `upstream_http_error`, `invalid_endpoint`, `insecure_url` (credential headers over plain http to non-loopback are refused).

**Hardening** (from a pre-PR adversarial review round; every finding fixed and pinned red-first):
- SSE endpoint events can no longer redirect credentialed POSTs cross-origin (confirmed-exploitable pre-fix).
- SSE-framed POST responses are bounded by total request timeout (a keepalive-dripping server previously hung the call forever and wedged `ExternalFederationManager` via its lock).
- Public operations serialize behind a request lock (stdio parity), so reconnects can't destroy in-flight requests.

## Tests

- 30 tests in `test_http_external_transport.py` run both transports against **real uvicorn stub MCP servers on ephemeral ports** (httpx's ASGI test transport buffers streams, so SSE needs real sockets): session enforcement, SSE-framed responses, runtime-auth header merge, request serialization, timeout bounding, cross-origin endpoint rejection, session-expiry recovery, SSE parser edge cases, reason-code mapping.
- 3 new gateway registry tests (redaction, header patch, URL validation). Affected suites: 165 passed.
- Full `MCP_unified/tests` dir: failure set **byte-identical** to a clean checkout of dev (same 22F/8E env-baseline set; by-name diff).

## Notes for release

- Version bumped 0.2.1 → 0.3.0 (doc copies synced). tldw_chatbook will bump its `mcp` extra pin after release.
- Compatibility: definitions saved by 0.3.0 serialize the new `headers` field; a 0.2.x reader (`extra="forbid"`) rejects such rows — worth a release-note line.
- Scope: the YAML/JSON config-file registry (`ExternalServerRegistryConfig`) still declares only `stdio`/`websocket`; URL transports are storage-registry-only for now (documented in USER_GUIDE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw1uiUyYcAWcrKVHGuJCXi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Streamable HTTP and legacy SSE transports to mcp-unified's federation layer, so hosted MCP servers (Linear, Sentry, and other URL-served endpoints) are reachable for the first time — previously only locally spawned `stdio` servers worked. This is the server half of TASK-25900 / ADR-111 Option C.

**New Features**
- Adds `StreamableHttpExternalTransport` (single-endpoint JSON-RPC with JSON or SSE-framed responses, session capture and DELETE teardown) and `SseExternalTransport` (persistent GET stream with request-id correlation).
- `ExternalServerDefinition` gains `streamable_http`/`sse` transports and a static `headers` field; brokered per-call credentials merge their headers into tool calls.
- Failures map to distinct secret-free reason codes (`auth_required`, `tls_failed`, `connect_failed`, `request_timeout`, `connection_closed`).
- SSE endpoint events are pinned to the stream origin, SSE responses are bounded by the request timeout, and public operations serialize behind a request lock that `close()` also honors.
- Management responses redact `headers` values (`"***"`); the FastAPI patch body supports the new transports and `headers`, and header changes restart the active transport so tokens rotate cleanly.
- Credential headers over plain `http://` to non-loopback hosts are refused, and streamable JSON responses must match the request id.

**Migration**
- Version bumps to 0.3.0; definitions saved by 0.3.0 include the `headers` field, which a 0.2.x reader rejects.
- The YAML/JSON config-file registry still only declares `stdio`/`websocket`; URL transports are storage-registry-only.

<sup>Written for commit 27cd02755563d326d218787ac60e0bc8e0524cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

