### PR TITLE
chore(backlog): add Collections server prerequisites

### DIFF
--- a/backlog/tasks/task-13153 - Add-atomic-revision-guarded-hard-delete-for-Reading-items.md
+++ b/backlog/tasks/task-13153 - Add-atomic-revision-guarded-hard-delete-for-Reading-items.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13153
+title: Add atomic revision-guarded hard delete for Reading items
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:27'
+updated_date: '2026-09-03 02:29'
+labels:
+  - collections
+  - reading-list
+  - api
+  - concurrency
+  - deletion
+dependencies: []
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a positive, monotonically increasing integer `revision` to persisted Reading items and every Reading summary/detail response. Every item-owned mutation that can change the user's deletion decision increments that revision, including metadata/status/tag changes and capture-owned content changes. The permanent-delete request accepts `expected_revision` and enforces the authenticated user, item, and revision predicate in the same transaction as child cleanup and deletion. Stale preconditions conflict without deletion; missing items remain distinct. Delete capture-owned children/artifacts but never linked external Media or Notes. Advertise exact `hasReadingOptimisticDeletesV1=true` only when the complete atomic contract is active.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every Reading item summary/detail exposes a positive monotonic `revision`, and every item-owned change relevant to deletion advances it in SQLite and PostgreSQL.
+- [ ] #2 Hard delete atomically requires the authenticated user's exact `expected_revision`; stale requests return a documented conflict and remove nothing.
+- [ ] #3 Confirmed hard delete removes the Reading item and capture-owned children/artifacts without deleting linked external Media or Notes.
+- [ ] #4 Schema migration, concurrent mutation/delete, wrong-user, missing-item, rollback, and cascade behavior have focused SQLite/PostgreSQL regression coverage.
+- [ ] #5 Docs-info advertises `hasReadingOptimisticDeletesV1=true` only when the complete contract is active, and public API documentation describes the precondition and responses.
+- [ ] #6 A new or applicable Server ADR records the schema, destructive precondition, and ownership decision before implementation begins.
+<!-- AC:END -->

--- a/backlog/tasks/task-13153 - Add-atomic-revision-guarded-hard-delete-for-Reading-items.md
+++ b/backlog/tasks/task-13153 - Add-atomic-revision-guarded-hard-delete-for-Reading-items.md
@@ -4,7 +4,7 @@ title: Add atomic revision-guarded hard delete for Reading items
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:27'
-updated_date: '2026-09-03 02:29'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - reading-list
@@ -22,7 +22,17 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Add a positive, monotonically increasing integer `revision` to persisted Reading items and every Reading summary/detail response. Every item-owned mutation that can change the user's deletion decision increments that revision, including metadata/status/tag changes and capture-owned content changes. The permanent-delete request accepts `expected_revision` and enforces the authenticated user, item, and revision predicate in the same transaction as child cleanup and deletion. Stale preconditions conflict without deletion; missing items remain distinct. Delete capture-owned children/artifacts but never linked external Media or Notes. Advertise exact `hasReadingOptimisticDeletesV1=true` only when the complete atomic contract is active.
+Add a positive, monotonically increasing integer `revision` to persisted Reading items and every
+Reading summary/detail response. Every item-owned mutation that can change the user's deletion
+decision increments that revision, including metadata/status/tag changes and capture-owned content
+changes. The permanent-delete request accepts `expected_revision` and enforces `WHERE id = ? AND
+user_id = ? AND revision = ?` or its backend-equivalent in the same transaction as child cleanup
+and deletion. A stale precondition returns a documented 409/412 conflict without deleting the item;
+missing items remain distinct. The operation removes capture-owned children and artifacts but does
+not delete linked external Media or Notes. Docs-info advertises exact
+`hasReadingOptimisticDeletesV1=true` only when the response token and atomic mutation are active.
+SQLite/PostgreSQL migration, concurrent mutation/delete, authorization, conflict, cascade, and
+diagnostic-privacy behavior are covered.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-13154 - Add-coherent-scoped-tag-and-domain-aggregates-for-Reading-items.md
+++ b/backlog/tasks/task-13154 - Add-coherent-scoped-tag-and-domain-aggregates-for-Reading-items.md
@@ -1,0 +1,35 @@
+---
+id: TASK-13154
+title: Add coherent scoped tag and domain aggregates for Reading items
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:29'
+updated_date: '2026-09-03 02:30'
+labels:
+  - collections
+  - reading-list
+  - api
+  - facets
+  - pagination
+dependencies: []
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly documented Reading scope. Use distinct `capture_q` and `facet_q` parameters. Aggregate rows and exact totals use one snapshot with accepted capture search/status/favorite/date/tag/domain filters and self-excluding facet semantics. Results are user-scoped, normalize values with a stable tie-break order, and reveal neither capture content nor sensitive URL components. Advertise exact `hasReadingAggregateFacetsV1=true` only with the complete SQLite/PostgreSQL contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Authenticated callers can page every tag or domain aggregate through deterministic bounded results with exact aggregate totals and server-side `facet_q` search.
+- [ ] #2 Aggregate count and rows use one SQLite/PostgreSQL snapshot and apply `capture_q` plus all non-self facet filters before aggregation.
+- [ ] #3 Self-excluding tag/domain semantics are documented and verified for combined filters, concurrent writers, empty scopes, deep pages, and normalization collisions.
+- [ ] #4 Responses reveal no capture body, note, highlight, sensitive URL component, or other user's values.
+- [ ] #5 Docs-info advertises `hasReadingAggregateFacetsV1=true` only with the complete contract, and the ADR check plus focused API/database/security tests are recorded.
+<!-- AC:END -->

