### PR TITLE
fix(tests): seed AuthNZ users through UsersDB so the write guard permits it

### DIFF
--- a/tldw_Server_API/tests/Admin/test_admin_monitoring_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_monitoring_api.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import uuid
 
 import pytest
 from fastapi.testclient import TestClient
@@ -18,19 +17,12 @@ def _setup_env(tmp_path) -> None:
 
 async def _seed_assignable_user() -> int:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
     username = "monitoring_assignee"
     email = "monitoring_assignee@example.com"
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        str(uuid.uuid4()),
-        username,
-        email,
-        "x",
-    )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
-    return int(user_id)
+    return await ensure_test_user(pool, username, email)
 
 
 def _seed_runtime_alert(alerts_db_path: str) -> int:

--- a/tldw_Server_API/tests/Admin/test_bundle_ops.py
+++ b/tldw_Server_API/tests/Admin/test_bundle_ops.py
@@ -75,32 +75,34 @@ def test_authnz_backup_path_normalizes_windows_sqlite_url(monkeypatch):
 
 
 async def _seed_authnz_data() -> int:
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
+    """Seed one user and an audit row, and return the user id.
+
+    The user is created through UsersDB rather than a raw INSERT. username,
+    email and is_active are profile-visible columns, and
+    profile_user_write_guard rejects raw writes that touch them on a managed
+    AuthNZ connection -- so the direct INSERT this used to do now raises
+    ProfileUserWriteRejected.
+    """
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
 
     pool = await get_db_pool()
     username = "bundle_user"
     email = "bundle_user@example.com"
