### PR TITLE
Admin WebUI UX remediation: fix single-user 500, give admin an IA, make states trustworthy

### DIFF
--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -34,7 +34,11 @@ import {
 } from "@/hooks/useKeyboardShortcuts"
 import { useShortcutConfig } from "@/hooks/keyboard/useShortcutConfig"
 import type { KeyboardShortcut as ConfiguredKeyboardShortcut } from "@/hooks/keyboard/useKeyboardShortcuts"
-import { getCommandPaletteTarget } from "@/routes/route-metadata"
+import {
+  getCommandPaletteTarget,
+  getRouteCommandPaletteLabel
+} from "@/routes/route-metadata"
+import { ADMIN_MODULES } from "@/components/Option/Admin/admin-modules"
 import { RESEARCH_WORKSPACE_PATH } from "@/routes/route-paths"
 import { searchSettings } from "@/data/settings-index"
 import { cn } from "@/libs/utils"
@@ -324,6 +328,34 @@ export function CommandPalette({
         category: "navigation",
         keywords: ["mcp", "hub", "acp", "policy", "server"],
       },
+      // Admin modules, derived from the admin registry so the palette and the
+      // admin surface can't drift apart (2026-09 UX audit finding S1). Labels
+      // come from route metadata to satisfy palette label governance.
+      ...(!isSidepanel
+        ? ([
+            {
+              id: "nav-admin",
+              label: getRouteCommandPaletteLabel("/admin"),
+              description: t(
+                "common:commandPalette.adminOverviewDescription",
+                "Admin Operations overview"
+              ),
+              icon: <Settings className="size-4" />,
+              ...buildRouteCommand("/admin"),
+              category: "navigation" as const,
+              keywords: ["admin", "operations", "server management"],
+            },
+            ...ADMIN_MODULES.map((module) => ({
+              id: `nav${module.route.replaceAll("/", "-")}`,
+              label: getRouteCommandPaletteLabel(module.route),
+              description: module.description,
+              icon: <Settings className="size-4" />,
+              ...buildRouteCommand(module.route),
+              category: "navigation" as const,
+              keywords: ["admin", module.label.toLowerCase()],
+            })),
+          ] as CommandItem[])
+        : []),
       ...(!isSidepanel ? ([
         {
           id: "nav-health",

--- a/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+++ b/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
@@ -494,6 +494,13 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
     titleDefault: "Admin & Help",
     items: [
       {
+        id: "admin-overview",
+        to: "/admin",
+        icon: CogIcon,
+        labelKey: "option:header.adminOverview",
+        labelDefault: "Admin Operations"
+      },
+      {
         id: "admin-server",
         to: "/admin/server",
         icon: CogIcon,

--- a/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
@@ -1,152 +1,62 @@
 import React from "react"
-import {
-  getOperationsRouteJob,
-  type OperationsRouteJob
-} from "@/routes/operations-route-jobs"
 import { PageShell } from "@/components/Common/PageShell"
+import {
+  ADMIN_MODULE_GROUPS,
+  ADMIN_MODULES,
+  type AdminModuleGroup
+} from "./admin-modules"
 
-type AdminOverviewModule = {
-  route: string
-  fallbackLabel: string
-  summary: string
-  status: "Route ready" | "Needs module configuration"
-  statusDescription: string
-}
-
-const ADMIN_MODULES: AdminOverviewModule[] = [
-  {
-    route: "/admin/server",
-    fallbackLabel: "Server Admin",
-    summary: "Server health, users, roles, storage, sessions, and media budget diagnostics.",
-    status: "Route ready",
-    statusDescription: "Open the module to load live server health and user data."
-  },
-  {
-    route: "/admin/integrations",
-    fallbackLabel: "Workspace Integrations",
-    summary: "Workspace integration policy for Slack, Discord, Telegram, and linked actors.",
-    status: "Route ready",
-    statusDescription: "Open the module to load workspace policy and provider state."
-  },
-  {
-    route: "/admin/sources",
-    fallbackLabel: "Admin Sources",
-    summary: "Administrative view of ingestion source availability, sync state, and setup.",
-    status: "Route ready",
-    statusDescription: "Open the module to load source capability and sync state."
-  },
-  {
-    route: "/admin/monitoring",
-    fallbackLabel: "Monitoring",
-    summary: "Monitoring metrics, alerts, runtime diagnostics, and operations telemetry.",
-    status: "Route ready",
-    statusDescription: "Open the module to load metrics, alerts, and diagnostic state."
-  }
-]
-
-const labelForJob = (
-  job: OperationsRouteJob | undefined,
-  fallbackLabel: string
-): string => job?.label ?? fallbackLabel
-
-const ModuleDiagnostics: React.FC<{
-  job: OperationsRouteJob | undefined
-  module: AdminOverviewModule
-}> = ({ job, module }) => {
-  return (
-    <details className="mt-4 rounded-md border border-border bg-surface2 px-3 py-2 text-xs text-text-muted">
-      <summary className="cursor-pointer font-medium text-text">Diagnostics</summary>
-      <dl className="mt-3 grid gap-2">
-        <div>
-          <dt className="font-semibold text-text-muted">Route</dt>
-          <dd>
-            <code className="rounded bg-surface px-1 py-0.5">{module.route}</code>
-          </dd>
-        </div>
-        <div>
-          <dt className="font-semibold text-text-muted">Capability source</dt>
-          <dd>{job?.capabilityMode ?? "frontend_state"}</dd>
-        </div>
-        <div>
-          <dt className="font-semibold text-text-muted">Owner</dt>
-          <dd>{job?.implementationOwner ?? "shared_route"}</dd>
-        </div>
-      </dl>
-    </details>
-  )
-}
+const groupedModules = ADMIN_MODULE_GROUPS.map((group: AdminModuleGroup) => ({
+  group,
+  modules: ADMIN_MODULES.filter((module) => module.group === group)
+})).filter((entry) => entry.modules.length > 0)
 
 export const AdminOperationsOverviewPage: React.FC = () => {
-  const adminJob = getOperationsRouteJob("/admin")
-
   return (
     <PageShell maxWidthClassName="max-w-6xl" className="py-8">
       <header className="space-y-3">
         <p className="text-sm font-semibold uppercase tracking-wide text-text-muted">
           Admin
         </p>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h1 className="text-3xl font-semibold text-text">Admin Operations</h1>
-            <p className="mt-2 max-w-3xl text-sm text-text-muted">
-              Review the available admin modules before opening a drill-down page.
-              Live health, users, policies, sources, and monitoring data load inside
-              each module.
-            </p>
-          </div>
-          <a
-            href="/admin/server"
-            className="inline-flex w-fit rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primaryStrong"
-          >
-            Open server admin
-          </a>
+        <div>
+          <h1 className="text-3xl font-semibold text-text">Admin Operations</h1>
+          <p className="mt-2 max-w-3xl text-sm text-text-muted">
+            Everything you can administer on this server, in one place. Open a
+            module to load its live data.
+          </p>
         </div>
       </header>
 
-      <section
-        className="mt-8 grid gap-4 md:grid-cols-2"
-        data-testid="admin-operations-modules"
-      >
-        {ADMIN_MODULES.map((module) => {
-          const job = getOperationsRouteJob(module.route)
-          const label = labelForJob(job, module.fallbackLabel)
-
-          return (
-            <article
-              key={module.route}
-              className="rounded-lg border border-border bg-surface p-5 shadow-sm"
-              data-testid={`admin-module-${module.route}`}
+      <div className="mt-8 space-y-8" data-testid="admin-operations-modules">
+        {groupedModules.map(({ group, modules }) => (
+          <section key={group} aria-labelledby={`admin-group-${group}`}>
+            <h2
+              id={`admin-group-${group}`}
+              className="text-sm font-semibold uppercase tracking-wide text-text-muted"
             >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-lg font-semibold text-text">
+              {group}
+            </h2>
+            <div className="mt-3 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {modules.map((module) => (
+                <article
+                  key={module.route}
+                  className="rounded-lg border border-border bg-surface p-4 shadow-sm"
+                  data-testid={`admin-module-${module.route}`}
+                >
+                  <h3 className="text-base font-semibold text-text">
                     <a className="hover:text-primary" href={module.route}>
-                      {label}
+                      {module.label}
                     </a>
-                  </h2>
-                  <p className="mt-2 text-sm text-text-muted">{module.summary}</p>
-                </div>
-                <span className="shrink-0 rounded-full border border-border bg-surface2 px-2 py-1 text-xs font-medium text-text">
-                  {module.status}
-                </span>
-              </div>
-
-              <p className="mt-4 text-sm text-text-muted">
-                {module.statusDescription}
-              </p>
-
-              <ModuleDiagnostics job={job} module={module} />
-            </article>
-          )
-        })}
-      </section>
-
-      <section className="mt-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
-        <p>
-          {adminJob?.primaryJob ??
-            "Review operations status and choose an admin module."}
-        </p>
-      </section>
+                  </h3>
+                  <p className="mt-1.5 text-sm text-text-muted">
+                    {module.description}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
     </PageShell>
   )
 }

--- a/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
@@ -1,0 +1,88 @@
+import React from "react"
+import {
+  ADMIN_MODULES,
+  adminModuleForRoute,
+  isAdminRoute
+} from "./admin-modules"
+
+/**
+ * Chrome shared by every admin page (2026-09 UX audit findings S1/S5):
+ * a skip link, a nav landmark linking all admin modules, and a document
+ * title per module. Rendered by the host app around admin route content.
+ *
+ * Kept dependency-free (React only) so host apps can mount it outside the
+ * shared component tree without pulling browser-specific modules into SSR.
+ */
+export const AdminRouteShell: React.FC<{
+  path: string
+  children: React.ReactNode
+}> = ({ path, children }) => {
+  const current = adminModuleForRoute(path)
+  const onOverview = isAdminRoute(path) && !current
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") return
+    const previous = document.title
+    document.title = current
+      ? `${current.label} · Admin · tldw`
+      : "Admin · tldw"
+    return () => {
+      document.title = previous
+    }
+  }, [current])
+
+  return (
+    <div className="flex min-h-full flex-col">
+      <a
+        href="#admin-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-50 focus:rounded-md focus:bg-surface focus:px-3 focus:py-2 focus:text-sm focus:text-text focus:shadow"
+      >
+        Skip to admin content
+      </a>
+      <nav
+        aria-label="Admin modules"
+        className="border-b border-border bg-surface px-4 py-2"
+      >
+        <div className="flex items-center gap-1 overflow-x-auto whitespace-nowrap text-sm">
+          <a
+            href="/admin"
+            aria-current={onOverview ? "page" : undefined}
+            className={
+              onOverview
+                ? "rounded-md bg-surface2 px-2.5 py-1 font-semibold text-text"
+                : "rounded-md px-2.5 py-1 font-medium text-text-muted hover:bg-surface2 hover:text-text"
+            }
+          >
+            Admin
+          </a>
+          <span aria-hidden="true" className="px-1 text-text-muted">
+            /
+          </span>
+          {ADMIN_MODULES.map((module) => {
+            const isCurrent = module.route === current?.route
+            return (
+              <a
+                key={module.route}
+                href={module.route}
+                aria-current={isCurrent ? "page" : undefined}
+                title={module.description}
+                className={
+                  isCurrent
+                    ? "rounded-md bg-surface2 px-2.5 py-1 font-semibold text-text"
+                    : "rounded-md px-2.5 py-1 text-text-muted hover:bg-surface2 hover:text-text"
+                }
+              >
+                {module.label}
+              </a>
+            )
+          })}
+        </div>
+      </nav>
+      <div id="admin-content" className="min-h-0 flex-1">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default AdminRouteShell

--- a/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
@@ -78,7 +78,9 @@ export const AdminRouteShell: React.FC<{
           })}
         </div>
       </nav>
-      <div id="admin-content" className="min-h-0 flex-1">
+      {/* tabIndex={-1} makes the skip-link target programmatically focusable,
+          so activating the link actually moves keyboard focus past the nav. */}
+      <div id="admin-content" tabIndex={-1} className="min-h-0 flex-1 outline-none">
         {children}
       </div>
     </div>

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -27,6 +27,7 @@ const ApiKeyManagementPage: React.FC = () => {
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null)
   const [users, setUsers] = useState<any[]>([])
   const [usersLoading, setUsersLoading] = useState(false)
+  const [usersError, setUsersError] = useState<string | null>(null)
 
   // API keys state
   const [keys, setKeys] = useState<any[]>([])
@@ -51,11 +52,21 @@ const ApiKeyManagementPage: React.FC = () => {
   // Load users for the selector
   const loadUsers = useCallback(async () => {
     setUsersLoading(true)
+    setUsersError(null)
     try {
       const result = await tldwClient.listAdminUsers({ limit: 100 })
-      setUsers(result.users || [])
+      const loaded = result.users || []
+      setUsers(loaded)
+      // Single-user servers have exactly one account — select it directly
+      // instead of asking the operator to search for themselves.
+      if (loaded.length === 1) {
+        setSelectedUserId((current) => current ?? loaded[0].id)
+      }
     } catch (err) {
       markAdminGuardFromError(err)
+      setUsersError(
+        sanitizeAdminErrorMessage(err, "Failed to load the user list.")
+      )
     } finally {
       setUsersLoading(false)
     }
@@ -217,7 +228,22 @@ const ApiKeyManagementPage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 16 }}>API Key Management</h2>
+      <h2 style={{ marginBottom: 4 }}>API Key Management</h2>
+      <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
+        Create, rotate, and revoke the API keys a user presents to
+        authenticate against this server.
+      </p>
+
+      {usersError && (
+        <Alert variant="error" title="Unable to load users" className="mb-4">
+          <Space orientation="vertical" size="small">
+            <span>{usersError}</span>
+            <Button size="small" onClick={() => void loadUsers()}>
+              Retry
+            </Button>
+          </Space>
+        </Alert>
+      )}
 
       {/* New key alert */}
       {newKeyValue && (
@@ -256,6 +282,17 @@ const ApiKeyManagementPage: React.FC = () => {
           />
         </Space>
       </Card>
+
+      {/* Pre-selection guidance (multi-user servers with several accounts) */}
+      {!selectedUserId && !usersLoading && !usersError && (
+        <Card size="small">
+          <p style={{ margin: 0, color: "var(--color-text-secondary, #888)" }}>
+            {users.length === 0
+              ? "No users were found on this server."
+              : "Select a user above to view and manage their API keys."}
+          </p>
+        </Card>
+      )}
 
       {/* Keys table */}
       {selectedUserId && (

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -228,7 +228,7 @@ const ApiKeyManagementPage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 4 }}>API Key Management</h2>
+      <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>API Key Management</h1>
       <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
         Create, rotate, and revoke the API keys a user presents to
         authenticate against this server.

--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -517,7 +517,7 @@ const BillingDashboardPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <h2>Billing Dashboard</h2>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Billing Dashboard</h1>
       <Tabs defaultActiveKey="overview" items={tabItems} />
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -457,6 +457,16 @@ const BillingDashboardPage: React.FC = () => {
     }
   }, [connectionConfig?.serverUrl, connectionConfigLoading])
 
+  // Failsafe: the capability probe must never hold the whole page in a
+  // skeleton (e.g. when the connection config never finishes loading or the
+  // openapi fetch hangs). After a short grace period, render and let the
+  // runtime endpoints report their own errors.
+  useEffect(() => {
+    if (capabilityCheckResolved) return
+    const timer = setTimeout(() => setCapabilityCheckResolved(true), 4000)
+    return () => clearTimeout(timer)
+  }, [capabilityCheckResolved])
+
   if (!capabilityCheckResolved) {
     return (
       <div style={{ padding: 24 }}>
@@ -478,8 +488,10 @@ const BillingDashboardPage: React.FC = () => {
   if (adminGuard === "notFound") {
     return (
       <div style={{ padding: 24 }}>
-        <Alert variant="warning" title="Not Available">
-          Billing endpoints are not available on this server.
+        <Alert variant="warning" title="Not available on this server">
+          Billing endpoints are not enabled here. Billing applies to
+          multi-user deployments with subscription management configured;
+          single-user servers do not use it.
         </Alert>
       </div>
     )

--- a/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
@@ -928,7 +928,7 @@ const DataOpsPage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 16 }}>Data Operations</h2>
+      <h1 style={{ marginBottom: 16, fontSize: "1.5rem", fontWeight: 600 }}>Data Operations</h1>
       <Tabs items={tabItems} defaultActiveKey="backups" />
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -25,6 +25,7 @@ import { downloadBlob } from "@/utils/download-blob"
 import { StatusBanner } from "./StatusBanner"
 import {
   deriveAdminGuardFromError,
+  isServiceUnavailableError,
   sanitizeAdminErrorMessage,
   type AdminGuardState
 } from "./admin-error-utils"
@@ -177,6 +178,19 @@ export const LlamacppAdminPage: React.FC = () => {
     }
   }, [])
 
+  // A 502/503/504 means the llama.cpp runtime is down — say that, instead of
+  // a generic failure (or, worse, the old "Admin APIs are not available" wall).
+  const describeLoadError = React.useCallback(
+    (error: unknown, fallback: string): string =>
+      isServiceUnavailableError(error)
+        ? t(
+            "settings:admin.llamacppRuntimeUnavailableBody",
+            "The llama.cpp runtime is not available on this server. Install or start llama.cpp, then retry."
+          )
+        : sanitizeAdminErrorMessage(error, fallback),
+    [t]
+  )
+
   const loadConfig = React.useCallback(async () => {
     try {
       setLoadingConfig(true)
@@ -184,7 +198,7 @@ export const LlamacppAdminPage: React.FC = () => {
       setConfig(data)
     } catch (error: unknown) {
       setStatusError(
-        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp configuration.")
+        describeLoadError(error, "Failed to load Llama.cpp configuration.")
       )
       markAdminGuardFromError(error)
     } finally {
@@ -201,7 +215,7 @@ export const LlamacppAdminPage: React.FC = () => {
     } catch (error: unknown) {
       setStatus(null)
       setStatusError(
-        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp status.")
+        describeLoadError(error, "Failed to load Llama.cpp status.")
       )
       markAdminGuardFromError(error)
     } finally {
@@ -225,7 +239,7 @@ export const LlamacppAdminPage: React.FC = () => {
       setInventory(null)
       setSelectedModelId(undefined)
       setInventoryError(
-        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp inventory.")
+        describeLoadError(error, "Failed to load Llama.cpp inventory.")
       )
       markAdminGuardFromError(error)
     } finally {
@@ -243,7 +257,7 @@ export const LlamacppAdminPage: React.FC = () => {
     } catch (error: unknown) {
       setAssets(null)
       setAssetError(
-        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp assets.")
+        describeLoadError(error, "Failed to load Llama.cpp assets.")
       )
       return false
     } finally {
@@ -328,7 +342,7 @@ export const LlamacppAdminPage: React.FC = () => {
       }
       setRuntimeUnsupported(false)
       setRuntimeError(
-        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp runtime instances.")
+        describeLoadError(error, "Failed to load Llama.cpp runtime instances.")
       )
     } finally {
       setLoadingRuntimes(false)

--- a/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
@@ -361,7 +361,7 @@ const MaintenancePage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 16 }}>Maintenance Console</h2>
+      <h1 style={{ marginBottom: 16, fontSize: "1.5rem", fontWeight: 600 }}>Maintenance Console</h1>
 
       {/* Maintenance Mode Card */}
       <Card title="Maintenance Mode" loading={maintLoading} style={{ marginBottom: 16 }}>

--- a/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
@@ -21,6 +21,7 @@ import { CollapsibleSection } from "./CollapsibleSection"
 import { Alert, Badge } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
+  isServiceUnavailableError,
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 
@@ -149,11 +150,21 @@ export const MlxAdminPage: React.FC = () => {
         setMaxConcurrent(data.max_concurrent)
       }
     } catch (e: any) {
-      setStatusError(sanitizeAdminErrorMessage(e, "Failed to load MLX status."))
+      // A 502/503/504 means the MLX runtime is down on the server — say so
+      // instead of showing a generic failure (2026-09 UX audit finding S3).
+      setStatusError(
+        isServiceUnavailableError(e)
+          ? t(
+              "settings:admin.mlxRuntimeUnavailableBody",
+              "The MLX runtime is not available on this server. MLX requires Apple Silicon; install or start it, then retry."
+            )
+          : sanitizeAdminErrorMessage(e, "Failed to load MLX status.")
+      )
       markAdminGuardFromError(e)
     } finally {
       setStatusLoading(false)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `t` is stable for the session; adding it re-triggers the initial load effect
   }, [])
 
   const loadProviders = React.useCallback(async () => {

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -57,7 +57,7 @@ function formatStatValue(value: unknown): React.ReactNode {
       <dl style={{ margin: 0 }}>
         {entries.map(([k, v]) => (
           <div key={k} style={{ display: "flex", gap: 8, fontSize: 12, lineHeight: 1.6 }}>
-            <dt style={{ color: "#666", minWidth: 100 }}>{k}:</dt>
+            <dt style={{ color: "#666", minWidth: 100 }}>{formatStatKey(k)}:</dt>
             <dd style={{ margin: 0 }}>{formatStatValue(v)}</dd>
           </div>
         ))}
@@ -67,11 +67,36 @@ function formatStatValue(value: unknown): React.ReactNode {
   return String(value)
 }
 
-/** Make a stat key more human-readable */
+const STAT_KEY_ACRONYMS: Record<string, string> = {
+  kb: "KB",
+  mb: "MB",
+  gb: "GB",
+  tb: "TB",
+  cpu: "CPU",
+  gpu: "GPU",
+  mcp: "MCP",
+  acp: "ACP",
+  llm: "LLM",
+  api: "API",
+  id: "ID",
+  url: "URL",
+  pct: "%"
+}
+
+/** Make a stat key human-readable: total_used_mb -> "Total Used MB",
+ * mcp_invocations_today -> "MCP Invocations Today", new_last_30d -> "New (last 30 days)". */
 function formatStatKey(key: string): string {
   return key
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .split("_")
+    .map(
+      (part) =>
+        STAT_KEY_ACRONYMS[part.toLowerCase()] ??
+        part.charAt(0).toUpperCase() + part.slice(1)
+    )
+    .join(" ")
+    .replace(/\bLast 30d\b/i, "(last 30 days)")
+    .replace(/\bLast 7d\b/i, "(last 7 days)")
+    .replace(/\bLast 24h\b/i, "(last 24 hours)")
 }
 
 function formatRuntimeCode(value: string | null | undefined): string {
@@ -161,6 +186,7 @@ const MonitoringDashboardPage: React.FC = () => {
   const [sandboxDiagnostics, setSandboxDiagnostics] = useState<SandboxAdminRuntimeDiagnosticsResponse | null>(null)
   const [sandboxDiagnosticsLoading, setSandboxDiagnosticsLoading] = useState(false)
   const [sandboxDiagnosticsError, setSandboxDiagnosticsError] = useState<SandboxDiagnosticsErrorState | null>(null)
+  const [sandboxDiagnosticsMissing, setSandboxDiagnosticsMissing] = useState(false)
 
   // Alert rules state
   const [alertRules, setAlertRules] = useState<AlertRuleRow[]>([])
@@ -220,10 +246,13 @@ const MonitoringDashboardPage: React.FC = () => {
       const diagnostics = await tldwClient.getSandboxRuntimeDiagnostics()
       setSandboxDiagnostics(diagnostics)
       setSandboxDiagnosticsError(null)
+      setSandboxDiagnosticsMissing(false)
     } catch (err: unknown) {
       const guardState = deriveAdminGuardFromError(err)
       const isForbidden = guardState === "forbidden"
+      const isMissing = guardState === "notFound"
       setSandboxDiagnostics(null)
+      setSandboxDiagnosticsMissing(isMissing)
       setSandboxDiagnosticsError(
         buildCapabilityState({
           featureName: "Sandbox diagnostics",
@@ -233,10 +262,14 @@ const MonitoringDashboardPage: React.FC = () => {
           error: err,
           title: isForbidden
             ? "Sandbox diagnostics access denied"
-            : "Sandbox diagnostics unavailable",
+            : isMissing
+              ? "Sandbox diagnostics not available on this server"
+              : "Sandbox diagnostics unavailable",
           message: isForbidden
             ? "You don't have permission to view sandbox runtime diagnostics."
-            : "Sandbox runtime diagnostics are not available."
+            : isMissing
+              ? "This server does not expose the sandbox runtime diagnostics API. This is expected when the sandbox module is not enabled."
+              : "Sandbox runtime diagnostics are not available."
         })
       )
     } finally {
@@ -655,10 +688,16 @@ const MonitoringDashboardPage: React.FC = () => {
               message={sandboxDiagnosticsError.message}
               diagnostics={sandboxDiagnosticsError.diagnostics}
               role="alert"
-              primaryAction={{
-                label: "Retry diagnostics",
-                onClick: () => void loadSandboxDiagnostics()
-              }}
+              primaryAction={
+                // Retrying a missing endpoint can never succeed — offer the
+                // action only for transient failures (2026-09 audit S9).
+                sandboxDiagnosticsMissing
+                  ? undefined
+                  : {
+                      label: "Retry diagnostics",
+                      onClick: () => void loadSandboxDiagnostics()
+                    }
+              }
             />
           )}
           {sandboxDiagnostics?.summary && (

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -614,7 +614,7 @@ const MonitoringDashboardPage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 4 }}>Monitoring &amp; Alerting</h2>
+      <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>Monitoring &amp; Alerting</h1>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
         Monitor your tldw server&apos;s health and set up alerts for important metrics. Create rules below to get notified when something needs attention.
       </Typography.Paragraph>

--- a/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
@@ -590,7 +590,7 @@ const OrgsTeamsPage: React.FC = () => {
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
-        <h2 style={{ margin: 0 }}>Organizations & Teams</h2>
+        <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 600 }}>Organizations & Teams</h1>
       </div>
 
       <Card

--- a/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
@@ -209,7 +209,7 @@ const RateLimitingPage: React.FC = () => {
 
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
-      <h2 style={{ marginBottom: 16 }}>Rate Limiting &amp; Resource Governor</h2>
+      <h1 style={{ marginBottom: 16, fontSize: "1.5rem", fontWeight: 600 }}>Rate Limiting &amp; Resource Governor</h1>
 
       {/* Governor Policy Card */}
       <Card

--- a/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
@@ -137,8 +137,14 @@ const RateLimitingPage: React.FC = () => {
 
   // ── Coverage Table Columns ──
 
-  const protectedRoutes = coverage?.protected ?? []
-  const unprotectedRoutes = coverage?.unprotected ?? []
+  // The diag endpoint returns protected_routes/unprotected_routes (+ counts);
+  // older builds used protected/unprotected. Reading the wrong keys rendered
+  // "78.9% coverage" above "0 routes | 0 routes" (2026-09 audit finding P11).
+  const protectedRoutes = coverage?.protected_routes ?? coverage?.protected ?? []
+  const unprotectedRoutes =
+    coverage?.unprotected_routes ?? coverage?.unprotected ?? []
+  const protectedCount = coverage?.protected_count ?? protectedRoutes.length
+  const unprotectedCount = coverage?.unprotected_count ?? unprotectedRoutes.length
   const coveragePct = coverage?.coverage_pct ?? (
     protectedRoutes.length + unprotectedRoutes.length > 0
       ? Math.round((protectedRoutes.length / (protectedRoutes.length + unprotectedRoutes.length)) * 100)
@@ -150,7 +156,11 @@ const RateLimitingPage: React.FC = () => {
       title: "Route",
       dataIndex: "route",
       key: "route",
-      render: (val: string, record: any) => <code>{val || record}</code>
+      // The diag endpoint emits { method, path } objects; legacy payloads used
+      // plain strings or { route }. Never render a raw object into the cell.
+      render: (val: string, record: any) => (
+        <code>{val || record?.path || String(record?.route ?? "")}</code>
+      )
     },
     {
       title: "Method",
@@ -275,8 +285,8 @@ const RateLimitingPage: React.FC = () => {
               />
             </div>
             <div>
-              <strong>Protected:</strong> {protectedRoutes.length} routes |{" "}
-              <strong>Unprotected:</strong> {unprotectedRoutes.length} routes
+              <strong>Protected:</strong> {protectedCount} routes |{" "}
+              <strong>Unprotected:</strong> {unprotectedCount} routes
             </div>
             {unprotectedRoutes.length > 0 && (
               <div>
@@ -286,7 +296,7 @@ const RateLimitingPage: React.FC = () => {
                     typeof r === "string" ? { route: r, key: i } : { ...r, key: i }
                   )}
                   columns={routeColumns}
-                  pagination={false}
+                  pagination={{ pageSize: 25, showSizeChanger: false }}
                   size="small"
                   style={{ marginTop: 8 }}
                 />
@@ -300,7 +310,7 @@ const RateLimitingPage: React.FC = () => {
 
       {/* Rate Limits Card */}
       <Card
-        title="Admin Rate Limits"
+        title="Per-user rate limit overrides"
         style={{ marginBottom: 16 }}
         extra={
           <Button onClick={() => loadRateLimits()} size="small">
@@ -308,6 +318,10 @@ const RateLimitingPage: React.FC = () => {
           </Button>
         }
       >
+        <p style={{ marginTop: 0, color: "var(--color-text-secondary, #888)" }}>
+          Overrides created for specific users or API keys. Baseline limits
+          come from the resource governor policy above.
+        </p>
         {rateLimitsError ? (
           <Alert title={rateLimitsError} />
         ) : (
@@ -318,7 +332,10 @@ const RateLimitingPage: React.FC = () => {
             loading={rateLimitsLoading}
             pagination={false}
             size="small"
-            locale={{ emptyText: "No rate limits configured" }}
+            locale={{
+              emptyText:
+                "No per-user overrides configured. The governor policy's baseline limits still apply."
+            }}
           />
         )}
       </Card>

--- a/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
@@ -776,6 +776,10 @@ const RbacEditorPage: React.FC = () => {
 
   return (
     <div style={{ padding: 16 }}>
+      <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>Roles &amp; Permissions</h1>
+      <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
+        Review the permission matrix, manage roles, and adjust per-user grants.
+      </p>
       <Tabs
         defaultActiveKey="matrix"
         items={[

--- a/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
@@ -62,6 +62,7 @@ interface EffectivePerm {
 
 const PermissionMatrixTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardError }) => {
   const [matrix, setMatrix] = useState<any>(null)
+  const [matrixError, setMatrixError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [toggling, setToggling] = useState<string | null>(null)
   const [categories, setCategories] = useState<string[]>([])
@@ -69,11 +70,15 @@ const PermissionMatrixTab: React.FC<{ onGuardError: (err: any) => void }> = ({ o
 
   const loadMatrix = useCallback(async () => {
     setLoading(true)
+    setMatrixError(null)
     try {
       const result = await tldwClient.getRolePermissionMatrix()
       setMatrix(result)
     } catch (err) {
       onGuardError(err)
+      setMatrixError(
+        sanitizeAdminErrorMessage(err, "Failed to load the permission matrix.")
+      )
     } finally {
       setLoading(false)
     }
@@ -117,6 +122,18 @@ const PermissionMatrixTab: React.FC<{ onGuardError: (err: any) => void }> = ({ o
   }, [loadMatrix])
 
   if (!matrix) {
+    if (matrixError && !loading) {
+      return (
+        <DesignSystemAlert variant="error" title="Unable to load the permission matrix">
+          <Space orientation="vertical" size="small">
+            <span>{matrixError}</span>
+            <Button size="small" onClick={() => void loadMatrix()}>
+              Retry
+            </Button>
+          </Space>
+        </DesignSystemAlert>
+      )
+    }
     return <Card loading={loading}><div style={{ minHeight: 200 }} /></Card>
   }
 
@@ -181,15 +198,32 @@ const PermissionMatrixTab: React.FC<{ onGuardError: (err: any) => void }> = ({ o
         </Space>
       }
     >
-      <Table
-        dataSource={filteredPermissions}
-        columns={columns}
-        rowKey="id"
-        loading={loading}
-        pagination={false}
-        scroll={{ x: 260 + roles.length * 120 }}
-        size="small"
-      />
+      {permissions.length === 0 && !loading ? (
+        <DesignSystemAlert
+          variant="info"
+          title="No permissions registered yet"
+        >
+          This server's RBAC catalog is empty, so there is nothing to grant or
+          revoke per role — built-in role behavior still applies. The matrix
+          fills in once permissions are seeded on the server (see the privilege
+          catalog configuration).
+        </DesignSystemAlert>
+      ) : (
+        <Table
+          dataSource={filteredPermissions}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          pagination={false}
+          scroll={{ x: 260 + roles.length * 120 }}
+          size="small"
+          locale={{
+            emptyText: selectedCategory
+              ? "No permissions in this category."
+              : "No permissions found."
+          }}
+        />
+      )}
     </Card>
   )
 }

--- a/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -653,11 +653,21 @@ export const ServerAdminPage: React.FC = () => {
               }>
               <Space orientation="vertical" size="middle" className="w-full">
                 {usersError && (
-                  <Alert
-                    variant="error"
-                    title={t("settings:admin.usersError", "Unable to load users")}>
-                    {usersError}
-                  </Alert>
+                  <StatePanel
+                    state="error"
+                    title={t("settings:admin.usersError", "Unable to load users")}
+                    message={usersError}
+                    primaryAction={{
+                      label: t("common:retry", "Retry"),
+                      onClick: () =>
+                        loadUsers(
+                          usersPage,
+                          usersPageSize,
+                          userRoleFilter,
+                          userActiveFilter
+                        )
+                    }}
+                  />
                 )}
                 <Space align="center" wrap>
                   <Text strong>
@@ -710,26 +720,39 @@ export const ServerAdminPage: React.FC = () => {
                   }}
                   onChange={handleUserTableChange}
                 />
-                {!usersLoading && (usersData?.users || []).length === 0 && (
-                  <StatePanel
-                    state="empty"
-                    title={t("settings:admin.users.emptyTitle", "No users found")}
-                    message={t(
-                      "settings:admin.users.empty",
-                      "No user diagnostics match the current filters."
-                    )}
-                    primaryAction={{
-                      label: t("common:refresh", "Refresh"),
-                      onClick: () =>
-                        loadUsers(
-                          usersPage,
-                          usersPageSize,
-                          userRoleFilter,
-                          userActiveFilter
-                        )
-                    }}
-                  />
-                )}
+                {/* Never blame the user's filters for a failed fetch: the
+                    empty panel only renders when the request succeeded, and
+                    only mentions filters when filters are actually set
+                    (2026-09 UX audit finding S4). */}
+                {!usersLoading &&
+                  !usersError &&
+                  (usersData?.users || []).length === 0 && (
+                    <StatePanel
+                      state="empty"
+                      title={t("settings:admin.users.emptyTitle", "No users found")}
+                      message={
+                        userRoleFilter || userActiveFilter
+                          ? t(
+                              "settings:admin.users.emptyFiltered",
+                              "No users match the current filters."
+                            )
+                          : t(
+                              "settings:admin.users.emptyNoFilters",
+                              "This server has no user accounts yet."
+                            )
+                      }
+                      primaryAction={{
+                        label: t("common:refresh", "Refresh"),
+                        onClick: () =>
+                          loadUsers(
+                            usersPage,
+                            usersPageSize,
+                            userRoleFilter,
+                            userActiveFilter
+                          )
+                      }}
+                    />
+                  )}
 
                 <Divider />
 

--- a/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -515,7 +515,7 @@ export const ServerAdminPage: React.FC = () => {
           </Text>
         )}
         <div>
-          <Title level={2}>{t("option:header.adminServer", "Server Admin")}</Title>
+          <Title level={1} style={{ fontSize: 30 }}>{t("option:header.adminServer", "Server Admin")}</Title>
           <Text type="secondary">
             {t(
               "settings:admin.serverIntro",

--- a/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
@@ -26,6 +26,14 @@ const downloadCsv = (data: string, filename: string) => {
   URL.revokeObjectURL(url)
 }
 
+
+// Dollar amounts: whole cents normally; sub-cent LLM costs keep 4 decimals
+// so tiny real spend does not round to an unhelpful $0.00.
+const formatUsd = (value: number): string => {
+  if (!Number.isFinite(value) || value === 0) return "$0.00"
+  return Math.abs(value) < 0.01 ? `$${value.toFixed(4)}` : `$${value.toFixed(2)}`
+}
+
 const UsageAnalyticsPage: React.FC = () => {
   // Admin guard state
   const [adminGuard, setAdminGuard] = useState<"forbidden" | "notFound" | null>(null)
@@ -223,13 +231,13 @@ const UsageAnalyticsPage: React.FC = () => {
     { title: "Provider", dataIndex: "provider", key: "provider" },
     { title: "Model", dataIndex: "model", key: "model" },
     { title: "Tokens", dataIndex: "tokens", key: "tokens", render: (v: number) => v?.toLocaleString() ?? "\u2014" },
-    { title: "Cost", dataIndex: "cost", key: "cost", render: (v: number) => v != null ? `$${v.toFixed(4)}` : "\u2014" }
+    { title: "Cost", dataIndex: "cost", key: "cost", render: (v: number) => v != null ? formatUsd(v) : "\u2014" }
   ]
 
   const topSpenderColumns = [
     { title: "User", dataIndex: "username", key: "username" },
     { title: "Total Tokens", dataIndex: "total_tokens", key: "total_tokens", render: (v: number) => v?.toLocaleString() ?? "\u2014" },
-    { title: "Total Cost", dataIndex: "total_cost", key: "total_cost", render: (v: number) => v != null ? `$${v.toFixed(4)}` : "\u2014" }
+    { title: "Total Cost", dataIndex: "total_cost", key: "total_cost", render: (v: number) => v != null ? formatUsd(v) : "\u2014" }
   ]
 
   const providerColumns = [
@@ -341,9 +349,7 @@ const UsageAnalyticsPage: React.FC = () => {
             />
             <Statistic
               title="Total Cost"
-              prefix="$"
-              value={llmSummary.total_cost ?? llmSummary.totalCost ?? 0}
-              precision={4}
+              value={formatUsd(llmSummary.total_cost ?? llmSummary.totalCost ?? 0)}
               loading={llmSummaryLoading}
             />
           </Space>

--- a/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
@@ -259,7 +259,7 @@ const UsageAnalyticsPage: React.FC = () => {
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
-        <h2 style={{ margin: 0 }}>Usage Analytics</h2>
+        <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 600 }}>Usage Analytics</h1>
         <Select
           value={dateRange}
           onChange={(val) => setDateRange(val)}

--- a/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
@@ -264,7 +264,7 @@ const WatchlistsPage: React.FC = () => {
 
   return (
     <div style={pageContainerStyle}>
-      <h2 style={{ marginBottom: 16 }}>Watchlists &amp; Alerts</h2>
+      <h1 style={{ marginBottom: 16, fontSize: "1.5rem", fontWeight: 600 }}>Watchlists &amp; Alerts</h1>
 
       {/* Watchlists Card */}
       <Card

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/AdminOperationsOverviewPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/AdminOperationsOverviewPage.test.tsx
@@ -4,44 +4,35 @@ import { describe, expect, it } from "vitest"
 import { render, screen, within } from "@testing-library/react"
 
 import { AdminOperationsOverviewPage } from "../AdminOperationsOverviewPage"
+import { ADMIN_MODULES } from "../admin-modules"
 
 describe("AdminOperationsOverviewPage", () => {
-  it("renders admin operations as an overview with module drill-down routes", () => {
+  it("links every registered admin module (the overview is the complete map)", () => {
     render(<AdminOperationsOverviewPage />)
 
     expect(
       screen.getByRole("heading", { name: "Admin Operations" })
     ).toBeInTheDocument()
-    expect(screen.queryByTestId("route-redirect-panel")).not.toBeInTheDocument()
 
     const modules = screen.getByTestId("admin-operations-modules")
-
-    for (const [label, href] of [
-      ["Server Admin", "/admin/server"],
-      ["Workspace Integrations", "/admin/integrations"],
-      ["Admin Sources", "/admin/sources"],
-      ["Monitoring", "/admin/monitoring"]
-    ] as const) {
-      const link = within(modules).getByRole("link", { name: label })
-      expect(link).toHaveAttribute("href", href)
+    for (const module of ADMIN_MODULES) {
+      const link = within(modules).getByRole("link", { name: module.label })
+      expect(link).toHaveAttribute("href", module.route)
     }
+    // Guard against regressing to a partial list (2026-09 audit finding S1).
+    expect(ADMIN_MODULES.length).toBeGreaterThanOrEqual(17)
   })
 
-  it("keeps module status visible and diagnostics behind disclosure", () => {
+  it("speaks operator language, not implementation status", () => {
     render(<AdminOperationsOverviewPage />)
 
-    const serverCard = screen.getByTestId("admin-module-/admin/server")
-
-    expect(within(serverCard).getByText("Route ready")).toBeInTheDocument()
+    expect(screen.queryByText("Route ready")).not.toBeInTheDocument()
+    expect(screen.queryByText("Diagnostics")).not.toBeInTheDocument()
     expect(
-      within(serverCard).getByText(
-        "Open the module to load live server health and user data."
-      )
-    ).toBeInTheDocument()
-
-    expect(screen.getAllByText("Diagnostics")).toHaveLength(4)
+      screen.queryByText("frontend_state", { exact: false })
+    ).not.toBeInTheDocument()
     expect(
-      screen.queryByText("implementationOwner", { exact: false })
+      screen.queryByText("Needs module configuration")
     ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+
+import { AdminRouteShell } from "../AdminRouteShell"
+import { ADMIN_MODULES, adminModuleForRoute, isAdminRoute } from "../admin-modules"
+
+describe("AdminRouteShell", () => {
+  it("renders a nav landmark linking every admin module", () => {
+    render(
+      <AdminRouteShell path="/admin/server">
+        <div>content</div>
+      </AdminRouteShell>
+    )
+
+    const nav = screen.getByRole("navigation", { name: "Admin modules" })
+    for (const module of ADMIN_MODULES) {
+      const link = within(nav).getByRole("link", { name: module.label })
+      expect(link).toHaveAttribute("href", module.route)
+    }
+  })
+
+  it("marks the current module and titles the document after it", () => {
+    render(
+      <AdminRouteShell path="/admin/server">
+        <div>content</div>
+      </AdminRouteShell>
+    )
+
+    const nav = screen.getByRole("navigation", { name: "Admin modules" })
+    expect(
+      within(nav).getByRole("link", { name: "Server Admin" })
+    ).toHaveAttribute("aria-current", "page")
+    expect(document.title).toBe("Server Admin · Admin · tldw")
+  })
+
+  it("provides a skip link to the admin content region", () => {
+    render(
+      <AdminRouteShell path="/admin/monitoring">
+        <div>content</div>
+      </AdminRouteShell>
+    )
+
+    const skip = screen.getByRole("link", { name: "Skip to admin content" })
+    expect(skip).toHaveAttribute("href", "#admin-content")
+    expect(document.getElementById("admin-content")).toBeTruthy()
+  })
+
+  it("resolves admin route helpers consistently", () => {
+    expect(isAdminRoute("/admin")).toBe(true)
+    expect(isAdminRoute("/admin/server/")).toBe(true)
+    expect(isAdminRoute("/administration")).toBe(false)
+    expect(isAdminRoute("/chat")).toBe(false)
+    expect(adminModuleForRoute("/admin/server?tab=users")?.label).toBe(
+      "Server Admin"
+    )
+    expect(adminModuleForRoute("/admin")).toBeUndefined()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
@@ -189,4 +189,33 @@ describe("ApiKeyManagementPage design-system states", () => {
     expect(alert).toHaveTextContent("Copy this key now -- it will not be shown again:")
     expect(alert).toHaveTextContent("sk-test-secret")
   })
+
+  it("auto-selects the only user so single-user servers skip the picker", async () => {
+    render(<ApiKeyManagementPage />)
+
+    await waitFor(() => {
+      expect(apiMock.listUserApiKeys).toHaveBeenCalledWith(11)
+    })
+    expect(await screen.findByText("API Keys")).toBeTruthy()
+  })
+
+  it("surfaces user-list failures with a retry instead of a silent dead end", async () => {
+    apiMock.listAdminUsers.mockRejectedValueOnce(
+      new Error("Request failed: 500 (GET /api/v1/admin/users)")
+    )
+
+    render(<ApiKeyManagementPage />)
+
+    const alert = await expectDesignSystemAlertForText("Unable to load users")
+    expect(alert).toHaveTextContent("Request failed: 500")
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+
+    await waitFor(() => {
+      expect(apiMock.listAdminUsers).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(apiMock.listUserApiKeys).toHaveBeenCalledWith(11)
+    })
+  })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
@@ -67,10 +67,10 @@ describe("BillingDashboardPage", () => {
 
     render(<BillingDashboardPage />)
 
-    const alert = await expectDesignSystemAlertForTitle("Not Available")
-    expect(
-      alert
-    ).toHaveTextContent("Billing endpoints are not available on this server.")
+    const alert = await expectDesignSystemAlertForTitle(
+      "Not available on this server"
+    )
+    expect(alert).toHaveTextContent("Billing endpoints are not enabled here.")
     expect(mocks.getBillingOverview).not.toHaveBeenCalled()
     expect(mocks.listAllSubscriptions).not.toHaveBeenCalled()
     expect(mocks.listBillingEvents).not.toHaveBeenCalled()

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
@@ -1045,11 +1045,28 @@ describe("LlamacppAdminPage", () => {
     })
   })
 
-  it("gates controls when admin APIs are unavailable", async () => {
+  it("keeps the page usable and names the runtime outage on a 503", async () => {
+    // Regression: a 503 (llama.cpp runtime down) used to be misdiagnosed as
+    // "Admin APIs not available" and blanked the whole page.
     apiMock.getLlamacppStatus.mockRejectedValueOnce(
       new Error(
         "Request failed: 503 (GET /api/v1/admin/llamacpp/status) config=/Users/dev/.config/tldw/config.txt"
       )
+    )
+
+    render(<LlamacppAdminPage />)
+
+    expect(
+      await screen.findByText(
+        "The llama.cpp runtime is not available on this server. Install or start llama.cpp, then retry."
+      )
+    ).toBeTruthy()
+    expect(screen.queryByText("Admin APIs not available")).toBeNull()
+  })
+
+  it("gates controls when admin APIs are genuinely missing (404)", async () => {
+    apiMock.getLlamacppStatus.mockRejectedValueOnce(
+      new Error("Request failed: 404 (GET /api/v1/admin/llamacpp/status)")
     )
 
     render(<LlamacppAdminPage />)

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx
@@ -99,11 +99,25 @@ describe("MlxAdminPage", () => {
     ).toBeTruthy()
   })
 
-  it("gates controls when admin APIs are unavailable", async () => {
+  it("names the runtime outage on a 503 instead of blaming missing admin APIs", async () => {
     apiMock.getMlxStatus.mockRejectedValueOnce(
       new Error(
         "Request failed: 503 (GET /api/v1/admin/mlx/status) config=/Users/dev/.config/tldw/config.txt"
       )
+    )
+
+    render(<MlxAdminPage />)
+
+    const alert = await expectDesignSystemAlertForText(
+      "The MLX runtime is not available on this server. MLX requires Apple Silicon; install or start it, then retry."
+    )
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.queryByText("Admin APIs not available")).toBeNull()
+  })
+
+  it("gates controls when admin APIs are genuinely missing (404)", async () => {
+    apiMock.getMlxStatus.mockRejectedValueOnce(
+      new Error("Request failed: 404 (GET /api/v1/admin/mlx/status)")
     )
 
     render(<MlxAdminPage />)

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx
@@ -142,4 +142,42 @@ describe("RateLimitingPage", () => {
     expect(alert).toHaveAttribute("role", "status")
     expect(mocks.listAdminRateLimits).not.toHaveBeenCalled()
   })
+
+  it("reads the diag coverage payload's real field names (protected_routes/counts)", async () => {
+    // Regression: the page read coverage.protected/unprotected while the diag
+    // endpoint returns protected_routes/unprotected_routes (+ counts), so it
+    // rendered "78.9%" above "Protected: 0 routes | Unprotected: 0 routes".
+    mocks.getGovernorCoverage.mockResolvedValueOnce({
+      total_routes: 10,
+      protected_count: 8,
+      unprotected_count: 2,
+      coverage_pct: 80,
+      protected_routes: Array.from({ length: 8 }, (_, i) => ({
+        method: "GET",
+        path: `/api/v1/protected-${i}`
+      })),
+      unprotected_routes: [
+        { method: "GET", path: "/api/v1/open-a" },
+        { method: "POST", path: "/api/v1/open-b" }
+      ]
+    })
+
+    render(<RateLimitingPage />)
+
+    await screen.findByText("/api/v1/open-a")
+    const summary = screen.getByText("Protected:").closest("div")
+    expect(summary?.textContent).toContain("Protected: 8 routes")
+    expect(summary?.textContent).toContain("Unprotected: 2 routes")
+    expect(screen.getByText("/api/v1/open-b")).toBeInTheDocument()
+  })
+
+  it("explains that empty per-user overrides still leave baseline limits active", async () => {
+    render(<RateLimitingPage />)
+
+    expect(
+      await screen.findByText(
+        "No per-user overrides configured. The governor policy's baseline limits still apply."
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
@@ -208,13 +208,20 @@ describe("ServerAdminPage design-system states", () => {
     ).toBeInTheDocument()
   })
 
-  it("renders user-load errors through the design-system Alert primitive", async () => {
+  it("renders user-load errors as an error state with retry, without a false empty panel", async () => {
     apiMock.listAdminUsers.mockRejectedValueOnce(new Error("Users exploded"))
 
     render(<ServerAdminPage />)
 
-    const alert = await expectDesignSystemAlertForTitle("Unable to load users")
-    expect(alert).toHaveTextContent("Users exploded")
+    expect(await screen.findByText("Unable to load users")).toBeInTheDocument()
+    expect(screen.getByText("Users exploded")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
+    // Regression (2026-09 audit S4): a failed fetch must not additionally
+    // render the filters-blaming empty state.
+    expect(screen.queryByText("No users found")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("No user diagnostics match the current filters.")
+    ).not.toBeInTheDocument()
   })
 
   it("renders role-load errors through the design-system Alert primitive", async () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
@@ -26,7 +26,9 @@ describe("StatusBanner", () => {
 
     expect(screen.getByText("Status Error")).toBeTruthy()
     const fullText = document.body.textContent || ""
-    expect(fullText).toContain("[admin-endpoint]")
+    // The endpoint parenthetical is dropped entirely once redacted, so no
+    // "[admin-endpoint]" placeholder noise remains — only the path redaction.
+    expect(fullText).not.toContain("[admin-endpoint]")
     expect(fullText).toContain("[redacted-path]")
     expect(fullText).not.toContain("/api/v1/admin/mlx/status")
     expect(fullText).not.toContain("/Users/dev/.config/tldw/config.txt")

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/admin-error-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/admin-error-utils.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "vitest"
 import {
   deriveAdminGuardFromError,
+  isServiceUnavailableError,
   sanitizeAdminErrorMessage
 } from "../admin-error-utils"
 
 describe("admin error utilities", () => {
-  it("derives guard state for forbidden and unavailable admin APIs", () => {
+  it("derives guard state for forbidden and missing admin APIs", () => {
     expect(deriveAdminGuardFromError(new Error("Request failed: 403"))).toBe(
       "forbidden"
-    )
-    expect(deriveAdminGuardFromError(new Error("Request failed: 503"))).toBe(
-      "notFound"
     )
     expect(deriveAdminGuardFromError(new Error("Request failed: 404"))).toBe(
       "notFound"
@@ -24,6 +22,24 @@ describe("admin error utilities", () => {
     expect(deriveAdminGuardFromError(new Error("network down"))).toBe(null)
   })
 
+  it("does not misdiagnose a 503 service outage as missing admin APIs", () => {
+    // Regression: a 503 from e.g. the llama.cpp runtime used to render the
+    // "Admin APIs are not available on this server" wall with a wrong remedy.
+    expect(deriveAdminGuardFromError(new Error("Request failed: 503"))).toBe(
+      null
+    )
+    expect(isServiceUnavailableError(new Error("Request failed: 503"))).toBe(
+      true
+    )
+    expect(isServiceUnavailableError({ status: 502, message: "bad gateway" })).toBe(
+      true
+    )
+    expect(isServiceUnavailableError(new Error("Request failed: 404"))).toBe(
+      false
+    )
+    expect(isServiceUnavailableError(new Error("network down"))).toBe(false)
+  })
+
   it("redacts endpoints and filesystem paths from user-facing errors", () => {
     const message = sanitizeAdminErrorMessage(
       new Error(
@@ -32,10 +48,23 @@ describe("admin error utilities", () => {
       "fallback message"
     )
 
-    expect(message).toContain("[admin-endpoint]")
     expect(message).toContain("[redacted-path]")
     expect(message).not.toContain("/api/v1/admin/llamacpp/status")
     expect(message).not.toContain("/Users/dev/.config/tldw/config.txt")
+    // The endpoint parenthetical carries no information once redacted, so it
+    // is dropped entirely rather than shown as "(GET [admin-endpoint])".
+    expect(message).not.toContain("[admin-endpoint]")
+    expect(message).toContain("Request failed: 503")
+  })
+
+  it("keeps redacting endpoints that appear outside parentheticals", () => {
+    const message = sanitizeAdminErrorMessage(
+      new Error("Upstream rejected GET /api/v1/admin/users with 500"),
+      "fallback message"
+    )
+
+    expect(message).toContain("[admin-endpoint]")
+    expect(message).not.toContain("/api/v1/admin/users")
   })
 
   it("returns fallback when message is missing", () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/admin-modules.registry-sync.test.ts
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/admin-modules.registry-sync.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { getRouteMetadata, ROUTE_METADATA } from "@/routes/route-metadata"
+import { ADMIN_MODULES } from "../admin-modules"
+
+/**
+ * The admin registry (admin-modules.ts) and route metadata are parallel
+ * declarations by design — the registry carries operator descriptions and
+ * groups that metadata lacks. These invariants keep the two from drifting
+ * (PR #2879 review recommendation).
+ */
+describe("admin module registry <-> route metadata sync", () => {
+  it("registers route metadata for every admin module", () => {
+    for (const module of ADMIN_MODULES) {
+      const metadata = getRouteMetadata(module.route)
+      expect(metadata, module.route).toBeDefined()
+      expect(metadata?.surface, module.route).toBe("admin_operator")
+    }
+  })
+
+  it("declares every admin_operator drill-down route in the admin registry", () => {
+    const registryRoutes = new Set(ADMIN_MODULES.map((module) => module.route))
+    const adminMetadataRoutes = ROUTE_METADATA.filter(
+      (metadata) =>
+        metadata.surface === "admin_operator" && metadata.path !== "/admin"
+    ).map((metadata) => metadata.path)
+
+    expect(adminMetadataRoutes.length).toBeGreaterThan(0)
+    for (const path of adminMetadataRoutes) {
+      expect(registryRoutes.has(path), path).toBe(true)
+    }
+  })
+
+  it("keeps registry routes unique and shaped like admin drill-downs", () => {
+    const routes = ADMIN_MODULES.map((module) => module.route)
+    expect(new Set(routes).size).toBe(routes.length)
+    for (const module of ADMIN_MODULES) {
+      expect(module.route, module.label).toMatch(/^\/admin\/[a-z0-9-]+$/)
+      expect(module.label.trim().length, module.route).toBeGreaterThan(0)
+      expect(module.description.trim().length, module.route).toBeGreaterThan(0)
+    }
+  })
+})

--- a/apps/packages/ui/src/components/Option/Admin/admin-error-utils.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-error-utils.ts
@@ -1,6 +1,12 @@
 export type AdminGuardState = "forbidden" | "notFound" | null
 
-const ADMIN_NOT_FOUND_CODES = new Set(["404", "405", "410", "501", "503"])
+// Codes that mean the admin endpoint itself does not exist on this server.
+// 5xx availability codes deliberately do NOT belong here: a 503 from e.g. the
+// llama.cpp service means "the backing runtime is down", not "this tldw server
+// lacks the /admin endpoints" — conflating them misdiagnoses the outage.
+const ADMIN_NOT_FOUND_CODES = new Set(["404", "405", "410", "501"])
+
+const SERVICE_UNAVAILABLE_CODES = new Set(["502", "503", "504"])
 
 const normalizeErrorMessage = (error: unknown): string => {
   if (typeof error === "string") return error
@@ -10,7 +16,7 @@ const normalizeErrorMessage = (error: unknown): string => {
   return ""
 }
 
-export const deriveAdminGuardFromError = (error: unknown): AdminGuardState => {
+const extractStatusCode = (error: unknown): string => {
   const rawMessage = normalizeErrorMessage(error)
   const statusFromField =
     error && typeof error === "object" && "status" in error
@@ -18,8 +24,12 @@ export const deriveAdminGuardFromError = (error: unknown): AdminGuardState => {
       : ""
   const statusMatch =
     rawMessage.match(/Request failed:\s*(\d{3})/i) ||
-    rawMessage.match(/\b(403|404|405|410|501|503)\b/)
-  const statusCode = statusFromField || statusMatch?.[1] || ""
+    rawMessage.match(/\b(403|404|405|410|501|502|503|504)\b/)
+  return statusFromField || statusMatch?.[1] || ""
+}
+
+export const deriveAdminGuardFromError = (error: unknown): AdminGuardState => {
+  const statusCode = extractStatusCode(error)
 
   if (statusCode === "403") {
     return "forbidden"
@@ -29,6 +39,15 @@ export const deriveAdminGuardFromError = (error: unknown): AdminGuardState => {
   }
   return null
 }
+
+/**
+ * True when the failure is a temporary upstream/service availability problem
+ * (502/503/504) rather than a missing or forbidden admin API. Pages should
+ * treat this as "the backing service is down — retry / start it", never as
+ * "this server has no admin endpoints".
+ */
+export const isServiceUnavailableError = (error: unknown): boolean =>
+  SERVICE_UNAVAILABLE_CODES.has(extractStatusCode(error))
 
 export const sanitizeAdminErrorMessage = (
   error: unknown,
@@ -60,6 +79,15 @@ export const sanitizeAdminErrorMessage = (
     /[A-Za-z]:\\(?:[^\\\s]+\\)+[^\\\s)]+/g,
     "[redacted-path]"
   )
+
+  // A parenthetical that only carried the (now redacted) endpoint adds no
+  // information for the reader — drop it instead of showing "[admin-endpoint]".
+  cleaned = cleaned
+    .replace(
+      /\s*\(\s*(?:(?:GET|POST|PUT|PATCH|DELETE)\s+)?\[admin-endpoint\]\s*\)/gi,
+      ""
+    )
+    .trim()
 
   if (cleaned.length > 220) {
     cleaned = `${cleaned.slice(0, 217)}...`

--- a/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
@@ -100,7 +100,7 @@ export const ADMIN_MODULES: AdminModule[] = [
   {
     route: "/admin/mlx",
     label: "MLX LM",
-    description: "Load and monitor MLX language models on Apple Silicon.",
+    description: "Load and monitor MLX models on Apple Silicon.",
     group: "Local models"
   },
   {

--- a/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
@@ -1,0 +1,161 @@
+/**
+ * Single source of truth for the admin surface.
+ *
+ * Every admin module (route, operator-facing label, one-line purpose, group)
+ * is declared here once. The admin overview page, the cross-module nav, and
+ * document titles all derive from this list — never maintain a second,
+ * partial list of admin routes elsewhere (2026-09 UX audit finding S1).
+ */
+
+export type AdminModuleGroup =
+  | "Server"
+  | "Access & security"
+  | "Data"
+  | "Local models"
+  | "Observability"
+  | "Workspace"
+
+export interface AdminModule {
+  route: string
+  label: string
+  description: string
+  group: AdminModuleGroup
+}
+
+export const ADMIN_MODULE_GROUPS: AdminModuleGroup[] = [
+  "Server",
+  "Access & security",
+  "Data",
+  "Local models",
+  "Observability",
+  "Workspace"
+]
+
+export const ADMIN_MODULES: AdminModule[] = [
+  {
+    route: "/admin/server",
+    label: "Server Admin",
+    description:
+      "Server health, users, roles, storage, sessions, and media budget diagnostics.",
+    group: "Server"
+  },
+  {
+    route: "/admin/maintenance",
+    label: "Maintenance",
+    description:
+      "Maintenance mode, feature flags, and incident tracking for this server.",
+    group: "Server"
+  },
+  {
+    route: "/admin/runtime-config",
+    label: "Runtime Config",
+    description: "Inspect and adjust runtime configuration values.",
+    group: "Server"
+  },
+  {
+    route: "/admin/api-keys",
+    label: "API Keys",
+    description: "Create, rotate, and revoke the API keys users authenticate with.",
+    group: "Access & security"
+  },
+  {
+    route: "/admin/rbac",
+    label: "Roles & Permissions",
+    description: "Role-based access control: the permission matrix and role grants.",
+    group: "Access & security"
+  },
+  {
+    route: "/admin/orgs",
+    label: "Organizations & Teams",
+    description: "Organization and team structure for multi-user deployments.",
+    group: "Access & security"
+  },
+  {
+    route: "/admin/rate-limiting",
+    label: "Rate Limiting",
+    description: "Resource governor policy and endpoint rate-limit coverage.",
+    group: "Access & security"
+  },
+  {
+    route: "/admin/data-ops",
+    label: "Data Operations",
+    description:
+      "Backups and schedules, data subject requests, retention policies, and bundles.",
+    group: "Data"
+  },
+  {
+    route: "/admin/sources",
+    label: "Sources",
+    description:
+      "Local folders and archive snapshots that sync into notes or media.",
+    group: "Data"
+  },
+  {
+    route: "/admin/llamacpp",
+    label: "Llama.cpp",
+    description:
+      "Manage the llama.cpp inference server: launch, models, profiles, assets.",
+    group: "Local models"
+  },
+  {
+    route: "/admin/mlx",
+    label: "MLX LM",
+    description: "Load and monitor MLX language models on Apple Silicon.",
+    group: "Local models"
+  },
+  {
+    route: "/admin/monitoring",
+    label: "Monitoring",
+    description: "Health metrics, alerts, and operations telemetry for this server.",
+    group: "Observability"
+  },
+  {
+    route: "/admin/usage",
+    label: "Usage Analytics",
+    description: "Request, storage, and LLM usage over time, with CSV export.",
+    group: "Observability"
+  },
+  {
+    route: "/admin/billing",
+    label: "Billing",
+    description:
+      "Subscriptions and billing events (multi-user deployments only).",
+    group: "Observability"
+  },
+  {
+    route: "/admin/integrations",
+    label: "Workspace Integrations",
+    description:
+      "Slack, Discord, and Telegram workspace policy and linked actors.",
+    group: "Workspace"
+  },
+  {
+    route: "/admin/watchlists-items",
+    label: "Watchlist Items",
+    description: "Review collected watchlist updates, matches, and briefings.",
+    group: "Workspace"
+  },
+  {
+    route: "/admin/watchlists-runs",
+    label: "Watchlist Runs",
+    description: "Run history and job inspection for watchlists (coming soon).",
+    group: "Workspace"
+  }
+]
+
+const normalizeAdminPath = (path: string): string => {
+  const withoutQuery = path.split(/[?#]/)[0] ?? ""
+  return withoutQuery.length > 1 && withoutQuery.endsWith("/")
+    ? withoutQuery.slice(0, -1)
+    : withoutQuery
+}
+
+export const adminModuleForRoute = (path: string): AdminModule | undefined => {
+  const normalized = normalizeAdminPath(path)
+  return ADMIN_MODULES.find((module) => module.route === normalized)
+}
+
+export const isAdminRoute = (path: string): boolean => {
+  const normalized = normalizeAdminPath(path)
+  return normalized === "/admin" || normalized.startsWith("/admin/")
+}

--- a/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
@@ -356,11 +356,23 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
       })
     : null
 
-  // One page-level status at a time: when the overview endpoint itself is
-  // unavailable, the per-section callouts and empty provider cards below it
-  // only contradict the banner (2026-09 UX audit finding S3).
+  // One page-level status at a time — but only when the overview error means
+  // the workspace-integrations feature is absent from this server (4xx
+  // endpoint-missing codes). The policy/bot/actor panels load from separate
+  // endpoints, so a transient overview failure must not hide their data or
+  // retry actions (2026-09 UX audit finding S3 + PR #2879 review).
+  const overviewErrorStatus =
+    overviewQuery.isError && !overviewQuery.data
+      ? getCapabilityErrorStatus(overviewQuery.error)
+      : null
   const overviewUnavailable =
-    overviewQuery.isError && !overviewQuery.data && !personalIntegrationsUnsupported
+    overviewQuery.isError &&
+    !overviewQuery.data &&
+    !personalIntegrationsUnsupported &&
+    (overviewErrorStatus === 404 ||
+      overviewErrorStatus === 405 ||
+      overviewErrorStatus === 410 ||
+      overviewErrorStatus === 501)
 
   const handlePersonalAction = async (connection: IntegrationConnection, action: string) => {
     if (scope !== "personal" || !isPersonalProvider(connection.provider)) {

--- a/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
@@ -218,40 +218,45 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
 
   // A 4xx (endpoint missing, forbidden) will not change on retry; hammering
   // an absent workspace API produced 12 404s per page load (audit finding S9).
+  // Transient failures (5xx/network) get exactly one quick retry.
   const retryUnlessClientError = (failureCount: number, error: unknown) => {
     const status = getCapabilityErrorStatus(error)
     if (typeof status === "number" && status >= 400 && status < 500) {
       return false
     }
-    return failureCount < 3
+    return failureCount < 1
   }
 
   const slackPolicyQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "slack-policy"),
     queryFn: getWorkspaceSlackPolicy,
     enabled: scope === "workspace",
-    retry: retryUnlessClientError
+    retry: retryUnlessClientError,
+    retryDelay: 500
   })
 
   const discordPolicyQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "discord-policy"),
     queryFn: getWorkspaceDiscordPolicy,
     enabled: scope === "workspace",
-    retry: retryUnlessClientError
+    retry: retryUnlessClientError,
+    retryDelay: 500
   })
 
   const telegramBotQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "telegram-bot"),
     queryFn: getWorkspaceTelegramBot,
     enabled: scope === "workspace",
-    retry: retryUnlessClientError
+    retry: retryUnlessClientError,
+    retryDelay: 500
   })
 
   const telegramActorsQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "telegram-linked-actors"),
     queryFn: listWorkspaceTelegramLinkedActors,
     enabled: scope === "workspace",
-    retry: retryUnlessClientError
+    retry: retryUnlessClientError,
+    retryDelay: 500
   })
 
   const connectionsByProvider = useMemo(() => {

--- a/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
@@ -342,6 +342,12 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
       })
     : null
 
+  // One page-level status at a time: when the overview endpoint itself is
+  // unavailable, the per-section callouts and empty provider cards below it
+  // only contradict the banner (2026-09 UX audit finding S3).
+  const overviewUnavailable =
+    overviewQuery.isError && !overviewQuery.data && !personalIntegrationsUnsupported
+
   const handlePersonalAction = async (connection: IntegrationConnection, action: string) => {
     if (scope !== "personal" || !isPersonalProvider(connection.provider)) {
       return
@@ -440,7 +446,7 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
         />
       ) : null}
 
-      {!personalIntegrationsUnsupported ? (
+      {!personalIntegrationsUnsupported && !overviewUnavailable ? (
         <Row gutter={[16, 16]}>
           {connectionsByProvider.map((group) => (
             <Col key={group.provider} xs={24} lg={8}>
@@ -456,7 +462,7 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
         </Row>
       ) : null}
 
-      {isWorkspace ? (
+      {isWorkspace && !overviewUnavailable ? (
         <>
           {telegramActorsState ? (
             <RecoveryCallout

--- a/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/IntegrationManagementPage.tsx
@@ -216,28 +216,42 @@ export const IntegrationManagementPage: React.FC<IntegrationManagementPageProps>
     }
   })
 
+  // A 4xx (endpoint missing, forbidden) will not change on retry; hammering
+  // an absent workspace API produced 12 404s per page load (audit finding S9).
+  const retryUnlessClientError = (failureCount: number, error: unknown) => {
+    const status = getCapabilityErrorStatus(error)
+    if (typeof status === "number" && status >= 400 && status < 500) {
+      return false
+    }
+    return failureCount < 3
+  }
+
   const slackPolicyQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "slack-policy"),
     queryFn: getWorkspaceSlackPolicy,
-    enabled: scope === "workspace"
+    enabled: scope === "workspace",
+    retry: retryUnlessClientError
   })
 
   const discordPolicyQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "discord-policy"),
     queryFn: getWorkspaceDiscordPolicy,
-    enabled: scope === "workspace"
+    enabled: scope === "workspace",
+    retry: retryUnlessClientError
   })
 
   const telegramBotQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "telegram-bot"),
     queryFn: getWorkspaceTelegramBot,
-    enabled: scope === "workspace"
+    enabled: scope === "workspace",
+    retry: retryUnlessClientError
   })
 
   const telegramActorsQuery = useQuery({
     queryKey: buildIntegrationQueryKey("workspace", activeOrgId, "telegram-linked-actors"),
     queryFn: listWorkspaceTelegramLinkedActors,
-    enabled: scope === "workspace"
+    enabled: scope === "workspace",
+    retry: retryUnlessClientError
   })
 
   const connectionsByProvider = useMemo(() => {

--- a/apps/packages/ui/src/components/Option/Integrations/IntegrationPolicyPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/IntegrationPolicyPanel.tsx
@@ -8,6 +8,7 @@ import {
   InputNumber,
   List,
   Select,
+  Skeleton,
   Space,
   Switch,
   Tag,
@@ -178,9 +179,16 @@ const WorkspacePolicyEditor: React.FC<
   )
 
   return (
-    <Card title={title} loading={loading}>
-      {summary ? <Typography.Paragraph type="secondary">{summary}</Typography.Paragraph> : null}
-      {errorState ? (
+    // Card's `loading` prop unmounts children, disconnecting the useForm
+    // instance and logging an antd warning (#2874). Keep the cheap <Form>
+    // shell mounted instead — that's all the instance needs — and gate the
+    // heavy content on the loading flag.
+    <Card title={title}>
+      {loading ? <Skeleton active paragraph={{ rows: 4 }} /> : null}
+      {!loading && summary ? (
+        <Typography.Paragraph type="secondary">{summary}</Typography.Paragraph>
+      ) : null}
+      {!loading && errorState ? (
         <RecoveryCallout
           state={errorState.state}
           title={errorState.title}
@@ -199,17 +207,21 @@ const WorkspacePolicyEditor: React.FC<
       ) : errorMessage ? (
         <DsAlert variant="error" className="mb-4" title={errorMessage} />
       ) : null}
-      {!errorMessage && !errorState && isUnavailable ? (
+      {!loading && !errorMessage && !errorState && isUnavailable ? (
         <DsAlert variant="warning" className="mb-4" title={`${title} is unavailable`} />
       ) : null}
-      <Descriptions size="small" bordered column={1} style={{ marginBottom: 16 }}>
-        {policyDescription.map((item) => (
-          <Descriptions.Item key={item.label} label={item.label}>
-            {item.value}
-          </Descriptions.Item>
-        ))}
-      </Descriptions>
+      {!loading ? (
+        <Descriptions size="small" bordered column={1} style={{ marginBottom: 16 }}>
+          {policyDescription.map((item) => (
+            <Descriptions.Item key={item.label} label={item.label}>
+              {item.value}
+            </Descriptions.Item>
+          ))}
+        </Descriptions>
+      ) : null}
       <Form form={form} layout="vertical">
+        {!loading ? (
+        <>
         <Form.Item label="Default response mode" name="default_response_mode">
           <Select
             disabled={isUnavailable}
@@ -266,6 +278,8 @@ const WorkspacePolicyEditor: React.FC<
         <Button type="primary" onClick={() => void handleSave()} loading={saving} disabled={isUnavailable}>
           {`Save ${title}`}
         </Button>
+        </>
+        ) : null}
       </Form>
     </Card>
   )
@@ -354,8 +368,11 @@ const TelegramPolicyEditor: React.FC<
   }
 
   return (
-    <Card title="Telegram bot" loading={loading}>
-      {errorState ? (
+    // Same useForm/Card-loading interaction as WorkspacePolicyEditor (#2874):
+    // keep the <Form> shell mounted; gate heavy content on the loading flag.
+    <Card title="Telegram bot">
+      {loading ? <Skeleton active paragraph={{ rows: 4 }} /> : null}
+      {!loading && errorState ? (
         <RecoveryCallout
           state={errorState.state}
           title={errorState.title}
@@ -374,6 +391,7 @@ const TelegramPolicyEditor: React.FC<
       ) : errorMessage ? (
         <DsAlert variant="error" className="mb-4" title={errorMessage} />
       ) : null}
+      {!loading ? (
       <Descriptions size="small" bordered column={1} style={{ marginBottom: 16 }}>
         <Descriptions.Item label="Bot username">{bot?.bot_username ?? "—"}</Descriptions.Item>
         <Descriptions.Item label="Enabled">
@@ -381,8 +399,11 @@ const TelegramPolicyEditor: React.FC<
         </Descriptions.Item>
         <Descriptions.Item label="Linked actors">{linkedActors.length}</Descriptions.Item>
       </Descriptions>
+      ) : null}
 
       <Form form={form} layout="vertical">
+        {!loading ? (
+        <>
         <Form.Item label="Bot token" name="bot_token" rules={[{ required: true, message: "Bot token is required" }]}>
           <Input.Password placeholder="Enter bot token" autoComplete="off" disabled={isUnavailable} />
         </Form.Item>
@@ -403,9 +424,11 @@ const TelegramPolicyEditor: React.FC<
             Generate pairing code
           </Button>
         </Space>
+        </>
+        ) : null}
       </Form>
 
-      {localPairingCode ? (
+      {!loading && localPairingCode ? (
         <DsAlert variant="success" className="mt-4" title="Pairing code generated">
           <div className="flex flex-col">
             <span>
@@ -416,6 +439,7 @@ const TelegramPolicyEditor: React.FC<
         </DsAlert>
       ) : null}
 
+      {!loading ? (
       <div style={{ marginTop: 16 }}>
         <Typography.Title level={5}>Linked actors</Typography.Title>
         {linkedActors.length > 0 ? (
@@ -440,6 +464,7 @@ const TelegramPolicyEditor: React.FC<
           <Typography.Text type="secondary">No linked actors found.</Typography.Text>
         )}
       </div>
+      ) : null}
     </Card>
   )
 }

--- a/apps/packages/ui/src/components/Option/Integrations/__tests__/IntegrationManagementPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/__tests__/IntegrationManagementPage.test.tsx
@@ -370,8 +370,9 @@ describe("IntegrationManagementPage", () => {
     expect(
       screen.getByText("The connected server does not advertise personal integration management.")
     ).toBeInTheDocument()
+    // Diagnostics deliberately redact endpoint paths for display.
     expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
-      "/api/v1/integrations/personal"
+      "[server-endpoint]"
     )
     expect(mocks.listPersonalIntegrations).not.toHaveBeenCalled()
   })
@@ -395,10 +396,10 @@ describe("IntegrationManagementPage", () => {
     ).toBeInTheDocument()
 
     const diagnostics = screen.getByLabelText("Diagnostics")
-    expect(within(diagnostics).getByText("/api/v1/integrations/personal")).toBeInTheDocument()
+    expect(within(diagnostics).getByText("[server-endpoint]")).toBeInTheDocument()
     expect(within(diagnostics).getByText("403")).toBeInTheDocument()
     expect(
-      within(diagnostics).getByText("Request failed: 403 (GET /api/v1/integrations/personal)")
+      within(diagnostics).getByText("Request failed: 403 (GET [server-endpoint])")
     ).toBeInTheDocument()
   })
 
@@ -481,7 +482,7 @@ describe("IntegrationManagementPage", () => {
     expect(await screen.findByText("Degraded")).toBeInTheDocument()
     expect(screen.getByText("Workspace integrations are partially available")).toBeInTheDocument()
     expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
-      "/api/v1/integrations/workspace/telegram/linked-actors"
+      "[server-endpoint]"
     )
     expect(screen.getByLabelText("Diagnostics")).toHaveTextContent("503")
   })
@@ -536,7 +537,7 @@ describe("IntegrationManagementPage", () => {
 
     expect(await screen.findByText("Unable to load Slack policy")).toBeInTheDocument()
     const diagnostics = screen.getByLabelText("Diagnostics")
-    expect(within(diagnostics).getByText("/api/v1/integrations/workspace/slack/policy")).toBeInTheDocument()
+    expect(within(diagnostics).getByText("[server-endpoint]")).toBeInTheDocument()
     expect(within(diagnostics).getByText("404")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Save Slack policy" })).toBeDisabled()
   })

--- a/apps/packages/ui/src/components/Option/Setup/AudioInstallerPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Setup/AudioInstallerPanel.tsx
@@ -121,7 +121,9 @@ export const AudioInstallerPanel: React.FC = () => {
           />
         )}
 
-        <Descriptions size="small" column={2}>
+        {/* One column on phones: two squeezed columns wrapped values one
+            character per line at 390px (2026-09 UX audit finding S10). */}
+        <Descriptions size="small" column={{ xs: 1, sm: 2 }}>
           <Descriptions.Item
             label={t("settings:audioInstaller.machineProfile", "Machine profile")}
           >

--- a/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
+++ b/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
@@ -7,7 +7,14 @@ const OptionAdminWatchlistsItems = () => {
     <RouteErrorBoundary routeId="admin-watchlists-items" routeLabel="Watchlists Items">
       <OptionLayout>
         <div style={{ padding: "24px", maxWidth: "100%" }}>
-          <h2 style={{ marginBottom: 16 }}>Watchlists Items</h2>
+          <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>
+            Watchlists Items
+          </h1>
+          <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
+            Review collected updates, alert matches, and briefing candidates
+            across your watchlists. Create and configure watchlists on the
+            Watchlists page.
+          </p>
           <ItemsTab />
         </div>
       </OptionLayout>

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -738,6 +738,7 @@ export const ROUTE_METADATA = [
     group: "settings",
     surface: "admin_operator",
     smoke: "manual",
+    commandPalette: "show",
     requiresBackend: true,
     rationale: "Admin landing route for operator-only workflows."
   }),
@@ -747,6 +748,7 @@ export const ROUTE_METADATA = [
     group: "settings",
     surface: "admin_operator",
     availability: webAndExtension,
+    commandPalette: "show",
     requiresBackend: true,
     rationale: "Operator server status, user, role, and maintenance route."
   }),
@@ -756,8 +758,167 @@ export const ROUTE_METADATA = [
     group: "settings",
     surface: "admin_operator",
     smoke: "manual",
+    commandPalette: "show",
     requiresBackend: true,
     rationale: "Admin route for local MLX model status and operator controls."
+  }),
+  // Every admin module is registered here so the command palette and any
+  // metadata-driven navigation can find the full admin surface — the 2026-09
+  // UX audit (finding S1) flagged that most admin routes were URL-only.
+  defineRoute({
+    path: "/admin/llamacpp",
+    label: "Admin Llama.cpp",
+    group: "settings",
+    surface: "admin_operator",
+    availability: webAndExtension,
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for the managed llama.cpp inference server."
+  }),
+  defineRoute({
+    path: "/admin/runtime-config",
+    label: "Admin Runtime Config",
+    group: "settings",
+    surface: "admin_operator",
+    availability: webAndExtension,
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for runtime configuration inspection."
+  }),
+  defineRoute({
+    path: "/admin/monitoring",
+    label: "Monitoring",
+    group: "settings",
+    surface: "admin_operator",
+    availability: webAndExtension,
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for health metrics, alerts, and telemetry."
+  }),
+  defineRoute({
+    path: "/admin/integrations",
+    label: "Workspace Integrations",
+    group: "settings",
+    surface: "admin_operator",
+    availability: webAndExtension,
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for Slack/Discord/Telegram workspace policy."
+  }),
+  defineRoute({
+    path: "/admin/sources",
+    label: "Admin Sources",
+    group: "settings",
+    surface: "admin_operator",
+    availability: webAndExtension,
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for ingestion source availability and sync state."
+  }),
+  defineRoute({
+    path: "/admin/api-keys",
+    label: "Admin API Keys",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for creating, rotating, and revoking user API keys."
+  }),
+  defineRoute({
+    path: "/admin/rbac",
+    label: "Admin Roles & Permissions",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for the RBAC permission matrix and role grants."
+  }),
+  defineRoute({
+    path: "/admin/orgs",
+    label: "Admin Organizations",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for organizations and teams in multi-user mode."
+  }),
+  defineRoute({
+    path: "/admin/rate-limiting",
+    label: "Admin Rate Limiting",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for resource governor policy and rate limits."
+  }),
+  defineRoute({
+    path: "/admin/data-ops",
+    label: "Admin Data Operations",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for backups, retention, and data subject requests."
+  }),
+  defineRoute({
+    path: "/admin/usage",
+    label: "Admin Usage Analytics",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for request, storage, and LLM usage analytics."
+  }),
+  defineRoute({
+    path: "/admin/billing",
+    label: "Admin Billing",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for subscriptions and billing events."
+  }),
+  defineRoute({
+    path: "/admin/maintenance",
+    label: "Admin Maintenance",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for maintenance mode, feature flags, and incidents."
+  }),
+  defineRoute({
+    path: "/admin/watchlists-items",
+    label: "Admin Watchlist Items",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for reviewing collected watchlist updates."
+  }),
+  defineRoute({
+    path: "/admin/watchlists-runs",
+    label: "Admin Watchlist Runs",
+    group: "settings",
+    surface: "admin_operator",
+    smoke: "manual",
+    commandPalette: "show",
+    requiresBackend: true,
+    rationale: "Admin route for watchlist run history (planned surface)."
   }),
   defineRoute({
     path: "/mcp-hub",

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -1232,6 +1232,441 @@ export const ROUTE_METADATA = [
     surface: "internal_qa_debug",
     smoke: "exclude",
     rationale: "Web debug route for sidepanel error-boundary rendering."
+  }),
+  // ── Governance backfill (2026-09): every active smoke-inventory and
+  // shared-registry route is registered so metadata-coverage and heading
+  // governance hold. requiresH1 is explicitly false with an exception
+  // reason until each page passes a heading audit.
+  defineRoute({
+    path: "/settings/preferences",
+    label: "Preferences Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Startup and general preference settings route."
+  }),
+  defineRoute({
+    path: "/settings/tldw",
+    label: "TLDW Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "tldw server connection settings route."
+  }),
+  defineRoute({
+    path: "/settings/chat",
+    label: "Chat Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Chat behavior settings route."
+  }),
+  defineRoute({
+    path: "/settings/chat-macros",
+    label: "Chat Macros Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Chat macro management settings route."
+  }),
+  defineRoute({
+    path: "/settings/prompt",
+    label: "Workflow Prompts Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Service and workflow prompt settings route."
+  }),
+  defineRoute({
+    path: "/settings/knowledge",
+    label: "Knowledge Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Knowledge base settings route."
+  }),
+  defineRoute({
+    path: "/settings/rag",
+    label: "RAG Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Retrieval-augmented generation settings route."
+  }),
+  defineRoute({
+    path: "/settings/speech",
+    label: "Speech Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Speech-to-text and text-to-speech settings route."
+  }),
+  defineRoute({
+    path: "/settings/evaluations",
+    label: "Evaluations Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Evaluation configuration settings route."
+  }),
+  defineRoute({
+    path: "/settings/family-guardrails",
+    label: "Family Guardrails Wizard",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Family guardrails setup wizard route."
+  }),
+  defineRoute({
+    path: "/settings/guardian",
+    label: "Guardian Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Guardian oversight settings route."
+  }),
+  defineRoute({
+    path: "/settings/chatbooks",
+    label: "Chatbooks Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Chatbook export/import settings route."
+  }),
+  defineRoute({
+    path: "/settings/characters",
+    label: "Characters Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Character defaults settings route."
+  }),
+  defineRoute({
+    path: "/settings/world-books",
+    label: "World Books Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "World book settings route."
+  }),
+  defineRoute({
+    path: "/settings/chat-dictionaries",
+    label: "Dictionaries Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Chat dictionary settings route."
+  }),
+  defineRoute({
+    path: "/settings/processed",
+    label: "Processed Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Processed content review settings route."
+  }),
+  defineRoute({
+    path: "/settings/data",
+    label: "Data Management Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Data management and cleanup settings route."
+  }),
+  defineRoute({
+    path: "/settings/about",
+    label: "About",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "About and version information route."
+  }),
+  defineRoute({
+    path: "/settings/share",
+    label: "Share Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Content sharing settings route."
+  }),
+  defineRoute({
+    path: "/settings/quick-ingest",
+    label: "Quick Ingest Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Quick ingest defaults settings route."
+  }),
+  defineRoute({
+    path: "/settings/prompt-studio",
+    label: "Prompt Studio Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Prompt studio settings route."
+  }),
+  defineRoute({
+    path: "/settings/mcp-hub",
+    label: "MCP Hub Settings",
+    group: "settings",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "MCP hub settings alias inside the settings area."
+  }),
+  defineRoute({
+    path: "/settings/splash",
+    label: "Splash Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Splash screen settings route."
+  }),
+  defineRoute({
+    path: "/settings/ui",
+    label: "UI Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Interface appearance settings route."
+  }),
+  defineRoute({
+    path: "/settings/image-gen",
+    label: "Image Gen Settings",
+    group: "settings",
+    surface: "default_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Image generation settings alias; smoke-skipped pending Stage 5 gate."
+  }),
+  defineRoute({
+    path: "/media/123/view",
+    label: "Media View (Redirect)",
+    group: "media_library",
+    surface: "redirect",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Sample media detail redirect covered by the media route contract."
+  }),
+  defineRoute({
+    path: "/chat/agent",
+    label: "Agent Chat",
+    group: "chat",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Agent-driven chat surface route."
+  }),
+  defineRoute({
+    path: "/moderation",
+    label: "Moderation Review",
+    group: "safety",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Moderation review queue route."
+  }),
+  defineRoute({
+    path: "/moderation/rules",
+    label: "Content Rules",
+    group: "safety",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Moderation content rules route."
+  }),
+  defineRoute({
+    path: "/connectors/browse",
+    label: "Connector Catalog",
+    group: "operations",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Connector browsing route."
+  }),
+  defineRoute({
+    path: "/connectors/jobs",
+    label: "Connector Jobs",
+    group: "operations",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Connector job monitoring route."
+  }),
+  defineRoute({
+    path: "/connectors/sources",
+    label: "Connector Sources",
+    group: "operations",
+    surface: "advanced_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Connector source management route."
+  }),
+  defineRoute({
+    path: "/for/journalists",
+    label: "For Journalists",
+    group: "documentation",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Persona landing page for journalists."
+  }),
+  defineRoute({
+    path: "/for/osint",
+    label: "For OSINT",
+    group: "documentation",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Persona landing page for OSINT analysts."
+  }),
+  defineRoute({
+    path: "/for/researchers",
+    label: "For Researchers",
+    group: "documentation",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Persona landing page for researchers."
+  }),
+  defineRoute({
+    path: "/auth/magic-link",
+    label: "Magic Link",
+    group: "account",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Magic-link sign-in landing route."
+  }),
+  defineRoute({
+    path: "/auth/reset-password",
+    label: "Reset Password",
+    group: "account",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Password reset flow route."
+  }),
+  defineRoute({
+    path: "/auth/verify-email",
+    label: "Verify Email",
+    group: "account",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Email verification flow route."
+  }),
+  defineRoute({
+    path: "/billing/success",
+    label: "Billing Success",
+    group: "account",
+    surface: "hosted_only",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Billing checkout success landing route."
+  }),
+  defineRoute({
+    path: "/billing/cancel",
+    label: "Billing Cancel",
+    group: "account",
+    surface: "hosted_only",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Billing checkout cancellation landing route."
+  }),
+  defineRoute({
+    path: "/sources/new",
+    label: "New Source",
+    group: "operations",
+    surface: "default_self_hosted",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Source creation route."
+  }),
+  defineRoute({
+    path: "/sources/:sourceId",
+    label: "Source Detail",
+    group: "operations",
+    surface: "default_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Source detail route addressed by source id."
+  }),
+  defineRoute({
+    path: "/share/:token",
+    label: "Shared Content",
+    group: "media_library",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Public share link viewer route."
+  }),
+  defineRoute({
+    path: "/knowledge/shared/:shareToken",
+    label: "Shared Knowledge",
+    group: "knowledge",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Shared knowledge viewer route addressed by share token."
+  }),
+  defineRoute({
+    path: "/knowledge/thread/:threadId",
+    label: "Knowledge Thread",
+    group: "knowledge",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Knowledge thread route addressed by thread id."
+  }),
+  defineRoute({
+    path: "/prototype-workspaces",
+    label: "Prototype Workspaces",
+    group: "workspace",
+    surface: "labs_beta",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Prototype workspace experiments route."
+  }),
+  defineRoute({
+    path: "/scheduled-tasks/results",
+    label: "Scheduled Task Results",
+    group: "operations",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    requiresH1: false,
+    h1ExceptionReason: "Pre-governance page pending heading audit.",
+    rationale: "Scheduled task result inspection route."
   })
 ] as const satisfies readonly RouteMetadata[]
 

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -472,6 +472,7 @@ export const HEADER_SHORTCUT_IDS = [
   "presentation-studio",
   "acp-playground",
   "workflows",
+  "admin-overview",
   "admin-server",
   "admin-integrations",
   "documentation",

--- a/apps/tldw-frontend/e2e/smoke/page-inventory.ts
+++ b/apps/tldw-frontend/e2e/smoke/page-inventory.ts
@@ -80,21 +80,49 @@ const METADATA_CHILD_SMOKE_ROUTE_PATHS = new Set([
   "/admin/server"
 ])
 
-const METADATA_SMOKE_PAGES: PageEntry[] = ROUTE_METADATA.filter(
-  (metadata) =>
-    (isAuditedRootRoute(metadata.path) ||
-      METADATA_CHILD_SMOKE_ROUTE_PATHS.has(metadata.path)) &&
-    metadata.availability.includes("web") &&
-    metadata.smoke !== "exclude"
-).map((metadata) => ({
-  path: metadata.path,
-  name: metadata.label,
-  category: routeGroupToPageCategory(metadata.group),
-  ...(metadata.smoke === "manual"
-    ? { skip: `Manual smoke: ${metadata.rationale}` }
-    : {}),
-  ...METADATA_PAGE_OVERRIDES[metadata.path]
-}))
+// Pages that graduated from EXTRA_PAGES into route metadata stay in the smoke
+// inventory (keyed off the extra-page list below) so registering metadata for
+// a page never silently removes its smoke coverage.
+const GRADUATED_SURFACE_EXCLUSIONS = new Set([
+  "legacy_alias",
+  "redirect",
+  "deprecated"
+])
+
+const buildMetadataSmokePages = (
+  extraPageEntryByPath: Map<string, PageEntry>
+): PageEntry[] =>
+  ROUTE_METADATA.filter(
+    (metadata) =>
+      (isAuditedRootRoute(metadata.path) ||
+        METADATA_CHILD_SMOKE_ROUTE_PATHS.has(metadata.path) ||
+        (extraPageEntryByPath.has(metadata.path) &&
+          !GRADUATED_SURFACE_EXCLUSIONS.has(metadata.surface))) &&
+      metadata.availability.includes("web") &&
+      metadata.smoke !== "exclude"
+  ).map((metadata) => {
+    // Extra-page fields only carry over for graduated pages; audited root
+    // routes keep their original metadata-driven entries untouched.
+    const graduated =
+      !isAuditedRootRoute(metadata.path) &&
+      !METADATA_CHILD_SMOKE_ROUTE_PATHS.has(metadata.path)
+    const extraEntry = graduated
+      ? extraPageEntryByPath.get(metadata.path)
+      : undefined
+    return {
+      path: metadata.path,
+      name: metadata.label,
+      category: routeGroupToPageCategory(metadata.group),
+      ...(extraEntry?.expectedTestId
+        ? { expectedTestId: extraEntry.expectedTestId }
+        : {}),
+      ...(metadata.smoke === "manual"
+        ? { skip: `Manual smoke: ${metadata.rationale}` }
+        : {}),
+      ...(extraEntry?.skip ? { skip: extraEntry.skip } : {}),
+      ...METADATA_PAGE_OVERRIDES[metadata.path]
+    }
+  })
 
 /**
  * Extra pages in the tldw-frontend application that are outside the audited
@@ -373,8 +401,12 @@ const EXTRA_PAGES: PageEntry[] = [
  * Audited root routes are owned by route metadata; child and special-case
  * smoke pages remain explicit here until they get first-class metadata.
  */
+const EXTRA_PAGE_ENTRY_BY_PATH = new Map(
+  EXTRA_PAGES.map((page) => [page.path, page])
+)
+
 export const PAGES: PageEntry[] = [
-  ...METADATA_SMOKE_PAGES,
+  ...buildMetadataSmokePages(EXTRA_PAGE_ENTRY_BY_PATH),
   ...EXTRA_PAGES.filter((page) => !METADATA_ROUTE_PATHS.has(page.path))
 ]
 

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2068,
   "schema_count": 3133,
-  "sha256": "f897d58d7eb8f09783c5bc41914e12812a0c74a2d52b67de7a7a31731130edc9"
+  "sha256": "dfe0660dd696bfe73fff606021fe20cca3599da5724a391d714bc7898e649a20"
 }

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -9,6 +9,8 @@ import { useRouter } from "next/router"
 import React from "react"
 import { BackendRecoveryUiProvider } from "@/components/Common/BackendRecoveryUiContext"
 import { PageAssistLoader } from "@/components/Common/PageAssistLoader"
+import { AdminRouteShell } from "@/components/Option/Admin/AdminRouteShell"
+import { isAdminRoute } from "@/components/Option/Admin/admin-modules"
 import { FirstRunGate } from "@/components/PersonaGarden/FirstRunGate"
 import { AppProviders } from "@web/components/AppProviders"
 import ErrorBoundary from "@web/components/ErrorBoundary"
@@ -389,10 +391,14 @@ export default function App({ Component, pageProps }: AppProps) {
     () => buildFirstRunSetupRoute(router.asPath || routePath || "/"),
     [routePath, router.asPath]
   )
+  const isAdminRoutePath = isAdminRoute(routePath)
   const shouldBypassFirstRunOverlay =
     !shouldBypassGates &&
     (routePath === "/" ||
       routePath === "/research-workspace" ||
+      // Admin routes are operator surfaces: never hijack them with the
+      // assistant-onboarding interstitial (2026-09 UX audit finding S8).
+      isAdminRoutePath ||
       firstRunEntryIntent === CHARACTER_CHAT_ONBOARDING_INTENT)
 
   const handleStartSetup = React.useCallback(() => {
@@ -417,7 +423,13 @@ export default function App({ Component, pageProps }: AppProps) {
 
   const layoutContent = (
     <OptionLayout {...layoutProps}>
-      <Component {...pageProps} />
+      {isAdminRoutePath ? (
+        <AdminRouteShell path={routePath}>
+          <Component {...pageProps} />
+        </AdminRouteShell>
+      ) : (
+        <Component {...pageProps} />
+      )}
     </OptionLayout>
   )
 

--- a/apps/tldw-frontend/pages/admin/runtime-config.tsx
+++ b/apps/tldw-frontend/pages/admin/runtime-config.tsx
@@ -1,0 +1,5 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-admin-runtime-config"), {
+  ssr: false
+})

--- a/apps/tldw-frontend/scripts/admin-uat-driver.mjs
+++ b/apps/tldw-frontend/scripts/admin-uat-driver.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/*
+ * Admin WebUI UAT driver — live browser walkthrough of all /admin routes.
+ * Pass A: first-time user, no seeded auth (real first-run experience).
+ * Pass B: configured power user (seeded single-user auth), sweep all admin pages.
+ * Emits screenshots + observations JSON for heuristic evaluation.
+ */
+import { chromium } from "@playwright/test"
+import fs from "node:fs/promises"
+
+const WEB = process.env.WEB_URL || "http://localhost:8080"
+const SERVER = process.env.SERVER_URL || "http://127.0.0.1:8000"
+const API_KEY = process.env.TLDW_API_KEY || ""
+const OUT = process.env.OUT_DIR || "/tmp/admin-uat"
+
+const ADMIN_ROUTES = [
+  "/admin", "/admin/server", "/admin/api-keys", "/admin/billing",
+  "/admin/data-ops", "/admin/integrations", "/admin/llamacpp",
+  "/admin/maintenance", "/admin/mlx", "/admin/monitoring", "/admin/orgs",
+  "/admin/rate-limiting", "/admin/rbac", "/admin/sources", "/admin/usage",
+  "/admin/watchlists-items", "/admin/watchlists-runs"
+]
+
+const MOBILE_ROUTES = new Set(["/admin", "/admin/server", "/admin/monitoring"])
+
+const report = { passA: [], passB: [], meta: { web: WEB, server: SERVER, when: new Date().toISOString() } }
+
+function attachCollectors(page, bucket) {
+  bucket.consoleErrors = []
+  bucket.pageErrors = []
+  bucket.failedRequests = []
+  bucket.apiCalls = []
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") {
+      const t = m.text()
+      if (bucket.consoleErrors.length < 40) bucket.consoleErrors.push(`${m.type()}: ${t.slice(0, 300)}`)
+    }
+  })
+  page.on("pageerror", (e) => bucket.pageErrors.push(String(e.message).slice(0, 300)))
+  page.on("response", async (r) => {
+    const url = r.url()
+    if (url.includes("/api/")) {
+      const rec = { url: url.replace(SERVER, "").replace(WEB, ""), status: r.status() }
+      if (bucket.apiCalls.length < 200) bucket.apiCalls.push(rec)
+      if (r.status() >= 400 && bucket.failedRequests.length < 60) bucket.failedRequests.push(rec)
+    }
+  })
+  page.on("requestfailed", (req) => {
+    if (bucket.failedRequests.length < 60)
+      bucket.failedRequests.push({ url: req.url().replace(SERVER, "").replace(WEB, "").slice(0, 200), status: "net:" + (req.failure()?.errorText || "?") })
+  })
+}
+
+async function probePage(page) {
+  return await page.evaluate(() => {
+    const txt = (el) => (el?.innerText || "").trim()
+    const h1s = [...document.querySelectorAll("h1")].map(txt).filter(Boolean)
+    const h2s = [...document.querySelectorAll("h2")].map(txt).filter(Boolean).slice(0, 20)
+    const buttons = [...document.querySelectorAll("button")]
+    const unnamedButtons = buttons.filter((b) => {
+      const name = (b.getAttribute("aria-label") || b.title || b.innerText || "").trim()
+      return !name
+    }).length
+    const landmarks = ["main", "nav", "header", "aside"].map((t) => `${t}:${document.querySelectorAll(t).length}`).join(" ")
+    const tables = document.querySelectorAll("table").length
+    const forms = document.querySelectorAll("form").length
+    const inputs = document.querySelectorAll("input,select,textarea").length
+    const bodyText = (document.body.innerText || "").replace(/\n{3,}/g, "\n\n").slice(0, 3000)
+    return {
+      title: document.title, h1s, h2s, buttons: buttons.length, unnamedButtons,
+      landmarks, tables, forms, inputs, bodyText
+    }
+  })
+}
+
+async function visit(page, route, bucket, shotName) {
+  const url = WEB + route
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout
+: 30000 })
+  } catch (e) {
+    bucket.gotoError = e.message.slice(0, 200)
+  }
+  try { await page.waitForLoadState("networkidle", { timeout: 12000 }) } catch {}
+  await page.waitForTimeout(1500)
+  bucket.finalUrl = page.url()
+  try {
+    bucket.probe = await probePage(page)
+  } catch (e) { bucket.probeError = e.message.slice(0, 200) }
+  try {
+    await page.screenshot({ path: `${OUT}/${shotName}.png`, fullPage: false })
+    await page.screenshot({ path: `${OUT}/${shotName}-full.png`, fullPage: true })
+  } catch (e) { bucket.shotError = e.message.slice(0, 200) }
+  console.log(`[done] ${route} -> ${bucket.finalUrl} (h1: ${bucket.probe?.h1s?.[0] || "-"})`)
+}
+
+function seedScript({ serverUrl, apiKey }) {
+  return ({ serverUrl, apiKey }) => {
+    const cfg = { serverUrl, authMode: "single-user", apiKey }
+    try { localStorage.setItem("tldwConfig", JSON.stringify(cfg)) } catch {}
+    try { localStorage.setItem("isMigrated", "true") } catch {}
+    try { localStorage.setItem("__tldw_first_run_complete", "true") } catch {}
+    try { localStorage.setItem("assistant_setup_dismissed", "true") } catch {}
+    try {
+      localStorage.setItem("serverUrl", serverUrl)
+      localStorage.setItem("tldwServerUrl", serverUrl)
+      localStorage.setItem("tldw-api-host", serverUrl)
+      localStorage.setItem("authMode", "single-user")
+      localStorage.setItem("apiKey", apiKey)
+    } catch {}
+  }
+}
+
+async function main() {
+  await fs.mkdir(OUT, { recursive: true })
+  const browser = await chromium.launch()
+
+  // ---------- Pass A: first-time user, nothing configured ----------
+  {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+    const page = await ctx.newPage()
+    for (const route of ["/", "/admin", "/admin/server"]) {
+      const bucket = { route }
+      attachCollectors(page, bucket)
+      await visit(page, route, bucket, "A" + (route === "/" ? "-root" : route.replaceAll("/", "-")))
+      report.passA.push(bucket)
+      page.removeAllListeners("console"); page.removeAllListeners("pageerror")
+      page.removeAllListeners("response"); page.removeAllListeners("requestfailed")
+    }
+    await ctx.close()
+  }
+
+  // ---------- Pass B: configured power user ----------
+  {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+    await ctx.addInitScript(seedScript({}), { serverUrl: SERVER, apiKey: API_KEY })
+    const page = await ctx.newPage()
+
+    // Discoverability probe: from home, how many links point at /admin?
+    {
+      const bucket = { route: "home-discoverability" }
+      attachCollectors(page, bucket)
+      await visit(page, "/", bucket, "B-home")
+      try {
+        bucket.adminLinks = await page.evaluate(() =>
+          [...document.querySelectorAll("a[href*='/admin']")].map((a) => ({
+            href: a.getAttribute("href"), text: (a.innerText || a.getAttribute("aria-label") || "").trim().slice(0, 60)
+          })).slice(0, 30)
+        )
+      } catch {}
+      report.passB.push(bucket)
+      page.removeAllListeners("console"); page.removeAllListeners("pageerror")
+      page.removeAllListeners("response"); page.removeAllListeners("requestfailed")
+    }
+
+    for (const route of ADMIN_ROUTES) {
+      const bucket = { route }
+      attachCollectors(page, bucket)
+      await visit(page, route, bucket, "B" + route.replaceAll("/", "-"))
+      report.passB.push(bucket)
+      page.removeAllListeners("console"); page.removeAllListeners("pageerror")
+      page.removeAllListeners("response"); page.removeAllListeners("requestfailed")
+    }
+    await ctx.close()
+  }
+
+  // ---------- Pass C: mobile viewport spot-check ----------
+  {
+    const ctx = await browser.newContext({ viewport: { width: 390, height: 844 } })
+    await ctx.addInitScript(seedScript({}), { serverUrl: SERVER, apiKey: API_KEY })
+    const page = await ctx.newPage()
+    for (const route of MOBILE_ROUTES) {
+      const bucket = { route: "mobile:" + route }
+      attachCollectors(page, bucket)
+      await visit(page, route, bucket, "M" + route.replaceAll("/", "-"))
+      report.passB.push(bucket)
+      page.removeAllListeners("console"); page.removeAllListeners("pageerror")
+      page.removeAllListeners("response"); page.removeAllListeners("requestfailed")
+    }
+    await ctx.close()
+  }
+
+  await browser.close()
+  await fs.writeFile(`${OUT}/report.json`, JSON.stringify(report, null, 2))
+  console.log(`report written to ${OUT}/report.json`)
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/apps/tldw-frontend/scripts/admin-uat-interactions.mjs
+++ b/apps/tldw-frontend/scripts/admin-uat-interactions.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/* Admin UAT pass D — targeted interaction probes. */
+import { chromium } from "@playwright/test"
+import fs from "node:fs/promises"
+
+const WEB = process.env.WEB_URL || "http://localhost:8080"
+const SERVER = process.env.SERVER_URL || "http://127.0.0.1:8000"
+const API_KEY = process.env.TLDW_API_KEY || ""
+const OUT = process.env.OUT_DIR || "/tmp/admin-uat"
+
+const out = { steps: [] }
+const note = (s, detail) => { out.steps.push({ s, detail }); console.log(`[step] ${s} :: ${detail || ""}`) }
+
+const seed = ({ serverUrl, apiKey }) => {
+  const cfg = { serverUrl, authMode: "single-user", apiKey }
+  try { localStorage.setItem("tldwConfig", JSON.stringify(cfg)) } catch {}
+  try { localStorage.setItem("isMigrated", "true") } catch {}
+  try { localStorage.setItem("__tldw_first_run_complete", "true") } catch {}
+  try { localStorage.setItem("assistant_setup_dismissed", "true") } catch {}
+  try {
+    localStorage.setItem("serverUrl", serverUrl)
+    localStorage.setItem("tldwServerUrl", serverUrl)
+    localStorage.setItem("tldw-api-host", serverUrl)
+    localStorage.setItem("authMode", "single-user")
+    localStorage.setItem("apiKey", apiKey)
+  } catch {}
+}
+
+async function shot(page, name) {
+  try { await page.screenshot({ path: `${OUT}/${name}.png` }) } catch {}
+}
+
+async function main() {
+  await fs.mkdir(OUT, { recursive: true })
+  const browser = await chromium.launch()
+
+  // D1: first-time user clicks "Skip for now" on /admin interstitial
+  {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+    const page = await ctx.newPage()
+    await page.goto(WEB + "/admin", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(2500)
+    const skip = page.getByText("Skip for now").first()
+    if (await skip.count()) {
+      await skip.click()
+      await page.waitForTimeout(2500)
+      await shot(page, "D1-admin-after-skip")
+      note("D1 skip-for-now", `url=${page.url()} :: body starts: ${(await page.evaluate(() => document.body.innerText.slice(0, 400))).replace(/\n/g, " | ")}`)
+    } else {
+      note("D1 skip-for-now", "no interstitial found")
+      await shot(page, "D1-admin-no-interstitial")
+    }
+    await ctx.close()
+  }
+
+  // Authed context for the rest
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+  await ctx.addInitScript(seed, { serverUrl: SERVER, apiKey: API_KEY })
+  const page = await ctx.newPage()
+
+  // D2: server admin — Create role with empty name (validation?) then real create (feedback?)
+  {
+    await page.goto(WEB + "/admin/server", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(3500)
+    const createBtn = page.getByRole("button", { name: /create role/i }).first()
+    if (await createBtn.count()) {
+      await createBtn.scrollIntoViewIfNeeded()
+      await createBtn.click()
+      await page.waitForTimeout(1200)
+      await shot(page, "D2a-create-role-empty")
+      note("D2a create-role empty submit", (await page.evaluate(() => document.body.innerText)).match(/required|enter|name|invalid|error/i)?.[0] || "no visible validation keyword")
+      const nameInput = page.getByPlaceholder(/role name/i).first()
+      if (await nameInput.count()) {
+        await nameInput.fill("uat-analyst")
+        await createBtn.click()
+        await page.waitForTimeout(2000)
+        await shot(page, "D2b-create-role-filled")
+        const body = await page.evaluate(() => document.body.innerText)
+        note("D2b create-role uat-analyst", body.includes("uat-analyst") ? "role appears in list" : "role NOT visible after create")
+      }
+    } else note("D2 create-role", "button not found")
+  }
+
+  // D3: api-keys — open user select, type, see whether any options / error appear
+  {
+    await page.goto(WEB + "/admin/api-keys", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(2500)
+    const sel = page.locator(".ant-select-selector").first()
+    if (await sel.count()) {
+      await sel.click()
+      await page.keyboard.type("admin")
+      await page.waitForTimeout(2500)
+      await shot(page, "D3-api-keys-user-search")
+      const dropdown = await page.evaluate(() => document.querySelector(".ant-select-dropdown")?.innerText?.slice(0, 200) || "NO DROPDOWN")
+      note("D3 api-keys user search", dropdown.replace(/\n/g, " | "))
+    } else note("D3 api-keys", "no select found")
+  }
+
+  // D4: data-ops — Create Backup with no dataset selected (validation?)
+  {
+    await page.goto(WEB + "/admin/data-ops", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(2500)
+    const btn = page.getByRole("button", { name: /create backup/i }).first()
+    if (await btn.count()) {
+      await btn.click()
+      await page.waitForTimeout(1500)
+      await shot(page, "D4-create-backup-novalue")
+      const toasts = await page.evaluate(() => [...document.querySelectorAll(".ant-message, .ant-notification, [role='alert']")].map(n => n.innerText).join(" || ").slice(0, 300))
+      note("D4 create-backup no dataset", toasts || "no toast/alert seen")
+    } else note("D4 data-ops", "create backup button not found")
+  }
+
+  // D5: maintenance — Create Incident empty (validation?)
+  {
+    await page.goto(WEB + "/admin/maintenance", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(2500)
+    const btn = page.getByRole("button", { name: /create incident/i }).first()
+    if (await btn.count()) {
+      await btn.click()
+      await page.waitForTimeout(1500)
+      await shot(page, "D5-create-incident-empty")
+      const toasts = await page.evaluate(() => [...document.querySelectorAll(".ant-message, .ant-notification, [role='alert']")].map(n => n.innerText).join(" || ").slice(0, 300))
+      note("D5 create-incident empty", toasts || "no toast/alert seen")
+    } else note("D5 maintenance", "create incident button not found")
+  }
+
+  // D6: keyboard focus probe on /admin/server
+  {
+    await page.goto(WEB + "/admin/server", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(3000)
+    const seq = []
+    for (let i = 0; i < 18; i++) {
+      await page.keyboard.press("Tab")
+      const info = await page.evaluate(() => {
+        const el = document.activeElement
+        if (!el) return "none"
+        const cs = getComputedStyle(el)
+        const outline = cs.outlineStyle !== "none" && parseFloat(cs.outlineWidth) > 0
+        const ring = (cs.boxShadow || "").includes("px") && cs.boxShadow !== "none"
+        const label = (el.getAttribute("aria-label") || el.textContent || el.tagName).trim().slice(0, 28)
+        return `${el.tagName.toLowerCase()}:${label}:${outline || ring ? "RING" : "no-ring"}`
+      })
+      seq.push(info)
+    }
+    note("D6 tab sequence /admin/server", seq.join(" -> "))
+    await shot(page, "D6-focus-state")
+  }
+
+  // D7: monitoring — check tabs/sections + alert rule form discoverability
+  {
+    await page.goto(WEB + "/admin/monitoring", { waitUntil: "domcontentloaded" })
+    await page.waitForTimeout(3000)
+    const btns = await page.evaluate(() => [...document.querySelectorAll("button")].map(b => b.innerText.trim()).filter(Boolean).slice(0, 40))
+    note("D7 monitoring buttons", btns.join(" | "))
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForTimeout(800)
+    await shot(page, "D7-monitoring-bottom")
+  }
+
+  await ctx.close()
+  await browser.close()
+  await fs.writeFile(`${OUT}/interactions.json`, JSON.stringify(out, null, 2))
+  console.log("interactions written")
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
@@ -174,7 +174,7 @@ async def list_users(
             logger.debug("TEST_MODE header assignment failed")
         raise
     except Exception as e:
-        logger.error("Failed to list users")
+        logger.exception("Failed to list users")
         try:
             if is_test_mode():
                 response.headers["X-TLDW-Admin-Error"] = str(e)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
@@ -174,7 +174,12 @@ async def list_users(
             logger.debug("TEST_MODE header assignment failed")
         raise
     except Exception as e:
-        logger.exception("Failed to list users")
+        logger.exception(
+            "Failed to list users (principal={}, page={}, limit={})",
+            getattr(principal, "user_id", None),
+            page,
+            limit,
+        )
         try:
             if is_test_mode():
                 response.headers["X-TLDW-Admin-Error"] = str(e)

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -165,7 +165,9 @@ class AdminUserCreateRequest(BaseModel):
 class UserSummary(BaseModel):
     """Summary information about a user"""
     id: int
-    uuid: UUID
+    # Optional: legacy SQLite installs bootstrapped the single-user row without a
+    # uuid; one NULL row must not 500 the whole admin users list.
+    uuid: UUID | None = None
     username: str
     email: str
     role: str

--- a/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import uuid as uuid_module
 from dataclasses import dataclass
 from typing import Any
 
@@ -407,10 +408,15 @@ class AuthnzUsersRepo:
                         parameters=(int(user_id),),
                     )
                 else:
+                    # SQLite has no column default for users.uuid (unlike Postgres),
+                    # so the bootstrap row must supply one; UserSummary responses
+                    # expect it. Existing rows with NULL uuid are backfilled below.
+                    fallback_uuid = str(uuid_module.uuid4())
                     await gateway.insert_user(
                         conn,
                         values={
                             "id": int(user_id),
+                            "uuid": fallback_uuid,
                             "username": str(username),
                             "email": str(email),
                             "password_hash": str(password_hash),
@@ -423,12 +429,12 @@ class AuthnzUsersRepo:
                     await gateway.execute_update(
                         conn,
                         user_id=int(user_id),
-                        profile_visible_fields=("role", "is_active", "is_verified"),
+                        profile_visible_fields=("role", "is_active", "is_verified", "uuid"),
                         statement=(
                             "UPDATE users SET role = 'admin', is_active = 1, "
-                            "is_verified = 1 WHERE id = ?"
+                            "is_verified = 1, uuid = COALESCE(uuid, ?) WHERE id = ?"
                         ),
-                        parameters=(int(user_id),),
+                        parameters=(fallback_uuid, int(user_id)),
                     )
         except Exception as exc:  # pragma: no cover - surfaced via callers
             logger.error(f"AuthnzUsersRepo.ensure_single_user_admin_user failed: {exc}")

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -219,7 +219,11 @@ async def create_user(
     except HTTPException:
         raise
     except Exception as exc:
-        logger.exception("Failed to create user")
+        logger.exception(
+            "Failed to create user (principal={}, username={})",
+            created_by,
+            payload.username,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create user",
@@ -256,7 +260,14 @@ async def list_users(
         )
         return users, total
     except Exception as e:
-        logger.exception("Failed to list users")
+        logger.exception(
+            "Failed to list users (principal={}, page={}, limit={}, role={}, org_id={})",
+            getattr(principal, "user_id", None),
+            page,
+            limit,
+            role,
+            org_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve users",

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -219,7 +219,7 @@ async def create_user(
     except HTTPException:
         raise
     except Exception as exc:
-        logger.error("Failed to create user")
+        logger.exception("Failed to create user")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create user",
@@ -256,7 +256,7 @@ async def list_users(
         )
         return users, total
     except Exception as e:
-        logger.error("Failed to list users")
+        logger.exception("Failed to list users")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve users",

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_users_single_user_uuid_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_users_single_user_uuid_sqlite.py
@@ -1,0 +1,84 @@
+"""Regression tests for the single-user bootstrap uuid fix.
+
+A fresh single-user SQLite install used to bootstrap the admin row without a
+uuid, which made GET /api/v1/admin/users 500 (UserSummary required a UUID).
+"""
+
+import pytest
+
+
+async def _fresh_pool(tmp_path, monkeypatch, name: str):
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / name
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    return await get_db_pool(), db_path
+
+
+@pytest.mark.asyncio
+async def test_ensure_single_user_admin_user_assigns_uuid_sqlite(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+    pool, _ = await _fresh_pool(tmp_path, monkeypatch, "single_user_uuid.db")
+    repo = AuthnzUsersRepo(db_pool=pool)
+
+    await repo.ensure_single_user_admin_user(user_id=1)
+
+    row = await repo.get_user_by_id(1)
+    assert row is not None
+    assert row.get("uuid"), "bootstrapped single-user row must carry a uuid"
+
+
+@pytest.mark.asyncio
+async def test_ensure_single_user_admin_user_preserves_uuid_sqlite(
+    tmp_path, monkeypatch
+):
+    """Repeated ensure calls (it runs at startup) must not rotate the uuid.
+
+    The COALESCE backfill only fills NULL; an already-assigned uuid stays
+    stable across restarts. (The NULL-backfill path itself only exists on
+    legacy schemas where users.uuid is nullable; it was verified against a
+    real legacy database and cannot be reproduced on the current NOT NULL
+    schema.)
+    """
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+    pool, _ = await _fresh_pool(tmp_path, monkeypatch, "single_user_stable.db")
+    repo = AuthnzUsersRepo(db_pool=pool)
+
+    await repo.ensure_single_user_admin_user(user_id=1)
+    first = await repo.get_user_by_id(1)
+    assert first is not None and first.get("uuid")
+
+    await repo.ensure_single_user_admin_user(user_id=1)
+    second = await repo.get_user_by_id(1)
+    assert second is not None
+    assert second["uuid"] == first["uuid"]
+
+    users, total = await repo.list_users(offset=0, limit=20)
+    assert total == 1
+    assert users[0]["uuid"] == first["uuid"]
+
+
+def test_user_summary_tolerates_null_uuid():
+    """One legacy NULL-uuid row must not 500 the admin users list."""
+    from tldw_Server_API.app.api.v1.schemas.admin_schemas import UserSummary
+
+    summary = UserSummary(
+        id=1,
+        uuid=None,
+        username="single_user",
+        email="single_user@example.local",
+        role="admin",
+        is_active=True,
+        is_verified=True,
+        created_at="2026-09-05T01:44:56",
+        storage_quota_mb=5120,
+        storage_used_mb=0.0,
+    )
+    assert summary.uuid is None

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_users_single_user_uuid_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_users_single_user_uuid_sqlite.py
@@ -4,28 +4,60 @@ A fresh single-user SQLite install used to bootstrap the admin row without a
 uuid, which made GET /api/v1/admin/users 500 (UserSummary required a UUID).
 """
 
+import pathlib
+from typing import AsyncIterator
+
 import pytest
+import pytest_asyncio
+
+from tldw_Server_API.app.core.AuthNZ.database import (
+    DatabasePool,
+    get_db_pool,
+    reset_db_pool,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+pytestmark = pytest.mark.unit
 
 
-async def _fresh_pool(tmp_path, monkeypatch, name: str):
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
-    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+@pytest_asyncio.fixture
+async def sqlite_pool(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[DatabasePool]:
+    """Yield a fresh SQLite AuthNZ pool and reset shared state afterwards.
 
-    db_path = tmp_path / name
+    Args:
+        tmp_path: Per-test directory for the throwaway SQLite database file.
+        monkeypatch: Used to point AUTH_MODE/DATABASE_URL at that file.
+
+    Yields:
+        The initialized :class:`DatabasePool` for the temporary database.
+    """
+    db_path = tmp_path / "single_user_uuid.db"
     monkeypatch.setenv("AUTH_MODE", "multi_user")
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
 
     reset_settings()
     await reset_db_pool()
-    return await get_db_pool(), db_path
+    pool = await get_db_pool()
+    try:
+        yield pool
+    finally:
+        await reset_db_pool()
+        reset_settings()
 
 
 @pytest.mark.asyncio
-async def test_ensure_single_user_admin_user_assigns_uuid_sqlite(tmp_path, monkeypatch):
-    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+async def test_ensure_single_user_admin_user_assigns_uuid_sqlite(
+    sqlite_pool: DatabasePool,
+) -> None:
+    """The bootstrapped single-user admin row must carry a uuid.
 
-    pool, _ = await _fresh_pool(tmp_path, monkeypatch, "single_user_uuid.db")
-    repo = AuthnzUsersRepo(db_pool=pool)
+    Regression: rows created without one made UserSummary validation fail and
+    the admin users list return HTTP 500.
+    """
+    repo = AuthnzUsersRepo(db_pool=sqlite_pool)
 
     await repo.ensure_single_user_admin_user(user_id=1)
 
@@ -36,8 +68,8 @@ async def test_ensure_single_user_admin_user_assigns_uuid_sqlite(tmp_path, monke
 
 @pytest.mark.asyncio
 async def test_ensure_single_user_admin_user_preserves_uuid_sqlite(
-    tmp_path, monkeypatch
-):
+    sqlite_pool: DatabasePool,
+) -> None:
     """Repeated ensure calls (it runs at startup) must not rotate the uuid.
 
     The COALESCE backfill only fills NULL; an already-assigned uuid stays
@@ -46,10 +78,7 @@ async def test_ensure_single_user_admin_user_preserves_uuid_sqlite(
     real legacy database and cannot be reproduced on the current NOT NULL
     schema.)
     """
-    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
-
-    pool, _ = await _fresh_pool(tmp_path, monkeypatch, "single_user_stable.db")
-    repo = AuthnzUsersRepo(db_pool=pool)
+    repo = AuthnzUsersRepo(db_pool=sqlite_pool)
 
     await repo.ensure_single_user_admin_user(user_id=1)
     first = await repo.get_user_by_id(1)
@@ -65,7 +94,7 @@ async def test_ensure_single_user_admin_user_preserves_uuid_sqlite(
     assert users[0]["uuid"] == first["uuid"]
 
 
-def test_user_summary_tolerates_null_uuid():
+def test_user_summary_tolerates_null_uuid() -> None:
     """One legacy NULL-uuid row must not 500 the admin users list."""
     from tldw_Server_API.app.api.v1.schemas.admin_schemas import UserSummary
 


### PR DESCRIPTION
Implements the prioritized fixes from the 2026-09-04 admin WebUI heuristic audit (NNG 10-heuristics evaluation of all 17 `/admin` routes on a live single-user dev server, first-time + power-user walkthroughs). Six commits, sequenced by the audit's P0→P3 plan; every stage verified by re-running the audit's browser sweep against the fixed build.

## P0 — the default install works
- **Backend: `GET /api/v1/admin/users` no longer 500s on fresh single-user SQLite installs.** Root cause: the bootstrap wrote `users.uuid = NULL` (SQLite has no column default, unlike Postgres) and `UserSummary.uuid` was required. `ensure_single_user_admin_user` now assigns a uuid on insert and backfills NULL via COALESCE on the startup/init update; the schema tolerates legacy NULL rows; swallowed exceptions log tracebacks. This single 500 broke Server Admin's Users & roles and the entire API Keys page.
- **API Keys** auto-selects the only user (single-user servers skip the picker), surfaces user-list failures with Retry instead of a silent dead end, and explains itself.
- **503 ≠ missing admin APIs.** 502/503/504 are no longer misdiagnosed as "Admin APIs are not available on this server" (with the wrong remedy); Llama.cpp and MLX name the runtime outage and keep the page usable.
- **Billing** can no longer hang in a permanent skeleton (4s capability-probe failsafe) and states plainly when it doesn't apply.

## P1 — admin has an information architecture
- `admin-modules.ts`: single source of truth for all 17 admin modules (route/label/purpose/group).
- `AdminRouteShell` wraps every `/admin/*` page in the web app: skip link, `Admin modules` nav landmark with `aria-current`, per-module document titles.
- Admin Operations overview rebuilt from the registry: every module, grouped, operator language — no more "Route ready" chips or `frontend_state` diagnostics. All admin routes registered in route metadata with command-palette visibility; header menu gains the Admin Operations link; `/admin/runtime-config` gets its missing web page.
- The assistant-onboarding interstitial no longer hijacks `/admin` routes; every admin page has a semantic h1.

## P2 — states tell the truth
- Server Admin: failed users fetch → one error state with Retry; the empty panel never blames filters for a 500 and only mentions filters when filters are set.
- Integrations: one page-level status banner at a time (no more "Unavailable" + "Degraded" simultaneously above empty provider cards); 4xx responses are no longer retried (was 12 404s per page load).
- Rate Limiting: reads the diag payload's real field names — fixes "78.9% coverage" above "Protected: 0 routes | Unprotected: 0 routes"; route cells handle `{method, path}` rows instead of crashing; "Per-user rate limit overrides" naming + copy resolves the "43 policies vs no rate limits configured" contradiction.
- RBAC: matrix load failures show an error with Retry; an empty permission catalog is explained instead of a bare "No data" grid.

## P3 — polish
Monitoring stat keys humanized (`total_used_mb` → "Total Used MB", `mcp_invocations_today` → "MCP Invocations Today"); no more unwinnable "Retry diagnostics" for a 404'd endpoint; usage costs format as $0.00 (4 decimals only sub-cent); mobile one-character-per-line wrap fixed in the audio installer; Watchlists Items gets an h1 + context copy. UAT driver scripts committed for future regression sweeps.

## Verification
- 218 AuthNZ_SQLite backend tests pass (3 new); all 121 admin component tests pass (12 new/updated); app-layout, header, and route-metadata suites green. Remaining failures are pre-existing on clean dev (verified via stashed baseline runs).
- Before/after browser sweep of all routes: users list 500 → 200 with data; document titles 0 → 20 pages; semantic h1s 6 → 18; admin nav landmark 0 → all pages; integrations 404s 12 → 8 (no retries; rest is dev StrictMode double-mount); first-time visitor to `/admin` sees Admin Operations instead of the "Build Your Assistant" interstitial.

## Follow-ups filed
Out-of-scope remainders are tracked in #2870 (Server Admin stats endpoint mismatch), #2871 (first-run wizard persistence + readiness detail), #2872 (extension admin parity), #2873 (admin i18n extraction), #2874 (useForm console warning), #2875 (SQLite users DDL drift), #2876 (live overview status grid), #2877 (watchlists item context), #2878 (Server Admin section ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GJqCP5hN77xWHtwJog5M9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the admin WebUI issues from the 2026-09-04 heuristic audit: single-user installs no longer 500 on the users list, the 17 admin routes share one registry and navigation, and failure/empty states stop blaming filters or missing APIs.

**Bug Fixes**
- `GET /api/v1/admin/users` no longer 500s on fresh single-user SQLite installs; the bootstrap assigns a uuid and legacy NULL rows are backfilled.
- 502/503/504 responses are no longer mislabeled as missing admin APIs; Llama.cpp and MLX name the runtime outage and keep the page usable.
- Rate limiting reads the diag payload's real field names, fixing "78.9% coverage" above "Protected: 0 routes".
- Integration queries stop retrying 4xx responses, eliminating the 12 404s per page load; transient failures keep independently-loaded panels and get one quick retry.
- Integration policy forms stay connected while loading instead of unmounting the form and logging an antd warning (closes #2874).
- Server Admin and RBAC failed fetches show one error state with Retry instead of a silent dead end or a filters-blaming empty panel.
- Usage costs format as $0.00, monitoring stat keys are humanized, and redacted endpoint paths no longer leak `[admin-endpoint]` placeholder noise.
- Sandbox diagnostics stop offering "Retry diagnostics" for a 404 endpoint that can never succeed.

**New Features**
- `admin-modules.ts` is the single source of truth for all admin routes, driving the overview, nav, document titles, and command palette; a registry-sync test guards it against route-metadata drift.
- A new `AdminRouteShell` wraps every `/admin/*` page with a skip link, "Admin modules" nav landmark, and per-module titles.
- The onboarding interstitial no longer hijacks `/admin` routes, and every admin page has a semantic h1.
- API Keys auto-selects the only user on single-user servers; Billing no longer hangs in a permanent skeleton.
- Route metadata now registers all 47 previously unregistered routes, so the route-governance suites pass without inherited-failure classification.
- UAT driver scripts are committed for future regression sweeps.

<sup>Written for commit cf1988e2f02cf7fae34e427dff2450e7bb204439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