--- a/backlog/tasks/task-13154 - Add-coherent-scoped-tag-and-domain-aggregates-for-Reading-items.md
+++ b/backlog/tasks/task-13154 - Add-coherent-scoped-tag-and-domain-aggregates-for-Reading-items.md
@@ -4,7 +4,7 @@ title: Add coherent scoped tag and domain aggregates for Reading items
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:29'
-updated_date: '2026-09-03 02:30'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - reading-list
@@ -22,7 +22,17 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly documented Reading scope. Use distinct `capture_q` and `facet_q` parameters. Aggregate rows and exact totals use one snapshot with accepted capture search/status/favorite/date/tag/domain filters and self-excluding facet semantics. Results are user-scoped, normalize values with a stable tie-break order, and reveal neither capture content nor sensitive URL components. Advertise exact `hasReadingAggregateFacetsV1=true` only with the complete SQLite/PostgreSQL contract.
+Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly
+documented Reading scope. It uses distinct `capture_q` and `facet_q` parameters so facet-value
+search never means filtering only already-loaded pages and cannot be confused with capture search.
+Aggregate rows and exact aggregate totals are evaluated in one snapshot with the accepted capture
+search/status/favorite/date/tag/domain filters. The contract
+uses self-excluding semantics: the requested facet ignores that facet's active filter while retaining
+all other scope filters, allowing the user to change it without losing alternatives. Normalized
+value plus stable tie-break ordering makes every matching value reachable. Results are user-scoped
+and exclude capture content and sensitive URL components. Docs-info advertises exact
+`hasReadingAggregateFacetsV1=true` only when the endpoint and its SQLite/PostgreSQL snapshot
+guarantees are active.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-13155 - Establish-safe-Collections-output-template-ownership-and-deletion.md
+++ b/backlog/tasks/task-13155 - Establish-safe-Collections-output-template-ownership-and-deletion.md
@@ -4,7 +4,7 @@ title: Establish safe Collections output-template ownership and deletion
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:30'
-updated_date: '2026-09-03 02:31'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - output-templates
@@ -21,7 +21,16 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Keep the existing `/outputs/templates` API, define the exact template types governed by Collections, and record the current live reference owner: Reading digest schedules. Historical rendered outputs are self-contained and do not block deletion. Update/delete remain user-scoped; deletion refuses a template referenced by a Reading digest schedule unless removed or reassigned. Record a source-level branch-base reference inventory; another live owner requires acceptance-criteria revision before implementation, not silent scope expansion. Advertise exact `hasCollectionsOutputTemplateManagementV1=true` only when bounded paging, CRUD, reference-safe deletion, and the ownership set are active.
+Keep the existing `/outputs/templates` API but define which template types are governed by the
+Collections umbrella and expose the current live reference owner: Reading digest schedules.
+Historical rendered outputs do not block deletion because they are self-contained. Update and
+delete remain user-scoped; deletion refuses a template referenced by a Reading digest schedule
+unless that reference is first removed or reassigned. The task records a source-level reference
+inventory at its branch base; finding another live owner requires updating the task acceptance
+criteria before implementation rather than silently expanding scope. The API returns bounded
+conflict reasons without leaking another user's objects. Docs-info advertises exact
+`hasCollectionsOutputTemplateManagementV1=true` only when bounded paging, CRUD, reference-safe
+deletion, and the documented ownership set are active. Existing template rendering remains intact.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-13155 - Establish-safe-Collections-output-template-ownership-and-deletion.md
+++ b/backlog/tasks/task-13155 - Establish-safe-Collections-output-template-ownership-and-deletion.md
@@ -1,0 +1,34 @@
+---
+id: TASK-13155
+title: Establish safe Collections output-template ownership and deletion
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:30'
+updated_date: '2026-09-03 02:31'
+labels:
+  - collections
+  - output-templates
+  - api
+  - deletion
+dependencies: []
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep the existing `/outputs/templates` API, define the exact template types governed by Collections, and record the current live reference owner: Reading digest schedules. Historical rendered outputs are self-contained and do not block deletion. Update/delete remain user-scoped; deletion refuses a template referenced by a Reading digest schedule unless removed or reassigned. Record a source-level branch-base reference inventory; another live owner requires acceptance-criteria revision before implementation, not silent scope expansion. Advertise exact `hasCollectionsOutputTemplateManagementV1=true` only when bounded paging, CRUD, reference-safe deletion, and the ownership set are active.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The API and documentation identify the exact output-template types governed by Collections and record a branch-base inventory of live template reference owners.
+- [ ] #2 Template listing remains bounded and user-scoped, while create/get/update/delete preserve the existing rendering contract and expose bounded errors.
+- [ ] #3 Deleting a template referenced by a Reading digest schedule is refused atomically without exposing another user's objects; historical self-contained outputs do not block deletion.
+- [ ] #4 Docs-info advertises `hasCollectionsOutputTemplateManagementV1=true` only when ownership, CRUD, paging, and reference-safe deletion guarantees are active.
+- [ ] #5 Focused database/API/security tests and the required Server ADR check pass.
+<!-- AC:END -->