-    if await is_postgres_backend():
-        await pool.execute(
-            """
-            INSERT INTO users (uuid, username, email, password_hash, is_active)
-            VALUES (?,?,?,?,1)
-            ON CONFLICT (username) DO NOTHING
-            """,
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
-    else:
-        await pool.execute(
-            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
+    users_db = UsersDB(pool)
+    await users_db.initialize()
     user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+    if user_id is None:
+        created = await users_db.create_user(
+            username=username,
+            email=email,
+            password_hash="x",
+            role="user",
+            is_active=True,
+            is_superuser=False,
+            uuid_value=uuid.uuid4(),
+        )
+        user_id = created["id"]
     await pool.execute(
         "INSERT INTO audit_logs (user_id, action, resource_type, resource_id, ip_address, details) VALUES (?,?,?,?,?,?)",
         int(user_id),

--- a/tldw_Server_API/tests/Admin/test_data_ops.py
+++ b/tldw_Server_API/tests/Admin/test_data_ops.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 from typing import Any
 
 import pytest
@@ -29,32 +28,13 @@ def _setup_env(tmp_path):
 
 
 async def _seed_authnz_data() -> int:
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
     username = "dataops_user"
     email = "dataops_user@example.com"
-    if await is_postgres_backend():
-        await pool.execute(
-            """
-            INSERT INTO users (uuid, username, email, password_hash, is_active)
-            VALUES (?,?,?,?,1)
-            ON CONFLICT (username) DO NOTHING
-            """,
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
-    else:
-        await pool.execute(
-            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+    user_id = await ensure_test_user(pool, username, email)
     await pool.execute(
         "INSERT INTO audit_logs (user_id, action, resource_type, resource_id, ip_address, details) VALUES (?,?,?,?,?,?)",
         int(user_id),

--- a/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
@@ -16,33 +16,13 @@ def _setup_env(tmp_path):
 
 async def _ensure_llm_tables_and_seed():
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
     pool = await get_db_pool()
-    # Ensure two users exist and capture their IDs (respect FK constraints)
-    import uuid as _uuid
-    if pool.pool:
-        # PostgreSQL-style
-        await pool.execute(
-            "INSERT INTO users (uuid, username, email, password_hash, is_active) VALUES ($1,$2,$3,$4,TRUE) ON CONFLICT (username) DO NOTHING",
-            str(_uuid.uuid4()), "llmuser1", "llmuser1@example.com", "x"
-        )
-        await pool.execute(
-            "INSERT INTO users (uuid, username, email, password_hash, is_active) VALUES ($1,$2,$3,$4,TRUE) ON CONFLICT (username) DO NOTHING",
-            str(_uuid.uuid4()), "llmuser2", "llmuser2@example.com", "x"
-        )
-        u1 = await pool.fetchval("SELECT id FROM users WHERE username = $1", "llmuser1")
-        u2 = await pool.fetchval("SELECT id FROM users WHERE username = $1", "llmuser2")
-    else:
-        # SQLite-style
-        await pool.execute(
-            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-            str(_uuid.uuid4()), "llmuser1", "llmuser1@example.com", "x"
-        )
-        await pool.execute(
-            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-            str(_uuid.uuid4()), "llmuser2", "llmuser2@example.com", "x"
-        )
-        u1 = await pool.fetchval("SELECT id FROM users WHERE username = ?", "llmuser1")
-        u2 = await pool.fetchval("SELECT id FROM users WHERE username = ?", "llmuser2")
+    # Ensure two users exist and capture their IDs (respect FK constraints).
+    # Seeded through UsersDB, which works on either backend and is the write
+    # path profile_user_write_guard sanctions.
+    u1 = await ensure_test_user(pool, "llmuser1", "llmuser1@example.com")
+    u2 = await ensure_test_user(pool, "llmuser2", "llmuser2@example.com")
     # Create tables if not exist
     if pool.pool:
         await pool.execute(

--- a/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py
+++ b/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -20,32 +19,13 @@ def _setup_env(tmp_path) -> None:
 
 
 async def _seed_audit_log_preview_data() -> int:
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
     username = "retention_preview_user"
     email = "retention_preview_user@example.com"
-    if await is_postgres_backend():
-        await pool.execute(
-            """
-            INSERT INTO users (uuid, username, email, password_hash, is_active)
-            VALUES ($1,$2,$3,$4,1)
-            ON CONFLICT (username) DO NOTHING
-            """,
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
-    else:
-        await pool.execute(
-            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-            str(uuid.uuid4()),
-            username,
-            email,
-            "x",
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+    user_id = await ensure_test_user(pool, username, email)
 
     now = datetime.now(timezone.utc)
     stale_created_at = (now - timedelta(days=120)).isoformat()

--- a/tldw_Server_API/tests/Admin/test_router_analytics_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_router_analytics_endpoints.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,16 +16,12 @@ def _setup_env(tmp_path) -> None:
 
 async def _seed_router_rows() -> None:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        str(uuid.uuid4()),
-        "router_endpoints_user",
-        "router_endpoints_user@example.com",
-        "x",
+    user_id = await ensure_test_user(
+        pool, "router_endpoints_user", "router_endpoints_user@example.com"
     )
-    user_id = int(await pool.fetchval("SELECT id FROM users WHERE username = ?", "router_endpoints_user"))
 
     await pool.execute(
         """

--- a/tldw_Server_API/tests/Admin/test_router_analytics_service.py
+++ b/tldw_Server_API/tests/Admin/test_router_analytics_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 from datetime import datetime, timezone
 
 import pytest
@@ -18,20 +17,13 @@ def _setup_env(tmp_path) -> None:
 
 async def _ensure_router_usage_seed_rows() -> int:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
-    await pool.execute(
-        """
-        CREATE TABLE IF NOT EXISTS users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            uuid TEXT UNIQUE,
-            username TEXT UNIQUE,
-            email TEXT,
-            password_hash TEXT,
-            is_active INTEGER DEFAULT 1
-        )
-        """
-    )
+    # The users table is created by UsersDB inside ensure_test_user below.
+    # Hand-rolling a cut-down one here is rejected by
+    # profile_user_write_guard: a users table without the profile-version
+    # columns would silently break the machinery that depends on them.
     await pool.execute(
         """
         CREATE TABLE IF NOT EXISTS llm_usage_log (
@@ -94,15 +86,9 @@ async def _ensure_router_usage_seed_rows() -> int:
     if "llm_budget_month_usd" not in key_cols:
         await pool.execute("ALTER TABLE api_keys ADD COLUMN llm_budget_month_usd REAL")
 
-    user_uuid = str(uuid.uuid4())
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        user_uuid,
-        "router_analytics_user",
-        "router_analytics_user@example.com",
-        "x",
+    user_id = await ensure_test_user(
+        pool, "router_analytics_user", "router_analytics_user@example.com"
     )
-    user_id = int(await pool.fetchval("SELECT id FROM users WHERE username = ?", "router_analytics_user"))
     await pool.execute(
         """
         INSERT OR REPLACE INTO api_keys (

--- a/tldw_Server_API/tests/Admin/test_usage_reporting.py
+++ b/tldw_Server_API/tests/Admin/test_usage_reporting.py
@@ -21,15 +21,11 @@ def _setup_env(tmp_path):
 
 async def _insert_usage_rows_sqlite():
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
 
     pool = await get_db_pool()
     # Create a test user to satisfy FK on usage_daily.user_id
-    import uuid as _uuid
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        str(_uuid.uuid4()), "usageuser", "usageuser@example.com", "x"
-    )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "usageuser")
+    user_id = await ensure_test_user(pool, "usageuser", "usageuser@example.com")
     # Ensure usage tables exist (migrations may be skipped in some single-user SQLite setups)
     await pool.execute(
         """

--- a/tldw_Server_API/tests/Admin/test_usage_reporting_bytes_in.py
+++ b/tldw_Server_API/tests/Admin/test_usage_reporting_bytes_in.py
@@ -20,20 +20,12 @@ def _setup_env(tmp_path):
 
 async def _prepare_tables_and_seed_bytes_in():
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.tests.helpers.authnz_seed import ensure_test_user
     pool = await get_db_pool()
 
     # Ensure two users exist
-    import uuid as _uuid
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        str(_uuid.uuid4()), "u_bytes1", "u_bytes1@example.com", "x"
-    )
-    await pool.execute(
-        "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
-        str(_uuid.uuid4()), "u_bytes2", "u_bytes2@example.com", "x"
-    )
-    u1 = await pool.fetchval("SELECT id FROM users WHERE username = ?", "u_bytes1")
-    u2 = await pool.fetchval("SELECT id FROM users WHERE username = ?", "u_bytes2")
+    u1 = await ensure_test_user(pool, "u_bytes1", "u_bytes1@example.com")
+    u2 = await ensure_test_user(pool, "u_bytes2", "u_bytes2@example.com")
 
     # Create usage_log with bytes_in column and usage_daily with bytes_in_total
     await pool.execute(

--- a/tldw_Server_API/tests/helpers/authnz_seed.py
+++ b/tldw_Server_API/tests/helpers/authnz_seed.py
@@ -47,12 +47,13 @@ async def ensure_test_user(
     """
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
 
-    existing = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
-    if existing is not None:
-        return int(existing)
-
     users_db = UsersDB(pool)
     await users_db.initialize()
+
+    existing = await users_db.get_user_by_username(username)
+    if existing is not None:
+        return int(existing["id"])
+
     created = await users_db.create_user(
         username=username,
         email=email or f"{username}@example.com",

--- a/tldw_Server_API/tests/helpers/authnz_seed.py
+++ b/tldw_Server_API/tests/helpers/authnz_seed.py
@@ -1,0 +1,65 @@
+"""Create AuthNZ users in tests without tripping the profile-write guard.
+
+``username``, ``email`` and ``is_active`` are profile-visible columns. Since
+``feat(authnz): version profile-visible user writes`` (5f31630280),
+``profile_user_write_guard`` rejects raw writes touching them on a managed
+AuthNZ connection, so the ``INSERT OR IGNORE INTO users (...)`` that test
+helpers used to do now raises ``ProfileUserWriteRejected``.
+
+Seed through this instead. It goes via ``UsersDB``, which is the path
+production uses and the one the guard sanctions.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any
+
+
+async def ensure_test_user(
+    pool: Any,
+    username: str,
+    email: str | None = None,
+    *,
+    role: str = "user",
+    password_hash: str = "x",
+    is_active: bool = True,
+    is_superuser: bool = False,
+) -> int:
+    """Return the id of ``username``, creating the user if it is not there yet.
+
+    Idempotent, matching the ``INSERT OR IGNORE`` semantics of the raw inserts
+    this replaces: callers seed the same fixed username across tests in a
+    session and expect the second call to be a no-op.
+
+    Args:
+        pool: An initialized AuthNZ connection pool.
+        username: Login name to look up or create.
+        email: Address for a newly created user. Defaults to
+            ``<username>@example.com``.
+        role: Role for a newly created user.
+        password_hash: Stored verbatim; these users never authenticate.
+        is_active: Active flag for a newly created user.
+        is_superuser: Superuser flag for a newly created user.
+
+    Returns:
+        The user's integer id.
+    """
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    existing = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+    if existing is not None:
+        return int(existing)
+
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+    created = await users_db.create_user(
+        username=username,
+        email=email or f"{username}@example.com",
+        password_hash=password_hash,
+        role=role,
+        is_active=is_active,
+        is_superuser=is_superuser,
+        uuid_value=_uuid.uuid4(),
+    )
+    return int(created["id"])


### PR DESCRIPTION
`tests/Admin` has **51 failing tests on dev**. 48 of them are one cause.

`feat(authnz): version profile-visible user writes` (5f31630280, **2026-07-26**) added `profile_user_write_guard`, a runtime firewall rejecting raw writes that touch profile-visible `users` columns on a managed AuthNZ connection. `username`, `email` and `is_active` are all profile-visible, so the seeding helper these tests share:

```sql
INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)
```

raises `ProfileUserWriteRejected`.

**The guard is right and the tests are wrong.** They now seed through `UsersDB`, the path production uses. A shared helper (`tests/helpers/authnz_seed.py`) carries the explanation so the next person writing a seeder doesn't rediscover it.

`test_router_analytics_service` also hand-rolled a cut-down `users` table, which the guard rejects too — correctly, since a `users` table without the profile-version columns would silently break the machinery that depends on them. `UsersDB` creates the canonical schema, so that bootstrap is simply deleted.

| | failed | passed |
|---|---|---|
| before | **51** | 775 |
| after | **17** | 809 |

## Why CI never caught this

This is the part worth attention. The last `ci.yml` run on `dev` is **2026-07-09** — seventeen days *before* the guard landed — and every run since is `cancelled`. The Admin shards are path-filtered, so a change under `app/core/AuthNZ/` never triggers them.

I nearly dismissed this whole thing: I checked CI, saw `admin-bundle-ops` **success** on all four platforms with 53 tests passing, and concluded the failures were local-only. That green result predates the code that broke it. Worth knowing that a green shard badge here can be almost two months stale.

## Not addressed here

- **14 guard failures** in seeders that pin an explicit user id, which `UsersDB.create_user` does not accept — each needs per-test handling rather than a mechanical swap.
- **3 unrelated failures**: a `TransactionError`, an `AdminWebhookStatusResponse` `ValidationError`, and one `200 != 500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmT6oLNxVvsLxfDmso2u7b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 38 of the 48 `tests/Admin` failures caused by `profile_user_write_guard` rejecting the raw `INSERT INTO users` seeders, dropping the failure count from 51 to 13.

- Seeds AuthNZ test users through `UsersDB` via a shared `tests/helpers/authnz_seed.py` helper instead of raw inserts, including the three seeders that previously wrapped the insert in a Postgres/SQLite branch. The helper both creates and looks up users through `UsersDB`, with no raw SQL.
- Removes the hand-rolled `users` table in `test_router_analytics_service` and uses the canonical schema `UsersDB` creates.
- CI never caught this because the last `dev` CI run predates the guard and the Admin shards are path-filtered, so AuthNZ changes never trigger them.

**Not addressed**
- 10 guard failures remain in seeders that pin an explicit user id, which `UsersDB.create_user` does not accept; converting `test_data_subject_requests_api.py` was tried and reverted because UsersDB-assigned ids (1–3) collide with the default user's real media databases.
- 3 unrelated failures remain: a `TransactionError`, an `AdminWebhookStatusResponse` validation error, and a `200 != 500`.

<sup>Written for commit bc3c259eb89958955c724c45da2bbb02e13a6c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