--- a/backlog/tasks/task-13156 - Attest-bounded-Reading-digest-schedule-and-output-management.md
+++ b/backlog/tasks/task-13156 - Attest-bounded-Reading-digest-schedule-and-output-management.md
@@ -4,7 +4,7 @@ title: Attest bounded Reading digest schedule and output management
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:31'
-updated_date: '2026-09-03 02:32'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - reading-list
@@ -21,7 +21,17 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Keep existing digest routes/shapes unchanged and add an exact bounded schedule-page route beside the bare-list route; retain the output-page envelope. Use deterministic ordering and user scoping. Create accepts a user-scoped `client_request_id`: identical key/payload returns the original schedule, mismatched payload conflicts, and exact key lookup reconciles lost responses. Preserve last status/run/next-run/output history as the only run evidence. Document refresh-based reconciliation for uncertain update/delete outcomes and separate worker availability. Advertise exact `hasReadingDigestManagementV1=true` only with these additive guarantees.
+Keep all existing digest routes and response shapes unchanged. Add an exact bounded schedule-page
+route beside the current bare-list route; the existing output-page route retains its envelope. Both
+use deterministic ordering and user scoping. Schedule creation accepts a caller-generated,
+user-scoped `client_request_id`: repeating the same key and normalized payload returns the original
+schedule, while reusing it with a different payload fails with a bounded conflict. Exact lookup by
+that key lets a client reconcile a lost create response. Preserve schedule `last_status`,
+`last_run_at`, `next_run_at`, and output history as the only run evidence; do not invent a distinct
+run-history API. Update/delete responses remain non-optimistic and are documented for refresh-based
+reconciliation after transport uncertainty. Docs-info advertises exact
+`hasReadingDigestManagementV1=true` only when these additive guarantees are active and configured
+scheduler/worker availability is reported separately.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-13156 - Attest-bounded-Reading-digest-schedule-and-output-management.md
+++ b/backlog/tasks/task-13156 - Attest-bounded-Reading-digest-schedule-and-output-management.md
@@ -1,0 +1,35 @@
+---
+id: TASK-13156
+title: Attest bounded Reading digest schedule and output management
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:31'
+updated_date: '2026-09-03 02:32'
+labels:
+  - collections
+  - reading-list
+  - digests
+  - pagination
+dependencies: []
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep existing digest routes/shapes unchanged and add an exact bounded schedule-page route beside the bare-list route; retain the output-page envelope. Use deterministic ordering and user scoping. Create accepts a user-scoped `client_request_id`: identical key/payload returns the original schedule, mismatched payload conflicts, and exact key lookup reconciles lost responses. Preserve last status/run/next-run/output history as the only run evidence. Document refresh-based reconciliation for uncertain update/delete outcomes and separate worker availability. Advertise exact `hasReadingDigestManagementV1=true` only with these additive guarantees.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Existing digest routes and response shapes remain compatible, and an additive schedule-page route returns exact totals with deterministic bounded rows.
+- [ ] #2 Schedule creation uses a user-scoped `client_request_id`; identical replays return the same schedule, payload mismatch conflicts, and exact lookup reconciles a lost response.
+- [ ] #3 Schedule and output reads never cross users and expose only `last_status`, `last_run_at`, `next_run_at`, and bounded output history rather than claiming a complete run ledger.
+- [ ] #4 Update/delete outcomes and scheduler/worker availability are documented separately so clients can refresh after uncertainty without inventing optimistic conflicts.
+- [ ] #5 Docs-info advertises `hasReadingDigestManagementV1=true` only when the additive paging and idempotent-create contract is active.
+- [ ] #6 Focused SQLite/PostgreSQL, API, concurrency, compatibility, and security tests pass; the ADR check is recorded.
+<!-- AC:END -->

--- a/backlog/tasks/task-13157 - Add-complete-restart-safe-Reading-export-jobs.md
+++ b/backlog/tasks/task-13157 - Add-complete-restart-safe-Reading-export-jobs.md
@@ -1,0 +1,35 @@
+---
+id: TASK-13157
+title: Add complete restart-safe Reading export jobs
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:32'
+updated_date: '2026-09-03 02:33'
+labels:
+  - collections
+  - reading-list
+  - export
+  - jobs
+dependencies: []
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep the existing page-scoped streaming export unchanged and add one cohesive Server-native export-job aggregate: authenticated create/history/detail/download/cleanup routes, coherent complete-scope evaluation, restart-truthful job state, a private managed artifact, idempotent request key, retention/cleanup, and the versioned portable-schema manifest needed to identify a complete artifact. These pieces are inseparable for a truthful complete job and form one reviewable PR. Exclude re-import parsing/merge, generic account backup, Chatbook UI, Local behavior, and additional export formats. Advertise exact `hasReadingExportJobsV1=true` only with the full lifecycle.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Existing page-scoped streaming export remains compatible, while additive authenticated job routes expose bounded create/history/detail/download/cleanup behavior.
+- [ ] #2 Each export job reads one explicit filter scope coherently and writes every matching capture exactly once to a private managed artifact, including scopes larger than one API page.
+- [ ] #3 A user-scoped request key makes identical creates idempotent and rejects a different normalized payload with a bounded conflict.
+- [ ] #4 Interrupted or failed jobs resume or terminate truthfully and never publish a partial artifact as complete; retention and confirmed cleanup are restart-safe.
+- [ ] #5 Every completed artifact includes the versioned Server-native schema identifier and manifest required by S5b, and unauthorized users cannot discover or download it.
+- [ ] #6 Docs-info advertises `hasReadingExportJobsV1=true` only with the full contract; a Server ADR plus focused job/database/API/security tests are complete.
+<!-- AC:END -->

--- a/backlog/tasks/task-13157 - Add-complete-restart-safe-Reading-export-jobs.md
+++ b/backlog/tasks/task-13157 - Add-complete-restart-safe-Reading-export-jobs.md
@@ -4,7 +4,7 @@ title: Add complete restart-safe Reading export jobs
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:32'
-updated_date: '2026-09-03 02:33'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - reading-list
@@ -21,7 +21,21 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Keep the existing page-scoped streaming export unchanged and add one cohesive Server-native export-job aggregate: authenticated create/history/detail/download/cleanup routes, coherent complete-scope evaluation, restart-truthful job state, a private managed artifact, idempotent request key, retention/cleanup, and the versioned portable-schema manifest needed to identify a complete artifact. These pieces are inseparable for a truthful complete job and form one reviewable PR. Exclude re-import parsing/merge, generic account backup, Chatbook UI, Local behavior, and additional export formats. Advertise exact `hasReadingExportJobsV1=true` only with the full lifecycle.
+Keep the current page-scoped streaming `/reading/export` route and response unchanged for existing
+clients. Add asynchronous, user-scoped export-job routes that evaluate one explicit filter scope
+coherently, write every matching item exactly once to a private managed artifact, expose bounded job
+history/detail, and support authorized download and confirmed cleanup. Interruption is restart-safe
+and never publishes a partial artifact as complete. A caller-generated export request key prevents
+duplicate artifacts after a lost create response; reusing a key with a different normalized scope or
+content payload returns a bounded conflict. Each artifact carries the versioned Server-native
+portable-schema identifier and manifest consumed by S5b. Docs-info advertises exact
+`hasReadingExportJobsV1=true` only when complete-scope export, job lifecycle, artifact retention,
+and cleanup guarantees are active.
+
+S5a is one reviewable Server PR boundary because its routes, job state, managed store,
+request-key idempotency, private artifact lifecycle, and portable manifest form one new
+Server-native export-job aggregate; none is truthful or independently useful without the others.
+It excludes re-import, generic backup, UI work, Local behavior, and additional export formats.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-13158 - Add-Server-native-Reading-export-re-import.md
+++ b/backlog/tasks/task-13158 - Add-Server-native-Reading-export-re-import.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13158
+title: Add Server-native Reading export re-import
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:33'
+updated_date: '2026-09-03 02:34'
+labels:
+  - collections
+  - reading-list
+  - import-export
+  - portability
+dependencies:
+  - TASK-13157
+references:
+  - 'tldw_chatbook:TASK-18919'
+  - >-
+    tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Retain Pocket JSON and Instapaper CSV import, then admit versioned Server-native JSONL/ZIP artifacts produced by S5a. Portable fields are submitted URL, title, summary, freeform note, status, favorite, tags, published/read timestamps, optional sanitized text/clean HTML, and capture-owned highlights. Exclude database/user IDs, authoritative created/updated timestamps, Media/linked-Note identities, generated audio, offline/archive files, and internal metadata. Allocate new identities and canonicalize URLs. On canonical collision preserve existing scalar/state/content, union tags, and add only nonduplicate capture-owned highlights by stable fingerprint. Re-import is idempotent. Advertise exact `hasReadingNativeImportV1=true` only with this versioned field/collision contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Import accepts the versioned Server-native JSONL/ZIP artifacts produced by S5a while retaining Pocket JSON and Instapaper CSV compatibility.
+- [ ] #2 Empty-authority import reproduces every declared portable field and allocates fresh local identities without importing user/database IDs, external links, private paths, or internal metadata.
+- [ ] #3 Canonical-URL collisions preserve existing scalar/state/content fields, union tags, and add only nonduplicate capture-owned highlights using the documented stable fingerprint.
+- [ ] #4 Re-importing the same artifact is idempotent and produces no duplicate capture or highlight; malformed, future-version, oversized, and partially corrupt input fails safely.
+- [ ] #5 Docs-info advertises `hasReadingNativeImportV1=true` only with the field/collision contract and public portability documentation.
+- [ ] #6 S5a is a same-repository dependency, and focused parser/job/database/API/security and multi-page round-trip tests pass with the applicable ADR recorded or amended.
+<!-- AC:END -->

--- a/backlog/tasks/task-13158 - Add-Server-native-Reading-export-re-import.md
+++ b/backlog/tasks/task-13158 - Add-Server-native-Reading-export-re-import.md
@@ -4,7 +4,7 @@ title: Add Server-native Reading export re-import
 status: To Do
 assignee: []
 created_date: '2026-09-03 02:33'
-updated_date: '2026-09-03 02:34'
+updated_date: '2026-09-03 02:41'
 labels:
   - collections
   - reading-list
@@ -22,7 +22,17 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Retain Pocket JSON and Instapaper CSV import, then admit versioned Server-native JSONL/ZIP artifacts produced by S5a. Portable fields are submitted URL, title, summary, freeform note, status, favorite, tags, published/read timestamps, optional sanitized text/clean HTML, and capture-owned highlights. Exclude database/user IDs, authoritative created/updated timestamps, Media/linked-Note identities, generated audio, offline/archive files, and internal metadata. Allocate new identities and canonicalize URLs. On canonical collision preserve existing scalar/state/content, union tags, and add only nonduplicate capture-owned highlights by stable fingerprint. Re-import is idempotent. Advertise exact `hasReadingNativeImportV1=true` only with this versioned field/collision contract.
+Retain Pocket JSON and Instapaper CSV import, then add Server-native JSONL/ZIP admission for
+artifacts produced by S5a. The portable schema includes submitted URL, title, summary, freeform
+note, status, favorite, tags, published/read timestamps, optional sanitized text/clean HTML, and
+capture-owned highlights. It excludes database/user IDs, authoritative created/updated timestamps,
+Media and linked-Note identities, generated audio, offline/archive files, and internal metadata.
+Import allocates new identities, recomputes canonical URLs, and records source timestamps only as
+bounded import provenance. On a canonical-URL collision it preserves existing scalar/state/content
+fields, unions tags, and adds only nonduplicate capture-owned highlights using a documented stable
+fingerprint. Importing into an empty authority reproduces every portable field; repeated import is
+idempotent and never creates another capture or highlight. Docs-info advertises exact
+`hasReadingNativeImportV1=true` only when this versioned field and collision contract is active.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

- add six atomic Server prerequisites for the Collections reader follow-up work
- define revision-guarded hard delete, complete aggregate facets, safe output templates, bounded digest management, restart-safe exports, and Server-native re-import
- keep S1-S5a independent while making TASK-13158 depend on export contract TASK-13157

## Backlog records

- TASK-13153 through TASK-13158
- all records are To Do, unassigned, and intentionally have no implementation plan yet

## Verification

- every task was read back through Backlog CLI and compared with the approved cross-repository design
- all-ref/all-worktree ID and normalized-title census found zero target collisions
- `git diff --check origin/dev...HEAD` passed
- branch diff contains exactly six Backlog task files

The official Backlog MCP was attempted first but stalled without making a mutation; the repository-documented CLI fallback created and verified the records. No production code changed, so runtime tests were not applicable.

Task IDs remain provisional until the collision census is rerun immediately before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six atomic Server prerequisite backlog tasks for the Collections reader follow-up, covering revision-guarded hard delete, scoped tag/domain aggregates, output-template ownership and safe deletion, bounded digest management, restart-safe exports, and Server-native re-import. No production code changes.

**Backlog records**
- TASK-13153 through TASK-13158 are all To Do, unassigned, and intentionally lack implementation plans.
- TASK-13158 depends on TASK-13157's export contract; the remaining tasks stay independent.
- Each task was verified against the approved cross-repository design with zero target collisions and a passing `git diff --check`.

<sup>Written for commit 371eabb24e3ee2958f88691c54b6f9cd77304682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

