### PR TITLE
feat(sync): activate Personal Context continuity

### DIFF
--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -130,11 +130,35 @@ The transport can validate and materialize inbound Chatbook-originated
 ongoing client lifecycle. The current products do not provide a dedicated
 Personal Context queue/status or post-link conflict-resolution surface.
 
-REST edits are not published to linked clients. They change the server copy
-without appending a Personal Context Sync entry, so post-link edits can make the
-peers diverge in either direction.
+Eligible REST mutations now append encrypted publication batches in the same
+canonical transaction. A bounded server relay installs those batches in Sync;
+interrupted publication remains retryable. This does not make the currently
+shipped Chatbook drain its ongoing queue.
 
-Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.
+Server purge journals its generation barrier, but remains pending because the
+cross-device acknowledgement-completion lifecycle is not yet enabled.
+
+### Ongoing activation (not yet enabled)
+
+The server still advertises `ongoing_sync_version: 0`. Explicit version-one
+bootstrap and activation-acknowledgement requests return HTTP 409 with
+`personal_context_ongoing_sync_unavailable`; existing first linking is unchanged.
+The implementation is preparation for the separate ongoing-sync rollout, not a
+setting clients should bypass.
+
+Once enabled, a previously completed link requests version-one bootstrap through
+`POST /api/v1/sync/personal-context/bootstrap`. Its response pins one exact
+eligible baseline, activation ID/digest, purge generation, publication watermark,
+transport checkpoint, and continuity proof. The device must durably install that
+baseline before sending the exact ID/digest and its local installation receipt to
+`POST /api/v1/sync/personal-context/activation/acknowledge`.
+
+Push, pull, conflict listing, and conflict resolution require both the current
+canonical continuity proof and this device's durable acknowledgement. Copying
+another device's proof or changing Sync metadata cannot activate a device.
+Retries reuse exact receipts. Delivery baselines expire after 30 days; obtain a
+fresh baseline rather than acknowledging an expired one. Capability downgrade
+preserves stored work and acknowledgements while blocking version-one exchanges.
 
 ## Transport deployment boundary
 

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -270,6 +270,15 @@ requesting device. Source batches remain uncovered and publish normally; the
 expired ID is retained as a tombstone and a subsequent bootstrap gets a new ID.
 Already installed or active activations are not retired by this recovery path.
 
+Activation acquires the process profile lease before the Sync guard, then enters
+the canonical generation transaction. Relay uses a nonblocking process-lease
+attempt: an ingress after-commit callback may still hold an outer Sync transaction,
+so waiting for that lease could deadlock an installer waiting for Sync. Contention
+returns pending without a canonical lease-claim query; durable batches remain for
+later relay. Before installation commits, the prepared generation and its exact
+device link receipt are checked again under the Sync and canonical guards, so an
+earlier authorization cannot survive a concurrent purge.
+
 Bootstrap remains blocked while accepted ingress has not finished canonical
 materialization. Guarded repair may move a failed ingress to applied only after
 verifying its exact canonical receipt; conflict and other non-retryable states

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -53,7 +53,7 @@ ADR](https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-per
 | Published during successful reviewed first linking when eligible | Not published by the shipped ongoing application lifecycle |
 | --- | --- |
 | Canonical manifest in the snapshot resulting from the user-approved content-free reconciliation plan | Later syncable Chatbook mutations: encrypted outbox entries are created but no shipped ongoing Personal Context caller sends them |
-| Required global and linked-workspace scopes in that snapshot | Ordinary server REST mutations: the server copy changes but no Personal Context Sync entry publishes them to Chatbook |
+| Required global and linked-workspace scopes in that snapshot | Later server edits: publication is journaled, but automatic delivery to the current Chatbook is not enabled |
 | Eligible record heads, tombstones, and proposal review state selected by reconciliation, including approved interview answer content after it becomes a canonical record payload | Device-only or non-syncable records |
 | Exact canonical object identities, versions, and bytes for those eligible objects | Runtime agent authority grants, tool availability, local workspace mappings, and enablement |
 | — | Peer-local at-rest encryption/recovery keys, local undo data, caches, ciphertext, database row identities, conflict-review metadata, acknowledgement tracking, and other operational state |
@@ -123,10 +123,10 @@ encrypted transactional read or write. Expected version IDs provide optimistic
 concurrency; unknown and cross-user opaque IDs receive the same not-found
 response.
 
-REST runtime policy and exports are server-local operations. REST record and
-proposal mutations change the canonical server copy, but no server-origin
-publisher currently appends those edits to the linked Personal Context Sync
-streams.
+REST runtime policy and exports are server-local operations. Eligible record and
+proposal changes append encrypted publication batches in their canonical
+transaction. A bounded post-commit relay installs them in the linked Sync streams;
+failed delivery remains durable work rather than rolling back the user mutation.
 
 `POST /scopes/workspace` is stricter than inbound canonical scope
 materialization. The REST path proves that the authenticated user owns the
@@ -199,12 +199,13 @@ Personal Context status/outbox surface, or dedicated post-link conflict
 resolver. Later syncable Chatbook mutations remain queued locally. Generic
 Sync conflict metadata is a transport capability, not a current user workflow.
 
-REST edits are not published to linked clients. They update the server
-canonical copy without appending a Personal Context Sync entry, so post-link
-editing can make the peers diverge in either direction.
+Eligible REST edits now append encrypted publication batches transactionally with
+canonical changes. The bounded server relay retries installation into Sync.
+Client-side ongoing delivery remains gated; publication alone is not evidence of
+cross-peer convergence.
 
-Server purge does not publish the protocol purge envelope, and acknowledgement
-completion is absent.
+Server purge journals a generation barrier. Cross-device acknowledgement
+completion is still absent.
 
 The `personal_context.purge` domain, adapter validation, and inbound service
 projection exist. The REST purge endpoint only advances the server-local
@@ -215,8 +216,7 @@ state, and leaves the profile in `purge_pending`. A mutation returns
 or object resolution, and entry into the existing-profile writable boundary.
 Manifest recreation is unsupported because surviving profile state prevents a
 replacement, while earlier gates may return their own errors. There is no
-shipped server producer/distributor for a purge envelope and no device
-acknowledgement-completion path.
+enabled end-to-end device acknowledgement-completion path.
 
 ## Future-client integration boundaries
 
@@ -225,13 +225,55 @@ domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable
 queue/status UX, and conflict review/resolution UX.
 
-Companion server work separately owns publishing server-origin REST mutations,
-producing and distributing purge envelopes, and tracking device
-acknowledgements. Completing the purge acknowledgement lifecycle is shared
+The server owns publication and device acknowledgement journals. Completing the
+purge acknowledgement lifecycle is shared
 cross-peer work: clients must consume and acknowledge the barrier, while the
 server must aggregate those acknowledgements and finish the lifecycle. Neither
 side should document post-link convergence or completed purge until its own
 responsibilities and the shared handshake are implemented and verified.
+
+### Activation storage and recovery
+
+`Personalization/personal_context_activation.py` owns the source-side orchestration;
+`Sync/v2/personal_context_activation.py` installs protected delivery baselines and
+coordinates exact device receipts. Neither enables `ongoing_sync_version: 1`.
+
+Preparation stores encrypted eligible heads and a whole-batch publication
+watermark. Baseline envelopes use a dedicated encrypted Sync journal because a
+whole profile can exceed the ordinary 100-row publication batch limit and can
+have watermark zero. They are delivered through the existing bootstrap response,
+not a new transport stream. Envelope IDs are deterministic and authenticated with
+profile, device, dataset, generation, activation ID and digest. The install receipt
+also binds ciphertext, checkpoint, and expiry.
+
+Sync installation commits before a leased canonical coverage CAS. A failure in
+between leaves the exact installation replayable. Source-body compaction is
+permitted only after canonical coverage; terminal batch/activation proof remains.
+Device acknowledgement similarly commits in Sync before the canonical device
+state advances. These are two independently committed stores, not one atomic
+transaction.
+
+The canonical publication journal owns the random generation-bound epoch and
+continuity token. Sync retains a secondary metadata fence, but cannot grant
+activation without canonical proof and that device's acknowledgement. A downgrade
+changes neither journal. Activation delivery expires after 30 days; renewal
+retires only the expired activation and its device acknowledgement, retaining
+other devices and publication coverage. Existing authorized profile purge removes
+the new baseline and acknowledgement storage too. Canonical encryption-key
+rotation rewraps baseline keys; Sync encryption uses the existing separately
+derived, rotation-stable profile integrity key.
+
+An interrupted canonical preparation has a 60-second lifetime. While it is fresh,
+relay reports pending; retries reuse the prepared bytes. Once stale, the bounded
+relay can expire that uninstalled preparation under its profile lease without the
+requesting device. Source batches remain uncovered and publish normally; the
+expired ID is retained as a tombstone and a subsequent bootstrap gets a new ID.
+Already installed or active activations are not retired by this recovery path.
+
+Bootstrap remains blocked while accepted ingress has not finished canonical
+materialization. Guarded repair may move a failed ingress to applied only after
+verifying its exact canonical receipt; conflict and other non-retryable states
+remain blocked. Do not clear apply status manually to obtain a baseline.
 
 Chatbook's current interview boundary is also relevant to compatible clients.
 Fixed mode generates questions locally and makes no model call; its encrypted

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -130,11 +130,35 @@ The transport can validate and materialize inbound Chatbook-originated
 ongoing client lifecycle. The current products do not provide a dedicated
 Personal Context queue/status or post-link conflict-resolution surface.
 
-REST edits are not published to linked clients. They change the server copy
-without appending a Personal Context Sync entry, so post-link edits can make the
-peers diverge in either direction.
+Eligible REST mutations now append encrypted publication batches in the same
+canonical transaction. A bounded server relay installs those batches in Sync;
+interrupted publication remains retryable. This does not make the currently
+shipped Chatbook drain its ongoing queue.
 
-Server purge does not publish the protocol purge envelope and remains pending because acknowledgement completion is absent.
+Server purge journals its generation barrier, but remains pending because the
+cross-device acknowledgement-completion lifecycle is not yet enabled.
+
+### Ongoing activation (not yet enabled)
+
+The server still advertises `ongoing_sync_version: 0`. Explicit version-one
+bootstrap and activation-acknowledgement requests return HTTP 409 with
+`personal_context_ongoing_sync_unavailable`; existing first linking is unchanged.
+The implementation is preparation for the separate ongoing-sync rollout, not a
+setting clients should bypass.
+
+Once enabled, a previously completed link requests version-one bootstrap through
+`POST /api/v1/sync/personal-context/bootstrap`. Its response pins one exact
+eligible baseline, activation ID/digest, purge generation, publication watermark,
+transport checkpoint, and continuity proof. The device must durably install that
+baseline before sending the exact ID/digest and its local installation receipt to
+`POST /api/v1/sync/personal-context/activation/acknowledge`.
+
+Push, pull, conflict listing, and conflict resolution require both the current
+canonical continuity proof and this device's durable acknowledgement. Copying
+another device's proof or changing Sync metadata cannot activate a device.
+Retries reuse exact receipts. Delivery baselines expire after 30 days; obtain a
+fresh baseline rather than acknowledging an expired one. Capability downgrade
+preserves stored work and acknowledgements while blocking version-one exchanges.
 
 ## Transport deployment boundary
 

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -270,6 +270,15 @@ requesting device. Source batches remain uncovered and publish normally; the
 expired ID is retained as a tombstone and a subsequent bootstrap gets a new ID.
 Already installed or active activations are not retired by this recovery path.
 
+Activation acquires the process profile lease before the Sync guard, then enters
+the canonical generation transaction. Relay uses a nonblocking process-lease
+attempt: an ingress after-commit callback may still hold an outer Sync transaction,
+so waiting for that lease could deadlock an installer waiting for Sync. Contention
+returns pending without a canonical lease-claim query; durable batches remain for
+later relay. Before installation commits, the prepared generation and its exact
+device link receipt are checked again under the Sync and canonical guards, so an
+earlier authorization cannot survive a concurrent purge.
+
 Bootstrap remains blocked while accepted ingress has not finished canonical
 materialization. Guarded repair may move a failed ingress to applied only after
 verifying its exact canonical receipt; conflict and other non-retryable states

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -53,7 +53,7 @@ ADR](https://github.com/rmusser01/tldw_server/blob/dev/backlog/decisions/002-per
 | Published during successful reviewed first linking when eligible | Not published by the shipped ongoing application lifecycle |
 | --- | --- |
 | Canonical manifest in the snapshot resulting from the user-approved content-free reconciliation plan | Later syncable Chatbook mutations: encrypted outbox entries are created but no shipped ongoing Personal Context caller sends them |
-| Required global and linked-workspace scopes in that snapshot | Ordinary server REST mutations: the server copy changes but no Personal Context Sync entry publishes them to Chatbook |
+| Required global and linked-workspace scopes in that snapshot | Later server edits: publication is journaled, but automatic delivery to the current Chatbook is not enabled |
 | Eligible record heads, tombstones, and proposal review state selected by reconciliation, including approved interview answer content after it becomes a canonical record payload | Device-only or non-syncable records |
 | Exact canonical object identities, versions, and bytes for those eligible objects | Runtime agent authority grants, tool availability, local workspace mappings, and enablement |
 | — | Peer-local at-rest encryption/recovery keys, local undo data, caches, ciphertext, database row identities, conflict-review metadata, acknowledgement tracking, and other operational state |
@@ -123,10 +123,10 @@ encrypted transactional read or write. Expected version IDs provide optimistic
 concurrency; unknown and cross-user opaque IDs receive the same not-found
 response.
 
-REST runtime policy and exports are server-local operations. REST record and
-proposal mutations change the canonical server copy, but no server-origin
-publisher currently appends those edits to the linked Personal Context Sync
-streams.
+REST runtime policy and exports are server-local operations. Eligible record and
+proposal changes append encrypted publication batches in their canonical
+transaction. A bounded post-commit relay installs them in the linked Sync streams;
+failed delivery remains durable work rather than rolling back the user mutation.
 
 `POST /scopes/workspace` is stricter than inbound canonical scope
 materialization. The REST path proves that the authenticated user owns the
@@ -199,12 +199,13 @@ Personal Context status/outbox surface, or dedicated post-link conflict
 resolver. Later syncable Chatbook mutations remain queued locally. Generic
 Sync conflict metadata is a transport capability, not a current user workflow.
 
-REST edits are not published to linked clients. They update the server
-canonical copy without appending a Personal Context Sync entry, so post-link
-editing can make the peers diverge in either direction.
+Eligible REST edits now append encrypted publication batches transactionally with
+canonical changes. The bounded server relay retries installation into Sync.
+Client-side ongoing delivery remains gated; publication alone is not evidence of
+cross-peer convergence.
 
-Server purge does not publish the protocol purge envelope, and acknowledgement
-completion is absent.
+Server purge journals a generation barrier. Cross-device acknowledgement
+completion is still absent.
 
 The `personal_context.purge` domain, adapter validation, and inbound service
 projection exist. The REST purge endpoint only advances the server-local
@@ -215,8 +216,7 @@ state, and leaves the profile in `purge_pending`. A mutation returns
 or object resolution, and entry into the existing-profile writable boundary.
 Manifest recreation is unsupported because surviving profile state prevents a
 replacement, while earlier gates may return their own errors. There is no
-shipped server producer/distributor for a purge envelope and no device
-acknowledgement-completion path.
+enabled end-to-end device acknowledgement-completion path.
 
 ## Future-client integration boundaries
 
@@ -225,13 +225,55 @@ domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable
 queue/status UX, and conflict review/resolution UX.
 
-Companion server work separately owns publishing server-origin REST mutations,
-producing and distributing purge envelopes, and tracking device
-acknowledgements. Completing the purge acknowledgement lifecycle is shared
+The server owns publication and device acknowledgement journals. Completing the
+purge acknowledgement lifecycle is shared
 cross-peer work: clients must consume and acknowledge the barrier, while the
 server must aggregate those acknowledgements and finish the lifecycle. Neither
 side should document post-link convergence or completed purge until its own
 responsibilities and the shared handshake are implemented and verified.
+
+### Activation storage and recovery
+
+`Personalization/personal_context_activation.py` owns the source-side orchestration;
+`Sync/v2/personal_context_activation.py` installs protected delivery baselines and
+coordinates exact device receipts. Neither enables `ongoing_sync_version: 1`.
+
+Preparation stores encrypted eligible heads and a whole-batch publication
+watermark. Baseline envelopes use a dedicated encrypted Sync journal because a
+whole profile can exceed the ordinary 100-row publication batch limit and can
+have watermark zero. They are delivered through the existing bootstrap response,
+not a new transport stream. Envelope IDs are deterministic and authenticated with
+profile, device, dataset, generation, activation ID and digest. The install receipt
+also binds ciphertext, checkpoint, and expiry.
+
+Sync installation commits before a leased canonical coverage CAS. A failure in
+between leaves the exact installation replayable. Source-body compaction is
+permitted only after canonical coverage; terminal batch/activation proof remains.
+Device acknowledgement similarly commits in Sync before the canonical device
+state advances. These are two independently committed stores, not one atomic
+transaction.
+
+The canonical publication journal owns the random generation-bound epoch and
+continuity token. Sync retains a secondary metadata fence, but cannot grant
+activation without canonical proof and that device's acknowledgement. A downgrade
+changes neither journal. Activation delivery expires after 30 days; renewal
+retires only the expired activation and its device acknowledgement, retaining
+other devices and publication coverage. Existing authorized profile purge removes
+the new baseline and acknowledgement storage too. Canonical encryption-key
+rotation rewraps baseline keys; Sync encryption uses the existing separately
+derived, rotation-stable profile integrity key.
+
+An interrupted canonical preparation has a 60-second lifetime. While it is fresh,
+relay reports pending; retries reuse the prepared bytes. Once stale, the bounded
+relay can expire that uninstalled preparation under its profile lease without the
+requesting device. Source batches remain uncovered and publish normally; the
+expired ID is retained as a tombstone and a subsequent bootstrap gets a new ID.
+Already installed or active activations are not retired by this recovery path.
+
+Bootstrap remains blocked while accepted ingress has not finished canonical
+materialization. Guarded repair may move a failed ingress to applied only after
+verifying its exact canonical receipt; conflict and other non-retryable states
+remain blocked. Do not clear apply status manually to obtain a baseline.
 
 Chatbook's current interview boundary is also relevant to compatible clients.
 Fixed mode generates questions locally and makes no model call; its encrypted

--- a/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/Published/User_Guides/Server/Personal_Context_Profile.md
@@ -99,8 +99,9 @@ reference](../../API-related/Personal_Context_API.md).
 8. Do not rely on the link for later changes. Chatbook creates encrypted local
    outbox entries for later syncable mutations, but the shipped app has no
    ongoing Personal Context sync caller. **Overview → Manual Sync** covers Notes
-   and Chat only. Ordinary server REST edits likewise remain server-local because
-   they are not published into the Personal Context Sync log.
+   and Chat only. The server now journals eligible REST edits and retries their
+   publication, but the client must support the separate ongoing-sync rollout
+   before later changes can converge automatically.
 
 ## What is shared
 
@@ -114,7 +115,7 @@ reference](../../API-related/Personal_Context_API.md).
 | Published during successful reviewed first linking when eligible | Not published by the shipped ongoing application lifecycle |
 | --- | --- |
 | Canonical manifest in the snapshot resulting from the user-approved content-free reconciliation plan | Later syncable Chatbook mutations: encrypted outbox entries are created but no shipped ongoing Personal Context caller sends them |
-| Required global and linked-workspace scopes in that snapshot | Ordinary server REST mutations: the server copy changes but no Personal Context Sync entry publishes them to Chatbook |
+| Required global and linked-workspace scopes in that snapshot | Later server edits: server publication exists, but automatic delivery to the current Chatbook is not enabled |
 | Eligible record heads, tombstones, and proposal review state selected by reconciliation, including approved interview answer content after it becomes a canonical record payload | Device-only or non-syncable records |
 | Exact canonical object identities, versions, and bytes for those eligible objects | Runtime agent authority grants, tool availability, local workspace mappings, and enablement |
 | — | Peer-local at-rest encryption/recovery keys, local undo data, caches, ciphertext, database row identities, conflict-review metadata, acknowledgement tracking, and other operational state |
@@ -122,7 +123,11 @@ reference](../../API-related/Personal_Context_API.md).
 
 The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
 
-Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
+The server still advertises ongoing Personal Context sync version zero. Do not
+change Sync metadata to force activation: each device needs a verified baseline
+and its own durable acknowledgement. This preparation does not add a new user
+action yet. Existing first linking and local editing remain available; keep local
+queued changes until the ongoing client workflow is released.
 
 The versioned [Shared Core
 contract](https://github.com/rmusser01/tldw_server/tree/dev/packages/tldw_profile_core)
@@ -192,7 +197,7 @@ check, so not every rejected request returns `profile_purge_pending`.
 
 The `personal_context.purge` protocol domain exists.
 
-The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.
+The server journals the purge barrier, but cross-device acknowledgement completion is not wired.
 Reconnecting devices does not currently clear `purge_pending`, and the current
 server has no completion path for that state.
 

--- a/Docs/User_Guides/Server/Personal_Context_Profile.md
+++ b/Docs/User_Guides/Server/Personal_Context_Profile.md
@@ -99,8 +99,9 @@ reference](../../API-related/Personal_Context_API.md).
 8. Do not rely on the link for later changes. Chatbook creates encrypted local
    outbox entries for later syncable mutations, but the shipped app has no
    ongoing Personal Context sync caller. **Overview → Manual Sync** covers Notes
-   and Chat only. Ordinary server REST edits likewise remain server-local because
-   they are not published into the Personal Context Sync log.
+   and Chat only. The server now journals eligible REST edits and retries their
+   publication, but the client must support the separate ongoing-sync rollout
+   before later changes can converge automatically.
 
 ## What is shared
 
@@ -114,7 +115,7 @@ reference](../../API-related/Personal_Context_API.md).
 | Published during successful reviewed first linking when eligible | Not published by the shipped ongoing application lifecycle |
 | --- | --- |
 | Canonical manifest in the snapshot resulting from the user-approved content-free reconciliation plan | Later syncable Chatbook mutations: encrypted outbox entries are created but no shipped ongoing Personal Context caller sends them |
-| Required global and linked-workspace scopes in that snapshot | Ordinary server REST mutations: the server copy changes but no Personal Context Sync entry publishes them to Chatbook |
+| Required global and linked-workspace scopes in that snapshot | Later server edits: server publication exists, but automatic delivery to the current Chatbook is not enabled |
 | Eligible record heads, tombstones, and proposal review state selected by reconciliation, including approved interview answer content after it becomes a canonical record payload | Device-only or non-syncable records |
 | Exact canonical object identities, versions, and bytes for those eligible objects | Runtime agent authority grants, tool availability, local workspace mappings, and enablement |
 | — | Peer-local at-rest encryption/recovery keys, local undo data, caches, ciphertext, database row identities, conflict-review metadata, acknowledgement tracking, and other operational state |
@@ -122,7 +123,11 @@ reference](../../API-related/Personal_Context_API.md).
 
 The home server wraps its Sync integrity key for authenticated registered Chatbook devices; this is not at-rest key sharing.
 
-Ordinary server REST record/proposal mutations are not currently published to linked Chatbook clients.
+The server still advertises ongoing Personal Context sync version zero. Do not
+change Sync metadata to force activation: each device needs a verified baseline
+and its own durable acknowledgement. This preparation does not add a new user
+action yet. Existing first linking and local editing remain available; keep local
+queued changes until the ongoing client workflow is released.
 
 The versioned [Shared Core
 contract](https://github.com/rmusser01/tldw_server/tree/dev/packages/tldw_profile_core)
@@ -192,7 +197,7 @@ check, so not every rejected request returns `profile_purge_pending`.
 
 The `personal_context.purge` protocol domain exists.
 
-The server purge endpoint does not publish the protocol purge envelope, and acknowledgement completion is not wired.
+The server journals the purge barrier, but cross-device acknowledgement completion is not wired.
 Reconnecting devices does not currently clear `purge_pending`, and the current
 server has no completion path for that state.
 

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2073,
   "schema_count": 3140,
-  "sha256": "36153c5c56cb2aec9693e537960f017de50b30e5fd6098c038438aa18903a174"
+  "sha256": "53e1e9a2ef87a01fbefa8e1f5300578a6a127c8c97bcb22b14e861ab00cb3ffb"
 }

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -143,3 +143,25 @@ operator configuration, with memory/restart guidance. Do not infer another
 architecture's support from a model-family label or one successful configuration.
 Publish warm/cold measurements before reuse assertions so failures retain useful
 evidence. Managed runtime evidence does not substitute for live client acceptance.
+
+## Activation fixtures must distinguish authorization from publication state
+
+**Incident (TASK-13162, 2026-09-05):** Adding canonical activation checks exposed
+older relay fixtures that granted access by writing only Sync metadata. Simply
+activating those fixtures would cover the pending source rows their recovery
+tests were meant to exercise.
+
+**Evidence and rule:** Production certification now performs real baseline
+installation and acknowledgement before creating relay debt. Narrow authority
+and budget tests use an explicit typed authorization double while preserving
+their real source rows and original assertions. Keep those concerns separate;
+never add a production metadata-only fallback to satisfy a test harness. Compare
+broader failures against unchanged dev before attributing them to the new guard.
+
+**Follow-up (TASK-13162):** Updating those proof fixtures exposed a deeper failure:
+guarded repair verified the canonical ingress receipt, but terminalization accepted
+only pending/applied rows, so a previously failed row could never unblock bootstrap.
+The original recovery assertion caught it. A focused regression failed on both
+SQLite and PostgreSQL before the one-line transition fix; all 22 receipt/state
+cases and 48 bootstrap tests then passed. Keep the recovery assertion through
+fixture repairs, and test retryable failure states as well as first application.

--- a/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
+++ b/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13162
 title: Activate existing Personal Context links with continuity fencing
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-05 16:15'
+updated_date: '2026-09-05 17:03'
 labels:
   - personal-context
   - sync
@@ -37,6 +37,7 @@ Add the replayable activation journal that establishes a server baseline and pub
 - [x] #6 Restart tests cover preparation, Sync installation, coverage CAS, compaction, acknowledgment, racing server writes, and first post-watermark relay.
 - [x] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs activation and continuity.
 - [x] #8 Failed ingress repair can unblock baseline preparation only after exact canonical receipt verification; mismatched receipts and non-retryable states remain rejected.
+- [x] #9 Concurrent activation and production ingress after-commit relay cannot deadlock; contended relay returns pending without losing publication debt.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -57,6 +58,12 @@ Final closing evidence, PostgreSQL required: 279 canonical/publication/authoriza
 Known separate issue: ordinary PostgreSQL ingress fixture insertion reached unchanged SyncDatabase._ensure_domain_state SQL translation with five placeholders and six parameters. No unrelated production fix was bundled. The new backend regression seeds valid ingress input rows with parameterized SQL and exercises real receipt/transition storage; it does not claim PostgreSQL ordinary-envelope insertion is verified. End-to-end bootstrap repair passes on SQLite. This transport insertion issue remains follow-up work. TASK-13163–13165 are not implemented; ongoing_sync_version remains 0.
 
 PR handoff 2026-09-05: rebased without conflicts onto dev 63358431d799828cfb86511f7babd8490bbbdda9; range-diff confirms the implementation patch is unchanged (rebased commit adb741dfb10c77fc5b873abb809f19e7517f7b20). Fresh post-rebase integration gate: 254 passed, zero failures/errors/skips, PostgreSQL required, /private/tmp/task13162-pr-rebased-verification.xml. Scoped Ruff and production Bandit passed again. Opened PR 2886 against dev: https://github.com/rmusser01/tldw_server/pull/2886. Human-written Change summary is still required before merge; no auto-merge enabled.
+
+PR 2886 review follow-up authorized 2026-09-05: user explicitly waived the human-written Change summary requirement for this PR only and authorized latest-dev rebase, all review/CI remediation and merge. Latest fetched dev remains 63358431d7, already the branch base. Plan: reproduce and address Qodo purge-generation/lock-order reports; move rollout dispatch into core, complete public docstrings/type hints and use domain exceptions; evaluate fixture feedback without introducing production test-only helpers or unrelated auth dependencies; reproduce/fix OpenAPI fingerprint CI drift; run focused regressions and independent review, reply to all threads, then wait for current-head Qodo/required checks and merge. ADR-002 continues to govern; no rollout or protocol-policy expansion.
+
+Independent specification review traced a remaining preexisting Sync-to-profile-lock path through production ingress after-commit relay. Extend the review remediation plan to reproduce that interleaving and make relay process-lock acquisition nonblocking, preserving ordinary activation lease acquisition, durable fencing and retryable pending debt. Verify a deterministic production callback regression plus existing recovery budgets. This is a bounded lock-order correction under ADR-002, not a new storage or protocol policy.
+
+Qodo remediation: core bootstrap now owns version dispatch; public activation contracts and fixture typing are explicit; activation errors use content-free domain subclasses with compatible HTTP translation. Activation takes profile lease before Sync and revalidates generation plus the exact link receipt inside the install guard. Production ingress after-commit relay skips a contended process lock before canonical SQL and retains durable publication debt. Deterministic regressions reproduced the races before the fixes and now pass, including later acknowledgment of the raced publication. Worker closing gate: 172 passed with PostgreSQL required; core dispatch gate: 124 passed. Independent specification and code/security review cleared the final behavioral changes. The two fixture suggestions were rebutted with concrete transaction and shared PostgreSQL fixture ownership evidence. Updated developer/published docs and regenerated the OpenAPI fingerprint; exact drift check passes (description-only difference, unchanged path/schema counts). Broad final targeted matrix and current-head CI/merge are still pending. Newly added activation files pass formatting; existing publication module has pre-existing whole-file formatter drift, so unrelated formatting is not bundled.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
+++ b/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-05 17:03'
+updated_date: '2026-09-05 19:06'
 labels:
   - personal-context
   - sync
@@ -64,12 +64,16 @@ PR 2886 review follow-up authorized 2026-09-05: user explicitly waived the human
 Independent specification review traced a remaining preexisting Sync-to-profile-lock path through production ingress after-commit relay. Extend the review remediation plan to reproduce that interleaving and make relay process-lock acquisition nonblocking, preserving ordinary activation lease acquisition, durable fencing and retryable pending debt. Verify a deterministic production callback regression plus existing recovery budgets. This is a bounded lock-order correction under ADR-002, not a new storage or protocol policy.
 
 Qodo remediation: core bootstrap now owns version dispatch; public activation contracts and fixture typing are explicit; activation errors use content-free domain subclasses with compatible HTTP translation. Activation takes profile lease before Sync and revalidates generation plus the exact link receipt inside the install guard. Production ingress after-commit relay skips a contended process lock before canonical SQL and retains durable publication debt. Deterministic regressions reproduced the races before the fixes and now pass, including later acknowledgment of the raced publication. Worker closing gate: 172 passed with PostgreSQL required; core dispatch gate: 124 passed. Independent specification and code/security review cleared the final behavioral changes. The two fixture suggestions were rebutted with concrete transaction and shared PostgreSQL fixture ownership evidence. Updated developer/published docs and regenerated the OpenAPI fingerprint; exact drift check passes (description-only difference, unchanged path/schema counts). Broad final targeted matrix and current-head CI/merge are still pending. Newly added activation files pass formatting; existing publication module has pre-existing whole-file formatter drift, so unrelated formatting is not bundled.
+
+Final targeted matrix completed: 673 passed, 53 warnings, zero failures/errors/skips, PostgreSQL required, 4739.07 seconds; /private/tmp/task13162-qodo-final.xml. All required CI gates passed and Qodo reported zero findings at 850ead03ee. Rebased onto dev 86eb9e517c after unrelated Buddy changes, preserving both testing-lessons additions in the sole documentation conflict. Range-diff confirms Personal Context code and tests unchanged; scoped Ruff passed again. Task remains In Progress until final rebased-head CI and remote merge complete. User explicitly approved unattended review fixes, rebases, pushes and merging PR 2886. ADR-002 and version-zero rollout remain unchanged.
+
+Latest-dev follow-up: rebased onto 53d683f0ed (merged llama.cpp snapshots). Preserved both appended testing-lessons entries and regenerated the combined OpenAPI fingerprint (2073 paths, 3140 schemas, sha256 53e1e9a2ef87a01fbefa8e1f5300578a6a127c8c97bcb22b14e861ab00cb3ffb). Range-diff preserves all Personal Context code/test patches; shared exceptions retain both domains. Fresh focused activation gate: 57 passed, 5 warnings, PostgreSQL required, 52.60 seconds, /private/tmp/task13162-latest-dev-activation.xml. Scoped Ruff, diff check and source/published developer-document comparison passed. Keep task In Progress until fresh remote checks and merge complete.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added replayable activation and canonical per-device continuity fencing for existing Personal Context links. Verified 659 distinct targeted cases, independent reviews, scoped Ruff/Bandit, and updated documentation. Ongoing-sync rollout remains disabled; separate PostgreSQL ordinary-ingress insertion issue is documented for follow-up.
+Implemented replayable Personal Context activation, exact per-device continuity, and failed-ingress repair. All eight Qodo findings addressed: six fixes and two verified fixture rebuttals. Final targeted matrix: 673 passed with PostgreSQL required and no skips. Independent reviews, scoped Ruff/Bandit and prior-head required CI passed. Final rebased-head CI and merge remain pending in PR 2886; task is not yet Done. Ongoing-sync rollout remains disabled; unrelated PostgreSQL ordinary-ingress insertion issue is documented.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
+++ b/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-13162
 title: Activate existing Personal Context links with continuity fencing
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
+updated_date: '2026-09-05 06:34'
 labels:
   - personal-context
   - sync
@@ -27,21 +28,46 @@ Add the replayable activation journal that establishes a server baseline and pub
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preparation stores one encrypted exact-head baseline, digest, purge generation, and watermark at a whole publication-batch boundary.
-- [ ] #2 Deterministic Sync installation and receipt verification precede a leased Personalization CAS that marks all covered batches covered_by_activation and advances content-free covered-through proof before compaction.
-- [ ] #3 Per-device acknowledgments and activation state replay idempotently by activation ID and digest across Personalization and Sync without claiming cross-database atomicity.
-- [ ] #4 A random activation epoch and continuity token are durable, generation-bound, echoed and validated on every version-1 exchange, and invalidated or write-fenced when journaling cannot be guaranteed.
-- [ ] #5 Capability downgrade preserves links and queued work; restoration requires the same proven continuity pair or a fresh baseline.
-- [ ] #6 Restart tests cover preparation, Sync installation, coverage CAS, compaction, acknowledgment, racing server writes, and first post-watermark relay.
-- [ ] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs activation and continuity.
+- [x] #1 Preparation stores one encrypted exact-head baseline, digest, purge generation, and watermark at a whole publication-batch boundary.
+- [x] #2 Deterministic Sync installation and receipt verification precede a leased Personalization CAS that marks all covered batches covered_by_activation and advances content-free covered-through proof before compaction.
+- [x] #3 Per-device acknowledgments and activation state replay idempotently by activation ID and digest across Personalization and Sync without claiming cross-database atomicity.
+- [x] #4 A random activation epoch and continuity token are durable, generation-bound, echoed and validated on every version-1 exchange, and invalidated or write-fenced when journaling cannot be guaranteed.
+- [x] #5 Capability downgrade preserves links and queued work; restoration requires the same proven continuity pair or a fresh baseline.
+- [x] #6 Restart tests cover preparation, Sync installation, coverage CAS, compaction, acknowledgment, racing server writes, and first post-watermark relay.
+- [x] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs activation and continuity.
+- [x] #8 Failed ingress repair can unblock baseline preparation only after exact canonical receipt verification; mismatched receipts and non-retryable states remain rejected.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implement Task 1 of Docs/superpowers/plans/2026-09-03-personal-context-ongoing-sync-02-server-activation-conflict-purge.md against merged PR 2868. 1. Verify existing contract, publication/lease and exchange-proof baseline. 2. Test-first: durable encrypted exact-head preparation at whole-batch watermark, deterministic Sync installation and verified Personalization coverage CAS. 3. Add replayable per-device acknowledgment, durable continuity validation and fail-closed downgrade behavior through existing authenticated endpoints/factories. 4. Exercise restart/failure boundaries, competing writes, compaction proof, post-watermark relay, SQLite/PostgreSQL and protected canaries with targeted tests. 5. Run scoped formatting/lint/Bandit, independent specification then code/security reviews, update docs and task evidence. 6. Compatibility investigation addition: reproduce verified failed-ingress retry rejection, extend only its legal terminalization transition, and prove exact-receipt/disallowed-state rejection plus successful bootstrap after repair. Preserve ongoing_sync_version=0; do not implement TASK-13163–13165. ADR required: no new ADR. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: implementing the approved activation/continuity journal and custody decisions without changing protocol policy.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented encrypted exact-head activation preparation, protected deterministic Sync installation, leased canonical coverage/compaction, exact per-device acknowledgement, canonical continuity enforcement, delivery expiry and abandoned-preparation recovery. Existing authorized purge removes the new journals. Version-0 rollout and shared wire records remain unchanged. Updated API/developer/user docs and generated published copies; ADR-002 governs without a new decision.
+
+Compatibility work preserved original cursor, race, projection and recovery assertions. Replaced metadata-only fixtures with explicit typed proof doubles where source publication state is the test subject; production certification and authenticated endpoints use real activation install/ack. Seven bootstrap failures also reproduced on unchanged dev (571 passed/7 failed at 3bc8c6a98c). Fixture repairs exposed a failed-ingress transition bug blocking bootstrap: added only failed to terminalization states after existing exact receipt verification. Regression RED: 2 failures/20 passes on SQLite/PostgreSQL; GREEN: 22 receipt/state cases plus all 48 bootstrap tests passed. This supporting fix was added to AC8 and the plan before implementation.
+
+Final closing evidence, PostgreSQL required: 279 canonical/publication/authorization tests; 156 relay/recovery/shared-contract tests; 254 activation/API/transport/bootstrap/ingress tests. All three runs exited zero with no failures/errors/skips; 659 distinct cases across the runs. JUnit: /private/tmp/task13162-canonical-final-close.xml, /private/tmp/task13162-relay-final-close.xml, /private/tmp/task13162-integration-final-close.xml. No full repository sweep. Ruff passed all 23 changed Python files; five new files pass format checks; diff check clean; published docs match source. Bandit: zero findings in 13 changed production files. Compared test findings against unchanged dev: new low-severity hardcoded-token flags are reviewed synthetic proof fixtures, not production secrets. Independent specification and code/security reviews have no remaining P1/P2 findings.
+
+Known separate issue: ordinary PostgreSQL ingress fixture insertion reached unchanged SyncDatabase._ensure_domain_state SQL translation with five placeholders and six parameters. No unrelated production fix was bundled. The new backend regression seeds valid ingress input rows with parameterized SQL and exercises real receipt/transition storage; it does not claim PostgreSQL ordinary-envelope insertion is verified. End-to-end bootstrap repair passes on SQLite. This transport insertion issue remains follow-up work. TASK-13163–13165 are not implemented; ongoing_sync_version remains 0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added replayable activation and canonical per-device continuity fencing for existing Personal Context links. Verified 659 distinct targeted cases, independent reviews, scoped Ruff/Bandit, and updated documentation. Ongoing-sync rollout remains disabled; separate PostgreSQL ordinary-ingress insertion issue is documented for follow-up.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
+++ b/backlog/tasks/task-13162 - Activate-existing-Personal-Context-links-with-continuity-fencing.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-05 06:34'
+updated_date: '2026-09-05 16:15'
 labels:
   - personal-context
   - sync
@@ -17,6 +17,7 @@ references:
   - >-
     backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
   - Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2886'
 priority: high
 ---
 
@@ -54,6 +55,8 @@ Compatibility work preserved original cursor, race, projection and recovery asse
 Final closing evidence, PostgreSQL required: 279 canonical/publication/authorization tests; 156 relay/recovery/shared-contract tests; 254 activation/API/transport/bootstrap/ingress tests. All three runs exited zero with no failures/errors/skips; 659 distinct cases across the runs. JUnit: /private/tmp/task13162-canonical-final-close.xml, /private/tmp/task13162-relay-final-close.xml, /private/tmp/task13162-integration-final-close.xml. No full repository sweep. Ruff passed all 23 changed Python files; five new files pass format checks; diff check clean; published docs match source. Bandit: zero findings in 13 changed production files. Compared test findings against unchanged dev: new low-severity hardcoded-token flags are reviewed synthetic proof fixtures, not production secrets. Independent specification and code/security reviews have no remaining P1/P2 findings.
 
 Known separate issue: ordinary PostgreSQL ingress fixture insertion reached unchanged SyncDatabase._ensure_domain_state SQL translation with five placeholders and six parameters. No unrelated production fix was bundled. The new backend regression seeds valid ingress input rows with parameterized SQL and exercises real receipt/transition storage; it does not claim PostgreSQL ordinary-envelope insertion is verified. End-to-end bootstrap repair passes on SQLite. This transport insertion issue remains follow-up work. TASK-13163–13165 are not implemented; ongoing_sync_version remains 0.
+
+PR handoff 2026-09-05: rebased without conflicts onto dev 63358431d799828cfb86511f7babd8490bbbdda9; range-diff confirms the implementation patch is unchanged (rebased commit adb741dfb10c77fc5b873abb809f19e7517f7b20). Fresh post-rebase integration gate: 254 passed, zero failures/errors/skips, PostgreSQL required, /private/tmp/task13162-pr-rebased-verification.xml. Scoped Ruff and production Bandit passed again. Opened PR 2886 against dev: https://github.com/rmusser01/tldw_server/pull/2886. Human-written Change summary is still required before merge; no auto-merge enabled.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -296,6 +296,11 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
         return HTTPException(status_code=status_code, detail=detail)
     if isinstance(exc, SyncStoreError):
         lowered = str(exc).lower()
+        if lowered == "personal_context_ongoing_sync_unavailable":
+            return HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "personal_context_ongoing_sync_unavailable"},
+            )
         if "personal_context_activation_required" in lowered:
             return HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -945,23 +950,14 @@ def bootstrap_sync_v2_personal_context(
     """Return the canonical profile snapshot and wrapped Sync integrity key."""
 
     user_id = _sync_user_id(user)
-    if (
-        request.ongoing_sync_version == 1
-        and service.capabilities(user_id=user_id).personal_context.ongoing_sync_version != 1
-    ):
-        raise HTTPException(status_code=409, detail={"code": "personal_context_ongoing_sync_unavailable"})
     try:
-        bootstrap = (
-            service.prepare_personal_context_activation
-            if request.ongoing_sync_version == 1
-            else service.bootstrap_personal_context
-        )
-        snapshot = bootstrap(
+        snapshot = service.bootstrap_personal_context(
             user_id=user_id,
             device_id=request.device_id,
             required_schema_version=request.required_schema_version,
             required_quotas=request.required_quotas,
             expected_purge_generation=request.expected_purge_generation,
+            ongoing_sync_version=request.ongoing_sync_version,
         )
     except Exception as exc:
         raise _safe_sync_v2_http_error(exc, user_id=user_id, device_id=request.device_id) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -945,8 +945,18 @@ def bootstrap_sync_v2_personal_context(
     """Return the canonical profile snapshot and wrapped Sync integrity key."""
 
     user_id = _sync_user_id(user)
+    if (
+        request.ongoing_sync_version == 1
+        and service.capabilities(user_id=user_id).personal_context.ongoing_sync_version != 1
+    ):
+        raise HTTPException(status_code=409, detail={"code": "personal_context_ongoing_sync_unavailable"})
     try:
-        snapshot = service.bootstrap_personal_context(
+        bootstrap = (
+            service.prepare_personal_context_activation
+            if request.ongoing_sync_version == 1
+            else service.bootstrap_personal_context
+        )
+        snapshot = bootstrap(
             user_id=user_id,
             device_id=request.device_id,
             required_schema_version=request.required_schema_version,
@@ -954,9 +964,7 @@ def bootstrap_sync_v2_personal_context(
             expected_purge_generation=request.expected_purge_generation,
         )
     except Exception as exc:
-        raise _safe_sync_v2_http_error(
-            exc, user_id=user_id, device_id=request.device_id
-        ) from exc
+        raise _safe_sync_v2_http_error(exc, user_id=user_id, device_id=request.device_id) from exc
     return SyncPersonalContextBootstrapResponse(
         dataset_id=snapshot.dataset_id,
         authority_id=snapshot.authority_id,
@@ -972,6 +980,8 @@ def bootstrap_sync_v2_personal_context(
         integrity_key_id=snapshot.integrity_key.integrity_key_id,
         key_record_id=snapshot.integrity_key.key_record_id,
         wrapped_key_blob=snapshot.integrity_key.wrapped_key_blob,
+        activation=snapshot.activation,
+        personal_context_exchange=snapshot.personal_context_exchange,
     )
 
 
@@ -1926,15 +1936,29 @@ def resolve_sync_v2_conflicts(
 )
 def acknowledge_personal_context_activation(
     request: SyncPersonalContextActivationAcknowledgeRequest,
+    user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ) -> SyncPersonalContextActivationAcknowledgeResponse:
-    """Reserve the versioned activation-acknowledgement route until activation is ready."""
+    """Acknowledge an exact installed baseline when ongoing rollout is ready."""
 
-    del request, service
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={"code": "personal_context_ongoing_sync_unavailable"},
-    )
+    user_id = _sync_user_id(user)
+    if service.capabilities(user_id=user_id).personal_context.ongoing_sync_version != 1:
+        raise HTTPException(status_code=409, detail={"code": "personal_context_ongoing_sync_unavailable"})
+    try:
+        receipt, proof = service.acknowledge_personal_context_activation(
+            user_id=user_id,
+            dataset_id=request.dataset_id,
+            device_id=request.device_id,
+            activation_id=request.activation_id,
+            baseline_digest=request.baseline_digest,
+            local_receipt_id=request.local_receipt_id,
+            exchange=request.personal_context_exchange,
+        )
+    except Exception as exc:
+        raise _safe_sync_v2_http_error(
+            exc, user_id=user_id, dataset_id=request.dataset_id, device_id=request.device_id
+        ) from exc
+    return SyncPersonalContextActivationAcknowledgeResponse(receipt=receipt, personal_context_exchange=proof)
 
 
 @router.post(

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -33,6 +33,12 @@ from tldw_Server_API.app.core.DB_Management.Personal_Context_Key_Store import (
     ServerProfileKeyProvider,
 )
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
+from tldw_Server_API.app.core.exceptions import (
+    PersonalContextActivationInputError,
+    PersonalContextActivationMissingError,
+    PersonalContextActivationPendingError,
+    PersonalContextActivationStaleError,
+)
 from tldw_Server_API.app.core.Personalization.personal_context_crypto import (
     EncryptedEnvelope,
     EnvelopeAuthenticationError,
@@ -1403,7 +1409,7 @@ class PersonalContextRepository:
             ).fetchone()
             is None
         ):
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationStaleError("personal_context_activation_required")
         connection.execute(
             """UPDATE personal_context_publication_relay_leases SET expires_at_ns = ?
                WHERE profile_id = ? AND owner_token = ?""",
@@ -1417,7 +1423,7 @@ class PersonalContextRepository:
     ) -> PreparedPersonalContextActivation:
         """Authenticate an exact journal snapshot before returning plaintext."""
         if row["state"] == "expired":
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationStaleError("personal_context_activation_required")
         keys = self._keys.load(str(row["profile_id"]), connection=connection)
         baseline = EnvelopeCipher(keys.encryption_key, key_version=keys.key_version).decrypt(
             EncryptedEnvelope(
@@ -1465,7 +1471,7 @@ class PersonalContextRepository:
                 (activation_id,),
             ).fetchone()
             if row is None:
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
             return self._decode_activation(connection, row)
 
     def prepare_activation(
@@ -1476,9 +1482,29 @@ class PersonalContextRepository:
         lease: PublicationRelayLease | None,
         fresh: bool = False,
     ) -> PreparedPersonalContextActivation:
-        """Commit one device's exact eligible heads and whole-batch watermark."""
+        """Commit one device's exact eligible heads and whole-batch watermark.
+
+        Args:
+            profile_id: Canonical profile to snapshot.
+            device_id: Nonempty device identifier of at most 128 characters.
+            lease: Current publication lease owned by the caller for this profile.
+            fresh: Replace an active baseline; prepared and installed baselines
+                always replay until their installation or acknowledgment finishes.
+
+        Returns:
+            The authenticated durable preparation, including its exact baseline,
+            digest, purge generation and whole-batch publication watermark.
+
+        Raises:
+            PersonalContextActivationInputError: The device identifier is invalid.
+            PersonalContextActivationStaleError: The caller's lease is not current.
+            PersonalContextActivationPendingError: Another preparation or an
+                incomplete publication batch prevents preparing a fresh baseline.
+            ProfileIntegrityError: The encrypted baseline or watermark is invalid.
+            ProfileStorageLockedError: Canonical profile keys are unavailable.
+        """
         if not device_id or len(device_id) > 128:
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationInputError("personal_context_activation_required")
         with self._database.transaction(immediate=True) as connection:
             self._require_activation_lease(connection, profile_id, lease)
             manifest, scopes, records, proposals, _key_id, _key = self.sync_bootstrap_snapshot(
@@ -1497,7 +1523,7 @@ class PersonalContextRepository:
                     return previous
                 try:
                     self._activation_current_pair(connection, row)
-                except ValueError:
+                except PersonalContextActivationStaleError:
                     pass  # A broken continuity proof requires a new exact-head baseline.
                 else:
                     if row["state"] == "installed" or not fresh:
@@ -1510,7 +1536,7 @@ class PersonalContextRepository:
                 ).fetchone()
                 is not None
             ):
-                raise ValueError("personal_context_activation_pending")
+                raise PersonalContextActivationPendingError("personal_context_activation_pending")
             if (
                 connection.execute(
                     """SELECT 1 FROM personal_context_activations a
@@ -1523,7 +1549,7 @@ class PersonalContextRepository:
                 ).fetchone()
                 is not None
             ):
-                raise ValueError("personal_context_activation_pending")
+                raise PersonalContextActivationPendingError("personal_context_activation_pending")
             profile = connection.execute(
                 "SELECT * FROM personal_context_publication_profiles WHERE profile_id = ?",
                 (profile_id,),
@@ -1608,13 +1634,15 @@ class PersonalContextRepository:
                 "SELECT * FROM personal_context_activations WHERE activation_id = ?",
                 (activation_id,),
             ).fetchone()
-            if row is None or not hmac.compare_digest(row["baseline_digest"], baseline_digest):
-                raise ValueError("personal_context_activation_required")
+            if row is None:
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
+            if not hmac.compare_digest(row["baseline_digest"], baseline_digest):
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             self._require_activation_lease(connection, row["profile_id"], lease)
             keys = self._keys.load(row["profile_id"], connection=connection)
             manifest = self._current_manifest_for_publication(connection, row["profile_id"], keys)
             if manifest.purge_generation != row["purge_generation"]:
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             yield self._decode_activation(connection, row)
 
     def complete_activation_install(
@@ -1628,14 +1656,16 @@ class PersonalContextRepository:
     ) -> PreparedPersonalContextActivation:
         """CAS verified Sync installation, source coverage, and continuity in one commit."""
         if not sync_receipt_id or type(home_server_cursor) is not int or home_server_cursor < 0:
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationInputError("personal_context_activation_required")
         with self._database.transaction(immediate=True) as connection:
             row = connection.execute(
                 "SELECT * FROM personal_context_activations WHERE activation_id = ?",
                 (activation_id,),
             ).fetchone()
-            if row is None or not hmac.compare_digest(row["baseline_digest"], baseline_digest):
-                raise ValueError("personal_context_activation_required")
+            if row is None:
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
+            if not hmac.compare_digest(row["baseline_digest"], baseline_digest):
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             activation = self._decode_activation(connection, row)
             self._require_activation_lease(connection, activation.profile_id, lease)
             profile = connection.execute(
@@ -1645,10 +1675,10 @@ class PersonalContextRepository:
             keys = self._keys.load(activation.profile_id, connection=connection)
             manifest = self._current_manifest_for_publication(connection, activation.profile_id, keys)
             if manifest.purge_generation != activation.purge_generation:
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             if row["state"] != "prepared":
                 if row["sync_receipt_id"] != sync_receipt_id or row["home_server_cursor"] != home_server_cursor:
-                    raise ValueError("personal_context_activation_required")
+                    raise PersonalContextActivationStaleError("personal_context_activation_required")
                 self._activation_current_pair(connection, row)
                 return self._decode_activation(connection, row)
             epoch = profile["activation_epoch"] if profile else None
@@ -1716,18 +1746,19 @@ class PersonalContextRepository:
         coverage and the shared continuity pair survive this per-device change.
         """
         if not sync_receipt_id or len(sync_receipt_id) > 128:
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationInputError("personal_context_activation_required")
         with self._database.transaction(immediate=True) as connection:
             row = connection.execute(
                 "SELECT * FROM personal_context_activations WHERE activation_id = ?",
                 (activation_id,),
             ).fetchone()
-            if (
-                row is None
-                or not hmac.compare_digest(row["baseline_digest"], baseline_digest)
-                or row["sync_receipt_id"] not in (None, sync_receipt_id)
+            if row is None:
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
+            if not hmac.compare_digest(row["baseline_digest"], baseline_digest) or row["sync_receipt_id"] not in (
+                None,
+                sync_receipt_id,
             ):
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             self._require_activation_lease(connection, row["profile_id"], lease)
             if row["state"] == "expired":
                 return
@@ -1750,8 +1781,10 @@ class PersonalContextRepository:
                 "SELECT * FROM personal_context_activations WHERE activation_id = ?",
                 (activation_id,),
             ).fetchone()
-            if activation is None or activation["state"] == "prepared" or not activation["sync_receipt_id"]:
-                raise ValueError("personal_context_activation_required")
+            if activation is None:
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
+            if activation["state"] == "prepared" or not activation["sync_receipt_id"]:
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             return connection.execute(
                 """UPDATE personal_context_publication_rows SET ciphertext = ?, wrapped_dek = ?,
                    wrapped_dek_nonce = ?, nonce = ?, row_state = 'shredded'
@@ -1796,19 +1829,20 @@ class PersonalContextRepository:
                 device_id,
             )
         ):
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationInputError("personal_context_activation_required")
         with self._database.transaction(immediate=True) as connection:
             row = connection.execute(
                 "SELECT * FROM personal_context_activations WHERE activation_id = ?",
                 (activation_id,),
             ).fetchone()
+            if row is None:
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
             if (
-                row is None
-                or row["device_id"] != device_id
+                row["device_id"] != device_id
                 or row["state"] == "prepared"
                 or not hmac.compare_digest(row["baseline_digest"], baseline_digest)
             ):
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             self._activation_current_pair(connection, row)
             expected = (baseline_digest, local_receipt_id, sync_ack_receipt_id, dataset_id)
             receipt = connection.execute(
@@ -1817,7 +1851,7 @@ class PersonalContextRepository:
                 (activation_id, device_id),
             ).fetchone()
             if receipt is not None and tuple(receipt) != expected:
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
             connection.execute(
                 """INSERT INTO personal_context_activation_devices (
                    activation_id, device_id, baseline_digest, local_receipt_id,
@@ -1858,7 +1892,7 @@ class PersonalContextRepository:
             or not hmac.compare_digest(profile["activation_epoch"] or "", activation["activation_epoch"])
             or not hmac.compare_digest(profile["continuity_token"] or "", activation["continuity_token"])
         ):
-            raise ValueError("personal_context_activation_required")
+            raise PersonalContextActivationStaleError("personal_context_activation_required")
 
     def validate_activation_exchange(
         self,
@@ -1877,7 +1911,7 @@ class PersonalContextRepository:
                 continuity_token=continuity_token,
             )
         except (TypeError, ValueError):
-            raise ValueError("personal_context_activation_required") from None
+            raise PersonalContextActivationInputError("personal_context_activation_required") from None
         with self._database.transaction() as connection:
             row = connection.execute(
                 """SELECT a.* FROM personal_context_activations a
@@ -1890,13 +1924,13 @@ class PersonalContextRepository:
                 (profile_id, device_id, dataset_id),
             ).fetchone()
             if row is None:
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationMissingError("personal_context_activation_required")
             self._activation_current_pair(connection, row)
             if not (
                 hmac.compare_digest(row["activation_epoch"], supplied.activation_epoch)
                 and hmac.compare_digest(row["continuity_token"], supplied.continuity_token)
             ):
-                raise ValueError("personal_context_activation_required")
+                raise PersonalContextActivationStaleError("personal_context_activation_required")
         return supplied
 
     def has_sync_profile_reservation(self) -> bool:

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -9,7 +9,8 @@ import secrets
 import sqlite3
 import time
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, TypeVar
@@ -43,9 +44,11 @@ from tldw_Server_API.app.core.Personalization.personal_context_publication impor
     PersonalContextPublicationJournal,
     PublicationBatchReceipt,
     PublicationObject,
+    PublicationRelayLease,
 )
 from tldw_Server_API.app.core.Personalization.personal_context_repository_models import (
     ConcurrentProfileUpdateError,
+    PreparedPersonalContextActivation,
     ProfileAlreadyExistsError,
     ProfileIntegrityError,
     ProfileKeyMaterial,
@@ -53,6 +56,9 @@ from tldw_Server_API.app.core.Personalization.personal_context_repository_models
     ProfileSemanticKeyCollisionError,
     ProfileStorageLockedError,
     ProfileUnsupportedSchemaError,
+)
+from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import (
+    PersonalContextExchangeProof,
 )
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
@@ -66,6 +72,7 @@ _SYNC_HISTORY_KEY_LABEL = b"tldw-personal-context-sync-history-v1"
 _DIRECT_CONFIRMED_FULL_PROFILE_PURGE = object()
 _DIRECT_PURGE_CLEANUP_ORIGIN = "direct_confirmed_full_profile_purge"
 _DIRECT_PURGE_CLAIM_SECONDS = 60
+_ACTIVATION_LEASE_SECONDS = 60
 _VERIFIED_DIRECT_PURGE_EXECUTION = object()
 _DIRECT_PURGE_CAPABILITY_SIGNING_KEY = secrets.token_bytes(32)
 
@@ -1359,6 +1366,539 @@ class PersonalContextRepository:
                 journal.transition_row_state(connection, row, row_state="staged")
             return len(superseded)
 
+    @staticmethod
+    def _activation_aad(row: Mapping[str, Any] | sqlite3.Row) -> bytes:
+        """Bind an encrypted baseline to its immutable journal identity."""
+        return canonical_json_bytes(
+            {
+                "purpose": "personal-context-activation-v1",
+                **{
+                    name: row[name]
+                    for name in (
+                        "profile_id",
+                        "device_id",
+                        "activation_id",
+                        "baseline_digest",
+                        "purge_generation",
+                        "publication_watermark",
+                    )
+                },
+            }
+        )
+
+    @staticmethod
+    def _require_activation_lease(
+        connection: sqlite3.Connection,
+        profile_id: str,
+        lease: PublicationRelayLease | None,
+    ) -> None:
+        """Fence activation with the current owner and bound its larger snapshot work."""
+        if (
+            lease is None
+            or lease.profile_id != profile_id
+            or connection.execute(
+                """SELECT 1 FROM personal_context_publication_relay_leases
+               WHERE profile_id = ? AND owner_token = ? AND expires_at_ns > ?""",
+                (profile_id, lease.owner_token, time.time_ns()),
+            ).fetchone()
+            is None
+        ):
+            raise ValueError("personal_context_activation_required")
+        connection.execute(
+            """UPDATE personal_context_publication_relay_leases SET expires_at_ns = ?
+               WHERE profile_id = ? AND owner_token = ?""",
+            (time.time_ns() + _ACTIVATION_LEASE_SECONDS * 1_000_000_000, profile_id, lease.owner_token),
+        )
+
+    def _decode_activation(
+        self,
+        connection: sqlite3.Connection,
+        row: sqlite3.Row,
+    ) -> PreparedPersonalContextActivation:
+        """Authenticate an exact journal snapshot before returning plaintext."""
+        if row["state"] == "expired":
+            raise ValueError("personal_context_activation_required")
+        keys = self._keys.load(str(row["profile_id"]), connection=connection)
+        baseline = EnvelopeCipher(keys.encryption_key, key_version=keys.key_version).decrypt(
+            EncryptedEnvelope(
+                **{
+                    name: row[name]
+                    for name in (
+                        "algorithm",
+                        "key_version",
+                        "nonce",
+                        "wrapped_dek",
+                        "wrapped_dek_nonce",
+                        "ciphertext",
+                    )
+                }
+            ),
+            self._activation_aad(row),
+        )
+        if not hmac.compare_digest(hashlib.sha256(baseline).hexdigest(), row["baseline_digest"]):
+            raise ProfileIntegrityError("Personal Context activation integrity failed")
+        return PreparedPersonalContextActivation(
+            **{
+                name: row[name]
+                for name in (
+                    "profile_id",
+                    "device_id",
+                    "activation_id",
+                    "baseline_digest",
+                    "purge_generation",
+                    "publication_watermark",
+                    "state",
+                    "sync_receipt_id",
+                    "home_server_cursor",
+                    "activation_epoch",
+                    "continuity_token",
+                )
+            },
+            baseline=baseline,
+        )
+
+    def load_activation(self, activation_id: str) -> PreparedPersonalContextActivation:
+        """Read and authenticate a durable baseline after a process restart."""
+        with self._database.transaction() as connection:
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError("personal_context_activation_required")
+            return self._decode_activation(connection, row)
+
+    def prepare_activation(
+        self,
+        profile_id: str,
+        *,
+        device_id: str,
+        lease: PublicationRelayLease | None,
+        fresh: bool = False,
+    ) -> PreparedPersonalContextActivation:
+        """Commit one device's exact eligible heads and whole-batch watermark."""
+        if not device_id or len(device_id) > 128:
+            raise ValueError("personal_context_activation_required")
+        with self._database.transaction(immediate=True) as connection:
+            self._require_activation_lease(connection, profile_id, lease)
+            manifest, scopes, records, proposals, _key_id, _key = self.sync_bootstrap_snapshot(
+                profile_id,
+                connection=connection,
+            )
+            row = connection.execute(
+                """SELECT * FROM personal_context_activations
+                   WHERE profile_id = ? AND device_id = ? AND purge_generation = ?
+                   ORDER BY rowid DESC LIMIT 1""",
+                (profile_id, device_id, manifest.purge_generation),
+            ).fetchone()
+            if row is not None and row["state"] != "expired":
+                previous = self._decode_activation(connection, row)
+                if row["state"] == "prepared":
+                    return previous
+                try:
+                    self._activation_current_pair(connection, row)
+                except ValueError:
+                    pass  # A broken continuity proof requires a new exact-head baseline.
+                else:
+                    if row["state"] == "installed" or not fresh:
+                        return previous
+            if (
+                connection.execute(
+                    """SELECT 1 FROM personal_context_activations
+                   WHERE profile_id = ? AND purge_generation = ? AND state = 'prepared' LIMIT 1""",
+                    (profile_id, manifest.purge_generation),
+                ).fetchone()
+                is not None
+            ):
+                raise ValueError("personal_context_activation_pending")
+            if (
+                connection.execute(
+                    """SELECT 1 FROM personal_context_activations a
+                   WHERE a.profile_id = ? AND a.purge_generation = ? AND a.home_server_cursor IS NOT NULL
+                     AND EXISTS (SELECT 1 FROM personal_context_publication_batches b
+                       WHERE b.profile_id = a.profile_id
+                         AND b.status NOT IN ('complete','covered_by_activation','purge_terminal'))
+                   LIMIT 1""",
+                    (profile_id, manifest.purge_generation),
+                ).fetchone()
+                is not None
+            ):
+                raise ValueError("personal_context_activation_pending")
+            profile = connection.execute(
+                "SELECT * FROM personal_context_publication_profiles WHERE profile_id = ?",
+                (profile_id,),
+            ).fetchone()
+            watermark = 0 if profile is None else int(profile["next_sequence"]) - 1
+            if (
+                watermark
+                and connection.execute(
+                    """SELECT 1 FROM personal_context_publication_batches b
+                   WHERE b.profile_id = ? AND b.profile_publication_sequence = ?
+                     AND b.batch_size = (SELECT COUNT(*) FROM personal_context_publication_rows r
+                       WHERE r.profile_id = b.profile_id
+                         AND r.profile_publication_sequence = b.profile_publication_sequence)""",
+                    (profile_id, watermark),
+                ).fetchone()
+                is None
+            ):
+                raise ProfileIntegrityError("Personal Context activation watermark is invalid")
+            baseline = canonical_json_bytes(
+                {
+                    "manifest": manifest.model_dump(mode="json"),
+                    "scopes": [item.model_dump(mode="json") for item in scopes],
+                    "records": [
+                        item.model_dump(mode="json") for item in records if item.controls.sync_mode is SyncMode.SYNCABLE
+                    ],
+                    "proposals": [
+                        item.model_dump(mode="json")
+                        for item in proposals
+                        if item.proposed_record is None or item.proposed_record.controls.sync_mode is SyncMode.SYNCABLE
+                    ],
+                }
+            )
+            identity = {
+                "profile_id": profile_id,
+                "device_id": device_id,
+                "activation_id": str(uuid.uuid4()),
+                "baseline_digest": hashlib.sha256(baseline).hexdigest(),
+                "purge_generation": manifest.purge_generation,
+                "publication_watermark": watermark,
+            }
+            keys = self._keys.load(profile_id, connection=connection)
+            envelope = EnvelopeCipher(keys.encryption_key, key_version=keys.key_version).encrypt(
+                baseline,
+                self._activation_aad(identity),
+            )
+            now = _now_text()
+            connection.execute(
+                """INSERT INTO personal_context_activations (
+                   profile_id, device_id, activation_id, baseline_digest, purge_generation,
+                   publication_watermark, state, algorithm, key_version, nonce, wrapped_dek,
+                   wrapped_dek_nonce, ciphertext, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, 'prepared', ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    *identity.values(),
+                    envelope.algorithm,
+                    envelope.key_version,
+                    envelope.nonce,
+                    envelope.wrapped_dek,
+                    envelope.wrapped_dek_nonce,
+                    envelope.ciphertext,
+                    now,
+                    now,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (identity["activation_id"],),
+            ).fetchone()
+            return self._decode_activation(connection, row)
+
+    @contextmanager
+    def activation_install_guard(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        *,
+        lease: PublicationRelayLease | None,
+    ) -> Iterator[PreparedPersonalContextActivation]:
+        """Hold canonical generation and lease stable through the independent Sync commit."""
+        with self._database.transaction(immediate=True) as connection:
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if row is None or not hmac.compare_digest(row["baseline_digest"], baseline_digest):
+                raise ValueError("personal_context_activation_required")
+            self._require_activation_lease(connection, row["profile_id"], lease)
+            keys = self._keys.load(row["profile_id"], connection=connection)
+            manifest = self._current_manifest_for_publication(connection, row["profile_id"], keys)
+            if manifest.purge_generation != row["purge_generation"]:
+                raise ValueError("personal_context_activation_required")
+            yield self._decode_activation(connection, row)
+
+    def complete_activation_install(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        sync_receipt_id: str,
+        *,
+        home_server_cursor: int,
+        lease: PublicationRelayLease | None,
+    ) -> PreparedPersonalContextActivation:
+        """CAS verified Sync installation, source coverage, and continuity in one commit."""
+        if not sync_receipt_id or type(home_server_cursor) is not int or home_server_cursor < 0:
+            raise ValueError("personal_context_activation_required")
+        with self._database.transaction(immediate=True) as connection:
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if row is None or not hmac.compare_digest(row["baseline_digest"], baseline_digest):
+                raise ValueError("personal_context_activation_required")
+            activation = self._decode_activation(connection, row)
+            self._require_activation_lease(connection, activation.profile_id, lease)
+            profile = connection.execute(
+                "SELECT * FROM personal_context_publication_profiles WHERE profile_id = ?",
+                (activation.profile_id,),
+            ).fetchone()
+            keys = self._keys.load(activation.profile_id, connection=connection)
+            manifest = self._current_manifest_for_publication(connection, activation.profile_id, keys)
+            if manifest.purge_generation != activation.purge_generation:
+                raise ValueError("personal_context_activation_required")
+            if row["state"] != "prepared":
+                if row["sync_receipt_id"] != sync_receipt_id or row["home_server_cursor"] != home_server_cursor:
+                    raise ValueError("personal_context_activation_required")
+                self._activation_current_pair(connection, row)
+                return self._decode_activation(connection, row)
+            epoch = profile["activation_epoch"] if profile else None
+            token = profile["continuity_token"] if profile else None
+            if not epoch or not token:
+                epoch, token = secrets.token_urlsafe(32), secrets.token_urlsafe(32)
+            now = _now_text()
+            connection.execute(
+                """INSERT INTO personal_context_publication_profiles (
+                   profile_id, next_sequence, activation_covered_through_sequence,
+                   purge_generation, activation_epoch, continuity_token, updated_at)
+                   VALUES (?, 1, ?, ?, ?, ?, ?)
+                   ON CONFLICT(profile_id) DO UPDATE SET
+                   activation_covered_through_sequence = MAX(activation_covered_through_sequence, excluded.activation_covered_through_sequence),
+                   activation_epoch = excluded.activation_epoch, continuity_token = excluded.continuity_token,
+                   updated_at = excluded.updated_at""",
+                (
+                    activation.profile_id,
+                    activation.publication_watermark,
+                    activation.purge_generation,
+                    epoch,
+                    token,
+                    now,
+                ),
+            )
+            connection.execute(
+                """UPDATE personal_context_publication_batches SET status = 'covered_by_activation',
+                   activation_id = ?, baseline_digest = ?, sync_receipt_id = ?, updated_at = ?
+                   WHERE profile_id = ? AND profile_publication_sequence <= ?
+                     AND status NOT IN ('complete','covered_by_activation','purge_terminal')""",
+                (
+                    activation_id,
+                    baseline_digest,
+                    sync_receipt_id,
+                    now,
+                    activation.profile_id,
+                    activation.publication_watermark,
+                ),
+            )
+            connection.execute(
+                """UPDATE personal_context_activations SET state = 'installed', sync_receipt_id = ?,
+                   home_server_cursor = ?, activation_epoch = ?, continuity_token = ?, updated_at = ?
+                   WHERE activation_id = ? AND state = 'prepared' AND baseline_digest = ?""",
+                (sync_receipt_id, home_server_cursor, epoch, token, now, activation_id, baseline_digest),
+            )
+            return self._decode_activation(
+                connection,
+                connection.execute(
+                    "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                    (activation_id,),
+                ).fetchone(),
+            )
+
+    def expire_activation(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        *,
+        sync_receipt_id: str,
+        lease: PublicationRelayLease | None,
+    ) -> None:
+        """Retire only one device baseline after the exact Sync installation expires.
+
+        The Sync owner verifies its receipt and expiry before calling. Source
+        coverage and the shared continuity pair survive this per-device change.
+        """
+        if not sync_receipt_id or len(sync_receipt_id) > 128:
+            raise ValueError("personal_context_activation_required")
+        with self._database.transaction(immediate=True) as connection:
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if (
+                row is None
+                or not hmac.compare_digest(row["baseline_digest"], baseline_digest)
+                or row["sync_receipt_id"] not in (None, sync_receipt_id)
+            ):
+                raise ValueError("personal_context_activation_required")
+            self._require_activation_lease(connection, row["profile_id"], lease)
+            if row["state"] == "expired":
+                return
+            self._decode_activation(connection, row)
+            connection.execute(
+                "DELETE FROM personal_context_activation_devices WHERE activation_id = ? AND device_id = ?",
+                (activation_id, row["device_id"]),
+            )
+            connection.execute(
+                """UPDATE personal_context_activations SET state = 'expired', sync_receipt_id = ?,
+                   activation_epoch = NULL, continuity_token = NULL, ciphertext = ?, wrapped_dek = ?,
+                   wrapped_dek_nonce = ?, nonce = ?, updated_at = ? WHERE activation_id = ?""",
+                (sync_receipt_id, b"", b"", b"", b"", _now_text(), activation_id),
+            )
+
+    def compact_activation(self, activation_id: str) -> int:
+        """Erase covered source ciphertext only after its content-free proof commits."""
+        with self._database.transaction(immediate=True) as connection:
+            activation = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if activation is None or activation["state"] == "prepared" or not activation["sync_receipt_id"]:
+                raise ValueError("personal_context_activation_required")
+            return connection.execute(
+                """UPDATE personal_context_publication_rows SET ciphertext = ?, wrapped_dek = ?,
+                   wrapped_dek_nonce = ?, nonce = ?, row_state = 'shredded'
+                   WHERE profile_id = ? AND profile_publication_sequence IN (
+                     SELECT profile_publication_sequence FROM personal_context_publication_batches
+                     WHERE profile_id = ? AND activation_id = ? AND baseline_digest = ?
+                       AND sync_receipt_id = ? AND status = 'covered_by_activation')
+                     AND profile_publication_sequence <= (
+                       SELECT activation_covered_through_sequence FROM personal_context_publication_profiles
+                       WHERE profile_id = ?) AND row_state != 'shredded'""",
+                (
+                    b"",
+                    b"",
+                    b"",
+                    b"",
+                    activation["profile_id"],
+                    activation["profile_id"],
+                    activation_id,
+                    activation["baseline_digest"],
+                    activation["sync_receipt_id"],
+                    activation["profile_id"],
+                ),
+            ).rowcount
+
+    def confirm_activation_device(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        device_id: str,
+        sync_ack_receipt_id: str,
+        *,
+        local_receipt_id: str,
+        dataset_id: str,
+    ) -> PreparedPersonalContextActivation:
+        """Record the exact verified independent Sync acknowledgment idempotently."""
+        if any(
+            not value or len(value) > 128
+            for value in (
+                sync_ack_receipt_id,
+                local_receipt_id,
+                dataset_id,
+                device_id,
+            )
+        ):
+            raise ValueError("personal_context_activation_required")
+        with self._database.transaction(immediate=True) as connection:
+            row = connection.execute(
+                "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+            ).fetchone()
+            if (
+                row is None
+                or row["device_id"] != device_id
+                or row["state"] == "prepared"
+                or not hmac.compare_digest(row["baseline_digest"], baseline_digest)
+            ):
+                raise ValueError("personal_context_activation_required")
+            self._activation_current_pair(connection, row)
+            expected = (baseline_digest, local_receipt_id, sync_ack_receipt_id, dataset_id)
+            receipt = connection.execute(
+                """SELECT baseline_digest, local_receipt_id, sync_ack_receipt_id, dataset_id
+                   FROM personal_context_activation_devices WHERE activation_id = ? AND device_id = ?""",
+                (activation_id, device_id),
+            ).fetchone()
+            if receipt is not None and tuple(receipt) != expected:
+                raise ValueError("personal_context_activation_required")
+            connection.execute(
+                """INSERT INTO personal_context_activation_devices (
+                   activation_id, device_id, baseline_digest, local_receipt_id,
+                   sync_ack_receipt_id, dataset_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(activation_id, device_id) DO NOTHING""",
+                (activation_id, device_id, *expected, _now_text()),
+            )
+            connection.execute(
+                "UPDATE personal_context_activations SET state = 'active', updated_at = ? WHERE activation_id = ?",
+                (_now_text(), activation_id),
+            )
+            return self._decode_activation(
+                connection,
+                connection.execute(
+                    "SELECT * FROM personal_context_activations WHERE activation_id = ?",
+                    (activation_id,),
+                ).fetchone(),
+            )
+
+    def _activation_current_pair(
+        self,
+        connection: sqlite3.Connection,
+        activation: sqlite3.Row,
+    ) -> None:
+        """Reject a stored baseline after generation or publication continuity changes."""
+        profile = connection.execute(
+            "SELECT * FROM personal_context_publication_profiles WHERE profile_id = ?",
+            (activation["profile_id"],),
+        ).fetchone()
+        keys = self._keys.load(activation["profile_id"], connection=connection)
+        manifest = self._current_manifest_for_publication(connection, activation["profile_id"], keys)
+        if (
+            profile is None
+            or manifest.purge_generation != activation["purge_generation"]
+            or profile["purge_generation"] != activation["purge_generation"]
+            or not activation["activation_epoch"]
+            or not activation["continuity_token"]
+            or not hmac.compare_digest(profile["activation_epoch"] or "", activation["activation_epoch"])
+            or not hmac.compare_digest(profile["continuity_token"] or "", activation["continuity_token"])
+        ):
+            raise ValueError("personal_context_activation_required")
+
+    def validate_activation_exchange(
+        self,
+        *,
+        profile_id: str,
+        device_id: str,
+        dataset_id: str,
+        activation_epoch: str,
+        continuity_token: str,
+    ) -> PersonalContextExchangeProof:
+        """Return the canonical proof only for an acknowledged current device baseline."""
+        try:
+            supplied = PersonalContextExchangeProof(
+                ongoing_sync_version=1,
+                activation_epoch=activation_epoch,
+                continuity_token=continuity_token,
+            )
+        except (TypeError, ValueError):
+            raise ValueError("personal_context_activation_required") from None
+        with self._database.transaction() as connection:
+            row = connection.execute(
+                """SELECT a.* FROM personal_context_activations a
+                   JOIN personal_context_activation_devices d ON d.activation_id = a.activation_id
+                     AND d.device_id = a.device_id AND d.baseline_digest = a.baseline_digest
+                   WHERE a.profile_id = ? AND a.device_id = ? AND d.dataset_id = ? AND a.state = 'active'
+                     AND a.rowid = (SELECT MAX(latest.rowid) FROM personal_context_activations latest
+                       WHERE latest.profile_id = a.profile_id AND latest.device_id = a.device_id)
+                   ORDER BY a.rowid DESC LIMIT 1""",
+                (profile_id, device_id, dataset_id),
+            ).fetchone()
+            if row is None:
+                raise ValueError("personal_context_activation_required")
+            self._activation_current_pair(connection, row)
+            if not (
+                hmac.compare_digest(row["activation_epoch"], supplied.activation_epoch)
+                and hmac.compare_digest(row["continuity_token"], supplied.continuity_token)
+            ):
+                raise ValueError("personal_context_activation_required")
+        return supplied
+
     def has_sync_profile_reservation(self) -> bool:
         """Return whether the only durable state is one content-free key reservation."""
 
@@ -1502,7 +2042,7 @@ class PersonalContextRepository:
             raise ProfileIntegrityError("Canonical object validation failed") from None
 
     def sync_bootstrap_snapshot(
-        self, profile_id: str
+        self, profile_id: str, *, connection: sqlite3.Connection | None = None
     ) -> tuple[
         ProfileManifest,
         tuple[ProfileScope, ...],
@@ -1513,7 +2053,7 @@ class PersonalContextRepository:
     ]:
         """Read all bounded canonical Sync heads and key identity in one transaction."""
 
-        with self._database.transaction() as connection:
+        with (self._database.transaction() if connection is None else nullcontext(connection)) as connection:
             keys = self._keys.load(profile_id, connection=connection)
             manifest_row = self._head_row(connection, profile_id, "manifest", profile_id)
             if manifest_row is None:
@@ -2814,6 +3354,16 @@ class PersonalContextRepository:
                 "DELETE FROM personal_context_receipts WHERE profile_id = ?",
                 (manifest.profile_id,),
             )
+            connection.execute(
+                """DELETE FROM personal_context_activation_devices WHERE activation_id IN (
+                   SELECT activation_id FROM personal_context_activations
+                   WHERE profile_id = ? AND purge_generation < ?)""",
+                (manifest.profile_id, manifest.purge_generation),
+            )
+            connection.execute(
+                "DELETE FROM personal_context_activations WHERE profile_id = ? AND purge_generation < ?",
+                (manifest.profile_id, manifest.purge_generation),
+            )
 
     @staticmethod
     def _direct_purge_cleanup_intent(row: sqlite3.Row) -> DirectPurgeCleanupIntent:
@@ -3279,6 +3829,20 @@ class PersonalContextRepository:
                     raise ConcurrentProfileUpdateError(
                         "encrypted publication changed concurrently"
                     )
+            for row in connection.execute(
+                "SELECT * FROM personal_context_activations WHERE profile_id = ? AND state != 'expired'", (profile_id,),
+            ).fetchall():
+                rewrapped = cipher.rewrap(
+                    EncryptedEnvelope(**{name: row[name] for name in (
+                        "algorithm", "key_version", "nonce", "wrapped_dek", "wrapped_dek_nonce", "ciphertext",
+                    )}), self._activation_aad(row), new_encryption_key, new_key_version=new_key_version,
+                )
+                connection.execute(
+                    """UPDATE personal_context_activations
+                       SET wrapped_dek = ?, wrapped_dek_nonce = ?, key_version = ?
+                       WHERE activation_id = ?""",
+                    (rewrapped.wrapped_dek, rewrapped.wrapped_dek_nonce, rewrapped.key_version, row["activation_id"]),
+                )
             return self._keys.replace_encryption_key(
                 profile_id,
                 encryption_key=new_encryption_key,

--- a/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
@@ -298,6 +298,40 @@ class PersonalizationDB:
                         expires_at_ns INTEGER NOT NULL
                     );
 
+                    CREATE TABLE IF NOT EXISTS personal_context_activations (
+                        activation_id TEXT PRIMARY KEY,
+                        profile_id TEXT NOT NULL,
+                        device_id TEXT NOT NULL,
+                        baseline_digest TEXT NOT NULL,
+                        purge_generation INTEGER NOT NULL CHECK (purge_generation >= 0),
+                        publication_watermark INTEGER NOT NULL CHECK (publication_watermark >= 0),
+                        state TEXT NOT NULL CHECK (state IN ('prepared','installed','active','expired')),
+                        sync_receipt_id TEXT,
+                        home_server_cursor INTEGER,
+                        activation_epoch TEXT,
+                        continuity_token TEXT,
+                        algorithm TEXT NOT NULL,
+                        key_version INTEGER NOT NULL,
+                        nonce BLOB NOT NULL,
+                        wrapped_dek BLOB NOT NULL,
+                        wrapped_dek_nonce BLOB NOT NULL,
+                        ciphertext BLOB NOT NULL,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_personal_context_activation_device
+                        ON personal_context_activations(profile_id, device_id, created_at);
+                    CREATE TABLE IF NOT EXISTS personal_context_activation_devices (
+                        activation_id TEXT NOT NULL,
+                        device_id TEXT NOT NULL,
+                        dataset_id TEXT NOT NULL,
+                        baseline_digest TEXT NOT NULL,
+                        local_receipt_id TEXT NOT NULL,
+                        sync_ack_receipt_id TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        PRIMARY KEY (activation_id, device_id)
+                    );
+
                     CREATE TABLE IF NOT EXISTS personal_context_publication_relay_attention (
                         profile_id TEXT NOT NULL,
                         profile_publication_sequence INTEGER NOT NULL,

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -380,6 +380,30 @@ CREATE TABLE IF NOT EXISTS sync_personal_context_link_receipts (
     PRIMARY KEY (user_id, dataset_id, device_id)
 );
 
+CREATE TABLE IF NOT EXISTS sync_personal_context_activations (
+    activation_id TEXT PRIMARY KEY,
+    dataset_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    profile_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    baseline_digest TEXT NOT NULL,
+    purge_generation BIGINT NOT NULL,
+    publication_watermark BIGINT NOT NULL,
+    home_server_cursor BIGINT NOT NULL,
+    receipt_id TEXT NOT NULL,
+    envelopes_json TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sync_personal_context_activation_profile
+    ON sync_personal_context_activations(user_id, profile_id);
+CREATE TABLE IF NOT EXISTS sync_personal_context_activation_acks (
+    activation_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    local_receipt_id TEXT NOT NULL,
+    receipt_id TEXT NOT NULL,
+    PRIMARY KEY (activation_id, device_id)
+);
+
 CREATE TABLE IF NOT EXISTS sync_domain_state (
     dataset_id TEXT NOT NULL,
     domain TEXT NOT NULL,
@@ -989,6 +1013,30 @@ CREATE TABLE IF NOT EXISTS sync_personal_context_link_receipts (
     purge_generation INTEGER NOT NULL,
     bootstrap_cursor TEXT NOT NULL,
     PRIMARY KEY (user_id, dataset_id, device_id)
+);
+
+CREATE TABLE IF NOT EXISTS sync_personal_context_activations (
+    activation_id TEXT PRIMARY KEY,
+    dataset_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    profile_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    baseline_digest TEXT NOT NULL,
+    purge_generation BIGINT NOT NULL,
+    publication_watermark BIGINT NOT NULL,
+    home_server_cursor BIGINT NOT NULL,
+    receipt_id TEXT NOT NULL,
+    envelopes_json TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sync_personal_context_activation_profile
+    ON sync_personal_context_activations(user_id, profile_id);
+CREATE TABLE IF NOT EXISTS sync_personal_context_activation_acks (
+    activation_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    local_receipt_id TEXT NOT NULL,
+    receipt_id TEXT NOT NULL,
+    PRIMARY KEY (activation_id, device_id)
 );
 
 CREATE TABLE IF NOT EXISTS sync_domain_state (
@@ -3955,6 +4003,183 @@ class SyncDatabase:
                 ),
                 connection=connection,
             )
+
+    def mirror_personal_context_activation(
+        self,
+        *,
+        dataset_id: str,
+        user_id: str,
+        profile_id: str,
+        purge_generation: int,
+        activation_epoch: str,
+        continuity_token: str,
+        connection: Any,
+    ) -> None:
+        """Mirror installed canonical continuity without enabling the rollout gate."""
+
+        if connection is None:
+            raise SyncStoreError("personal_context_activation_guard_required")
+        row = self._require_dataset_owner_for_update(dataset_id, user_id, connection=connection)
+        metadata = decode_json(row.get("metadata_json"), default={})
+        state = metadata.get("personal_context")
+        if not isinstance(state, dict) or any(
+            state.get(key) != value
+            for key, value in {
+                "profile_id": profile_id,
+                "purge_generation": purge_generation,
+                "link_state": "complete",
+            }.items()
+        ):
+            raise SyncStoreError("personal_context_activation_required")
+        state.update(activation_epoch=activation_epoch, continuity_token=continuity_token)
+        changed = self.execute(
+            """UPDATE sync_datasets SET metadata_json = ?, updated_at = ?
+               WHERE dataset_id = ? AND owner_user_id = ? AND metadata_json = ?""",
+            (encode_json(metadata, default={}), utcnow_iso(), dataset_id, user_id, row["metadata_json"]),
+            connection=connection,
+        )
+        if changed.rowcount != 1:
+            raise SyncStoreError("personal_context_activation_required")
+
+    def get_personal_context_activation(
+        self,
+        activation_id: str,
+        *,
+        connection: Any | None = None,
+    ) -> dict[str, Any] | None:
+        """Read one immutable encrypted baseline and its installation receipt."""
+
+        return _first(
+            self.execute(
+                "SELECT * FROM sync_personal_context_activations WHERE activation_id = ?",
+                (activation_id,),
+                connection=connection,
+            )
+        )
+
+    def install_personal_context_activation(
+        self,
+        *,
+        activation_id: str,
+        dataset_id: str,
+        user_id: str,
+        profile_id: str,
+        device_id: str,
+        baseline_digest: str,
+        purge_generation: int,
+        publication_watermark: int,
+        home_server_cursor: int,
+        receipt_id: str,
+        envelopes_json: str,
+        expires_at: str,
+        connection: Any,
+    ) -> dict[str, Any]:
+        """Install once under the caller's Sync and canonical source guards.
+
+        The application verifies encrypted envelope identity and canonical custody;
+        this boundary rejects every changed replay instead of replacing ciphertext.
+        """
+
+        if connection is None:
+            raise SyncStoreError("personal_context_activation_guard_required")
+        desired = {
+            "activation_id": activation_id,
+            "dataset_id": dataset_id,
+            "user_id": user_id,
+            "profile_id": profile_id,
+            "device_id": device_id,
+            "baseline_digest": baseline_digest,
+            "purge_generation": purge_generation,
+            "publication_watermark": publication_watermark,
+            "home_server_cursor": home_server_cursor,
+            "receipt_id": receipt_id,
+            "envelopes_json": envelopes_json,
+            "expires_at": expires_at,
+        }
+        self.execute(
+            """INSERT INTO sync_personal_context_activations
+               (activation_id, dataset_id, user_id, profile_id, device_id, baseline_digest,
+                purge_generation, publication_watermark, home_server_cursor, receipt_id,
+                envelopes_json, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(activation_id) DO NOTHING""",
+            tuple(desired.values()),
+            connection=connection,
+        )
+        stored = self.get_personal_context_activation(activation_id, connection=connection)
+        if stored is None or any(stored.get(key) != value for key, value in desired.items()):
+            raise SyncStoreError("personal_context_activation_receipt_mismatch")
+        return stored
+
+    def acknowledge_personal_context_activation(
+        self,
+        *,
+        activation_id: str,
+        dataset_id: str,
+        user_id: str,
+        device_id: str,
+        baseline_digest: str,
+        local_receipt_id: str,
+        connection: Any,
+    ) -> dict[str, Any]:
+        """Persist an exact device install acknowledgment without mutable replay."""
+
+        if connection is None:
+            raise SyncStoreError("personal_context_activation_guard_required")
+        activation = self.get_personal_context_activation(activation_id, connection=connection)
+        if activation is None or any(
+            activation.get(key) != value
+            for key, value in {
+                "dataset_id": dataset_id,
+                "user_id": user_id,
+                "device_id": device_id,
+                "baseline_digest": baseline_digest,
+            }.items()
+        ):
+            raise SyncStoreError("personal_context_activation_receipt_mismatch")
+        receipt_id = hashlib.sha256(
+            encode_json(
+                [activation_id, dataset_id, user_id, device_id, baseline_digest, local_receipt_id],
+                default=[],
+            ).encode()
+        ).hexdigest()
+        self.execute(
+            """INSERT INTO sync_personal_context_activation_acks
+               (activation_id, device_id, local_receipt_id, receipt_id)
+               VALUES (?, ?, ?, ?) ON CONFLICT(activation_id, device_id) DO NOTHING""",
+            (activation_id, device_id, local_receipt_id, receipt_id),
+            connection=connection,
+        )
+        stored = self.get_personal_context_activation_ack(
+            activation_id,
+            device_id,
+            connection=connection,
+        )
+        if (
+            stored is None
+            or stored.get("local_receipt_id") != local_receipt_id
+            or stored.get("receipt_id") != receipt_id
+        ):
+            raise SyncStoreError("personal_context_activation_receipt_mismatch")
+        return stored
+
+    def get_personal_context_activation_ack(
+        self,
+        activation_id: str,
+        device_id: str,
+        *,
+        connection: Any | None = None,
+    ) -> dict[str, Any] | None:
+        """Read the content-free acknowledgment retained for an ordinary device."""
+
+        return _first(
+            self.execute(
+                """SELECT * FROM sync_personal_context_activation_acks
+               WHERE activation_id = ? AND device_id = ?""",
+                (activation_id, device_id),
+                connection=connection,
+            )
+        )
 
     def has_personal_context_link_receipt(
         self,
@@ -8803,6 +9028,24 @@ class SyncDatabase:
             ):
                 raise SyncStoreError("Personal Context cleanup generation is invalid")
 
+            self.execute(
+                """DELETE FROM sync_personal_context_activation_acks
+                   WHERE activation_id IN (
+                     SELECT activation_id FROM sync_personal_context_activations
+                      WHERE dataset_id = ? AND user_id = ? AND profile_id = ?
+                        AND purge_generation <= ?
+                   )""",
+                (dataset_id, user_id, profile_id, old_generation_through),
+                connection=transaction,
+            )
+            self.execute(
+                """DELETE FROM sync_personal_context_activations
+                   WHERE dataset_id = ? AND user_id = ? AND profile_id = ?
+                     AND purge_generation <= ?""",
+                (dataset_id, user_id, profile_id, old_generation_through),
+                connection=transaction,
+            )
+
             candidate_rows = self.execute(
                 f"""
                 SELECT server_sequence, domain, entity_id, client_envelope_id,
@@ -9299,7 +9542,7 @@ class SyncDatabase:
                 UPDATE sync_envelopes
                    SET apply_status = 'applied', apply_error_code = NULL,
                        apply_error_message = NULL, applied_at = ?
-                 WHERE server_sequence = ? AND apply_status IN ('pending', 'applied')
+                 WHERE server_sequence = ? AND apply_status IN ('pending', 'failed', 'applied')
                 """,
                 (utcnow_iso(), server_cursor),
                 connection=conn,

--- a/tldw_Server_API/app/core/Personalization/personal_context_activation.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_activation.py
@@ -1,0 +1,118 @@
+"""Replayable activation orchestration across independently committed stores."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from tldw_Server_API.app.core.Personalization.personal_context_publication import (
+    PersonalContextPublicationRelayStore,
+)
+from tldw_Server_API.app.core.Personalization.personal_context_repository import (
+    PersonalContextRepository,
+)
+from tldw_Server_API.app.core.Personalization.personal_context_repository_models import (
+    PreparedPersonalContextActivation,
+)
+from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import (
+    PersonalContextExchangeProof,
+)
+
+
+class PersonalContextActivationService:
+    """Keep the shared lease and verified source coverage in one canonical owner."""
+
+    def __init__(self, repository: PersonalContextRepository) -> None:
+        """Use the authenticated user's existing canonical repository."""
+        self.repository = repository
+        self.publications = PersonalContextPublicationRelayStore(repository.database)
+
+    def prepare(
+        self,
+        profile_id: str,
+        *,
+        device_id: str,
+        fresh: bool = False,
+    ) -> PreparedPersonalContextActivation:
+        """Prepare or replay the exact device baseline under the shared relay lease."""
+        with self.publications.profile_lease(profile_id) as lease:
+            return self.repository.prepare_activation(
+                profile_id,
+                device_id=device_id,
+                fresh=fresh,
+                lease=lease,
+            )
+
+    def install(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        *,
+        install: Callable[[PreparedPersonalContextActivation], Mapping[str, Any]],
+        verify: Callable[[PreparedPersonalContextActivation, Mapping[str, Any]], bool],
+    ) -> PreparedPersonalContextActivation:
+        """Commit coverage only after the caller commits and verifies the exact Sync receipt.
+
+        The Sync owner acquires its dataset guard before calling this method.
+        Its install callback commits Sync independently while the canonical
+        generation remains fenced. A later failure leaves preparation replayable.
+        """
+        prepared = self.repository.load_activation(activation_id)
+        with self.publications.profile_lease(prepared.profile_id) as lease:
+            with self.repository.activation_install_guard(
+                activation_id,
+                baseline_digest,
+                lease=lease,
+            ) as current:
+                receipt = install(current)
+                if not verify(current, receipt):
+                    raise ValueError("personal_context_activation_required")
+                receipt_id = receipt.get("receipt_id")
+                home_server_cursor = receipt.get("home_server_cursor")
+                if not isinstance(receipt_id, str) or type(home_server_cursor) is not int:
+                    raise ValueError("personal_context_activation_required")
+            return self.repository.complete_activation_install(
+                activation_id,
+                baseline_digest,
+                receipt_id,
+                home_server_cursor=home_server_cursor,
+                lease=lease,
+            )
+
+    def acknowledge(
+        self,
+        activation_id: str,
+        baseline_digest: str,
+        device_id: str,
+        sync_ack_receipt_id: str,
+        *,
+        local_receipt_id: str,
+        dataset_id: str,
+    ) -> PreparedPersonalContextActivation:
+        """Record a device acknowledgement after its exact Sync receipt is verified."""
+        return self.repository.confirm_activation_device(
+            activation_id,
+            baseline_digest,
+            device_id,
+            sync_ack_receipt_id,
+            local_receipt_id=local_receipt_id,
+            dataset_id=dataset_id,
+        )
+
+    def validate_exchange(
+        self,
+        *,
+        profile_id: str,
+        device_id: str,
+        dataset_id: str,
+        activation_epoch: str,
+        continuity_token: str,
+    ) -> PersonalContextExchangeProof:
+        """Validate current generation and durable device acknowledgement."""
+        return self.repository.validate_activation_exchange(
+            profile_id=profile_id,
+            device_id=device_id,
+            dataset_id=dataset_id,
+            activation_epoch=activation_epoch,
+            continuity_token=continuity_token,
+        )

--- a/tldw_Server_API/app/core/Personalization/personal_context_activation.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_activation.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from contextlib import nullcontext
 from typing import Any
 
+from tldw_Server_API.app.core.exceptions import (
+    PersonalContextActivationInputError,
+    PersonalContextActivationStaleError,
+)
 from tldw_Server_API.app.core.Personalization.personal_context_publication import (
     PersonalContextPublicationRelayStore,
+    PublicationRelayLease,
 )
 from tldw_Server_API.app.core.Personalization.personal_context_repository import (
     PersonalContextRepository,
@@ -50,15 +56,31 @@ class PersonalContextActivationService:
         *,
         install: Callable[[PreparedPersonalContextActivation], Mapping[str, Any]],
         verify: Callable[[PreparedPersonalContextActivation, Mapping[str, Any]], bool],
+        lease: PublicationRelayLease | None = None,
     ) -> PreparedPersonalContextActivation:
         """Commit coverage only after the caller commits and verifies the exact Sync receipt.
 
-        The Sync owner acquires its dataset guard before calling this method.
+        The Sync owner acquires the profile lease before its dataset guard and
+        supplies that lease here, preserving lease -> Sync -> canonical ordering.
         Its install callback commits Sync independently while the canonical
         generation remains fenced. A later failure leaves preparation replayable.
+
+        Args:
+            activation_id: Identifier of the prepared activation.
+            baseline_digest: Expected digest of its exact baseline.
+            install: Callback that commits the baseline and returns its Sync receipt.
+            verify: Callback that verifies the receipt against the preparation.
+            lease: Already owned profile lease, or None to acquire one here.
+
+        Returns:
+            The activation with verified installation coverage recorded.
+
+        Raises:
+            PersonalContextActivationInputError: The receipt is malformed.
+            PersonalContextActivationStaleError: Verification or fencing fails.
         """
         prepared = self.repository.load_activation(activation_id)
-        with self.publications.profile_lease(prepared.profile_id) as lease:
+        with nullcontext(lease) if lease is not None else self.publications.profile_lease(prepared.profile_id) as lease:
             with self.repository.activation_install_guard(
                 activation_id,
                 baseline_digest,
@@ -66,11 +88,11 @@ class PersonalContextActivationService:
             ) as current:
                 receipt = install(current)
                 if not verify(current, receipt):
-                    raise ValueError("personal_context_activation_required")
+                    raise PersonalContextActivationStaleError("personal_context_activation_required")
                 receipt_id = receipt.get("receipt_id")
                 home_server_cursor = receipt.get("home_server_cursor")
                 if not isinstance(receipt_id, str) or type(home_server_cursor) is not int:
-                    raise ValueError("personal_context_activation_required")
+                    raise PersonalContextActivationInputError("personal_context_activation_required")
             return self.repository.complete_activation_install(
                 activation_id,
                 baseline_digest,

--- a/tldw_Server_API/app/core/Personalization/personal_context_publication.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_publication.py
@@ -566,13 +566,30 @@ class PersonalContextPublicationRelayStore:
         )
 
     @contextmanager
-    def profile_lease(self, profile_id: str) -> Iterator[PublicationRelayLease | None]:
-        """Acquire a recoverable SQLite lease shared by every process entry point."""
+    def profile_lease(
+        self, profile_id: str, *, blocking: bool = True
+    ) -> Iterator[PublicationRelayLease | None]:
+        """Claim a recoverable lease, optionally skipping a contended process lock.
+
+        Nonblocking relay callers may already hold Sync. They return no lease
+        before any canonical SQL when another thread owns the profile lock.
+        The durable claim still commits before yielding to external Sync work.
+
+        Args:
+            profile_id: Profile whose publication lease is requested.
+            blocking: Whether to wait for the in-process profile lock.
+
+        Yields:
+            The owned durable lease, or None when either lock is unavailable.
+        """
 
         key = (self._database.db_path, profile_id)
         with self._locks_guard:
             lock = self._profile_locks.setdefault(key, threading.RLock())
-        with lock:
+        if not lock.acquire(blocking=blocking):
+            yield None
+            return
+        try:
             owner_token = uuid.uuid4().hex
             now = time.time_ns()
             with self._database.transaction(immediate=True) as connection:
@@ -620,6 +637,8 @@ class PersonalContextPublicationRelayStore:
                         )
                         if released.rowcount != 1:
                             raise RuntimeError("publication relay lease changed")
+        finally:
+            lock.release()
 
     def renew_lease(self, lease: PublicationRelayLease) -> bool:
         """CAS-renew the current owner before an external stage transition."""

--- a/tldw_Server_API/app/core/Personalization/personal_context_publication.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_publication.py
@@ -25,7 +25,10 @@ from tldw_profile_core import (
 )
 from tldw_profile_core.canonical import canonical_json_bytes
 
-from tldw_Server_API.app.core.exceptions import PublicationRelayPoisoned
+from tldw_Server_API.app.core.exceptions import (
+    PublicationActivationPending,
+    PublicationRelayPoisoned,
+)
 from tldw_Server_API.app.core.Personalization.personal_context_crypto import (
     EncryptedEnvelope,
     EnvelopeAuthenticationError,
@@ -755,6 +758,33 @@ class PersonalContextPublicationRelayStore:
                 ).fetchone()
                 if lease.profile_id != profile_id or owned is None:
                     raise RuntimeError("publication relay lease changed")
+            activation = connection.execute(
+                """SELECT a.activation_id,
+                     a.created_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-60 seconds') AS stale
+                   FROM personal_context_activations a
+                   LEFT JOIN personal_context_publication_profiles p ON p.profile_id = a.profile_id
+                   WHERE a.profile_id = ? AND a.state = 'prepared'
+                     AND (p.profile_id IS NULL OR a.purge_generation = p.purge_generation) LIMIT 1""",
+                (profile_id,),
+            ).fetchone()
+            if activation is not None:
+                if budget is not None and not budget.consume_returned():
+                    raise PublicationActivationPending("Personal Context activation pending")
+                if lease is None or not activation["stale"]:
+                    raise PublicationActivationPending("Personal Context activation pending")
+                # A vanished requester cannot freeze other devices' queued writes.
+                # Retain the terminal ID/digest: an orphan Sync install cannot revive it.
+                connection.execute(
+                    """UPDATE personal_context_activations SET state = 'expired',
+                       ciphertext = ?, wrapped_dek = ?, wrapped_dek_nonce = ?, nonce = ?,
+                       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                       WHERE activation_id = ? AND state = 'prepared'""",
+                    (b"", b"", b"", b"", activation["activation_id"]),
+                )
+                if budget is not None:
+                    if not budget.can_inspect():
+                        return None
+                    row_limit = min(row_limit, budget.remaining_rows)
             batch = connection.execute(
                 """
                 SELECT * FROM personal_context_publication_batches
@@ -1575,10 +1605,13 @@ class PersonalContextPublicationJournal:
         updated = connection.execute(
             """
             UPDATE personal_context_publication_profiles
-            SET next_sequence = ?, purge_generation = ?, updated_at = ?
+            SET next_sequence = ?,
+                activation_epoch = CASE WHEN purge_generation = ? THEN activation_epoch ELSE NULL END,
+                continuity_token = CASE WHEN purge_generation = ? THEN continuity_token ELSE NULL END,
+                purge_generation = ?, updated_at = ?
             WHERE profile_id = ? AND next_sequence = ?
             """,
-            (sequence + 1, purge_generation, now, profile_id, sequence),
+            (sequence + 1, purge_generation, purge_generation, purge_generation, now, profile_id, sequence),
         )
         if updated.rowcount != 1:
             raise RuntimeError("Personal Context publication sequence changed concurrently")

--- a/tldw_Server_API/app/core/Personalization/personal_context_repository_models.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_repository_models.py
@@ -26,12 +26,31 @@ class ProfileKeyMaterial:
     integrity_key_version: int = 1
 
 
+@dataclass(frozen=True, slots=True, repr=False)
+class PreparedPersonalContextActivation:
+    """Authenticated exact-head baseline; decrypted bytes never enter diagnostics."""
+
+    profile_id: str
+    device_id: str
+    activation_id: str
+    baseline_digest: str
+    purge_generation: int
+    publication_watermark: int
+    baseline: bytes
+    state: str
+    sync_receipt_id: str | None
+    home_server_cursor: int | None
+    activation_epoch: str | None
+    continuity_token: str | None
+
+
 __all__ = [
     "ConcurrentProfileUpdateError",
     "ProfileAlreadyExistsError",
     "ProfileIntegrityError",
     "ProfileKeyAlreadyExistsError",
     "ProfileKeyMaterial",
+    "PreparedPersonalContextActivation",
     "ProfileQuotaExceededError",
     "ProfileSemanticKeyCollisionError",
     "ProfileStorageLockedError",

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_activation.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_activation.py
@@ -184,7 +184,28 @@ def prepare_activation(
     required_quotas: Mapping[str, int] | None = None,
     expected_purge_generation: int | None = None,
 ) -> PersonalContextBootstrap:
-    """Prepare, install and verify a linked device baseline without enabling rollout."""
+    """Prepare, install and verify a linked device baseline without enabling rollout.
+
+    Args:
+        service: Authenticated Sync owner providing canonical and transport stores.
+        user_id: Owner of the canonical profile and linked dataset.
+        device_id: Registered device with a current-generation link receipt.
+        required_schema_version: Optional caller schema compatibility requirement.
+        required_quotas: Optional caller quota compatibility requirements.
+        expected_purge_generation: Optional generation that must still be current
+            when the prepared baseline is installed.
+
+    Returns:
+        The exact installed baseline, wrapped integrity key, transport checkpoint,
+        activation receipt and continuity proof; device acknowledgment is separate.
+
+    Raises:
+        SyncStoreError: Access, capability, compatibility, link, generation or
+            protected installation receipt validation fails.
+        PersonalContextActivationError: Canonical preparation or installation
+            rejects invalid input, pending work, missing state or stale proof.
+        PersonalContextError: Canonical profile/key access or integrity fails.
+    """
 
     device = service._require_registered_device(user_id, device_id)
     capability = service.capabilities(user_id=user_id).personal_context
@@ -227,15 +248,19 @@ def prepare_activation(
     prepared = activations.prepare(manifest.profile_id, device_id=device_id)
     identity = _identity(prepared, dataset, user_id)
     cipher = _cipher(service, dataset)
-    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
+    with (
+        activations.publications.profile_lease(prepared.profile_id) as lease,
+        service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded,
+    ):
+        if lease is None:
+            raise SyncStoreError("personal_context_activation_pending")
         stored = guarded.get_personal_context_activation(prepared.activation_id)
         if stored is not None and _expired(stored):
             if not _verify_install(prepared, stored, identity, cipher):
                 raise SyncStoreError("personal_context_activation_receipt_mismatch")
-            with activations.publications.profile_lease(prepared.profile_id) as lease:
-                repository.expire_activation(
-                    prepared.activation_id, prepared.baseline_digest, sync_receipt_id=stored["receipt_id"], lease=lease
-                )
+            repository.expire_activation(
+                prepared.activation_id, prepared.baseline_digest, sync_receipt_id=stored["receipt_id"], lease=lease
+            )
             prepared = None
     if prepared is None:
         if service.personal_context_relay is not None:
@@ -244,11 +269,27 @@ def prepare_activation(
             )
         prepared = activations.prepare(manifest.profile_id, device_id=device_id)
         identity = _identity(prepared, dataset, user_id)
-    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
+    with (
+        activations.publications.profile_lease(prepared.profile_id) as lease,
+        service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded,
+    ):
+        if lease is None:
+            raise SyncStoreError("personal_context_activation_pending")
 
         def install(current: PreparedPersonalContextActivation) -> Mapping[str, Any]:
             """Commit Sync while the verified canonical generation guard remains held."""
 
+            if expected_purge_generation is not None and expected_purge_generation != current.purge_generation:
+                raise SyncStoreError("personal_context_purge_generation_stale")
+            if not guarded.has_personal_context_link_receipt(
+                user_id=user_id,
+                dataset_id=dataset.dataset_id,
+                device_id=device_id,
+                profile_id=current.profile_id,
+                integrity_key_id=integrity_key_id,
+                purge_generation=current.purge_generation,
+            ):
+                raise SyncStoreError("personal_context_activation_required")
             stored = guarded.get_personal_context_activation(current.activation_id)
             if stored is None:
                 history = guarded.get_dataset_envelope_range(dataset.dataset_id)
@@ -274,9 +315,10 @@ def prepare_activation(
             prepared.baseline_digest,
             install=install,
             verify=lambda current, row: _verify_install(current, row, identity, cipher),
+            lease=lease,
         )
-    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
-        with activations.publications.profile_lease(prepared.profile_id) as lease:
+    with activations.publications.profile_lease(prepared.profile_id) as lease:
+        with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
             with repository.activation_install_guard(installed.activation_id, installed.baseline_digest, lease=lease):
                 guarded.mirror_personal_context_activation(
                     dataset_id=dataset.dataset_id,
@@ -370,8 +412,8 @@ def acknowledge_activation(
         or not hmac.compare_digest(current.continuity_token, exchange.continuity_token)
     ):
         raise SyncStoreError("personal_context_activation_required")
-    with service.store.personal_context_authority_guard(dataset_id, prepared.profile_id) as guarded:
-        with activations.publications.profile_lease(prepared.profile_id) as lease:
+    with activations.publications.profile_lease(prepared.profile_id) as lease:
+        with service.store.personal_context_authority_guard(dataset_id, prepared.profile_id) as guarded:
             with repository.activation_install_guard(activation_id, baseline_digest, lease=lease) as live:
                 stored = guarded.get_personal_context_activation(activation_id)
                 if stored is None or not _verify_install(live, stored, identity, cipher):

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_activation.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_activation.py
@@ -1,0 +1,398 @@
+"""Install protected activation baselines through the existing Sync bootstrap path.
+
+Baseline envelopes have a dedicated journal, not ordinary publication ordinals:
+they may contain more than one publication batch or have a zero source watermark.
+The canonical journal owns continuity and coverage; Sync only owns delivery receipts.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import NAMESPACE_URL, uuid5
+
+from tldw_profile_core import ProfileManifest, ProfileProposal, ProfileRecord, ProfileScope
+from tldw_profile_core.canonical import canonical_json_bytes
+
+from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+from tldw_Server_API.app.core.Personalization.personal_context_crypto import EncryptedEnvelope, EnvelopeCipher
+from tldw_Server_API.app.core.Personalization.personal_context_repository_models import (
+    PreparedPersonalContextActivation,
+)
+
+from .errors import SyncStoreError
+from .models import PERSONAL_CONTEXT_SYNC_DOMAINS, SyncDataset
+from .personal_context_ongoing_contract import PersonalContextActivationReceipt, PersonalContextExchangeProof
+from .profile import (
+    _PERSONAL_CONTEXT_BOOTSTRAP_TOKEN_TTL_SECONDS,
+    PersonalContextBootstrap,
+    PersonalContextBootstrapIntegrityKey,
+    _personal_context_bootstrap_quotas,
+    _personal_context_quotas_compatible,
+)
+
+if TYPE_CHECKING:
+    from .service import SyncV2Service
+
+
+def _activation_now() -> datetime:
+    """Use one UTC clock for protected delivery expiration."""
+
+    return datetime.now(timezone.utc)
+
+
+def _expired(row: Mapping[str, Any]) -> bool:
+    """Reject malformed expiry metadata instead of treating it as unlimited."""
+
+    expiry = datetime.fromisoformat(row["expires_at"])
+    if expiry.tzinfo is None:
+        raise SyncStoreError("personal_context_activation_required")
+    return expiry <= _activation_now()
+
+
+def _identity(prepared: PreparedPersonalContextActivation, dataset: SyncDataset, user_id: str) -> dict[str, Any]:
+    """Bind protected baseline bytes to canonical and authenticated transport identity."""
+
+    return {
+        "activation_id": prepared.activation_id,
+        "dataset_id": dataset.dataset_id,
+        "user_id": user_id,
+        "profile_id": prepared.profile_id,
+        "device_id": prepared.device_id,
+        "baseline_digest": prepared.baseline_digest,
+        "purge_generation": prepared.purge_generation,
+        "publication_watermark": prepared.publication_watermark,
+    }
+
+
+def _cipher(service: SyncV2Service, dataset: SyncDataset) -> EnvelopeCipher:
+    """Reuse the same per-profile Sync storage key as ordinary authority envelopes."""
+
+    adapter = service.adapters.get("personal_context.manifest")
+    resolver = getattr(adapter, "encryption_key_resolver", None)
+    if resolver is None:
+        raise SyncStoreError("personal_context_activation_required")
+    key, version = resolver(dataset)
+    return EnvelopeCipher(key, key_version=version)
+
+
+def _protected_baseline(
+    prepared: PreparedPersonalContextActivation, identity: Mapping[str, Any], cipher: EnvelopeCipher
+) -> str:
+    """Encrypt deterministic baseline envelopes; no canonical body enters generic SQL."""
+
+    baseline = json.loads(prepared.baseline)
+    objects = [(kind, value) for kind in ("scopes", "records", "proposals") for value in baseline[kind]]
+    objects.append(("manifest", baseline["manifest"]))
+    result = []
+    for ordinal, (kind, value) in enumerate(objects):
+        envelope_id = str(uuid5(NAMESPACE_URL, f"personal-context-activation:{prepared.activation_id}:{ordinal}"))
+        aad = canonical_json_bytes({**identity, "envelope_id": envelope_id})
+        encrypted = cipher.encrypt(canonical_json_bytes({"kind": kind, "value": value}), aad)
+        fields = {
+            name: base64.b64encode(value).decode("ascii") if isinstance(value, bytes) else value
+            for name, value in asdict(encrypted).items()
+        }
+        result.append({"envelope_id": envelope_id, **fields})
+    return canonical_json_bytes(result).decode("utf-8")
+
+
+def _verify_install(
+    prepared: PreparedPersonalContextActivation,
+    row: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    cipher: EnvelopeCipher,
+) -> bool:
+    """Authenticate every pinned envelope, checkpoint and receipt before coverage."""
+
+    if any(row.get(key) != value for key, value in identity.items()):
+        return False
+    if type(row.get("home_server_cursor")) is not int or row["home_server_cursor"] < 0:
+        return False
+    baseline: dict[str, Any] = {"scopes": [], "records": [], "proposals": []}
+    encrypted = json.loads(row["envelopes_json"])
+    for ordinal, entry in enumerate(encrypted):
+        envelope_id = str(uuid5(NAMESPACE_URL, f"personal-context-activation:{prepared.activation_id}:{ordinal}"))
+        if entry["envelope_id"] != envelope_id:
+            return False
+        envelope = EncryptedEnvelope(
+            **{
+                name: base64.b64decode(entry[name], validate=True)
+                if name
+                in {
+                    "nonce",
+                    "wrapped_dek",
+                    "wrapped_dek_nonce",
+                    "ciphertext",
+                }
+                else entry[name]
+                for name in EncryptedEnvelope.__dataclass_fields__
+            }
+        )
+        clear = json.loads(cipher.decrypt(envelope, canonical_json_bytes({**identity, "envelope_id": envelope_id})))
+        if clear["kind"] == "manifest":
+            if "manifest" in baseline or ordinal != len(encrypted) - 1:
+                return False
+            baseline["manifest"] = clear["value"]
+        elif clear["kind"] in baseline and clear["kind"] != "manifest":
+            baseline[clear["kind"]].append(clear["value"])
+        else:
+            return False
+    receipt = hashlib.sha256(
+        canonical_json_bytes(
+            {
+                **identity,
+                "home_server_cursor": row["home_server_cursor"],
+                "envelopes_json": row["envelopes_json"],
+                "expires_at": row["expires_at"],
+            }
+        )
+    ).hexdigest()
+    return hmac.compare_digest(canonical_json_bytes(baseline), prepared.baseline) and hmac.compare_digest(
+        receipt, row["receipt_id"]
+    )
+
+
+def _receipt(prepared: PreparedPersonalContextActivation) -> PersonalContextActivationReceipt:
+    """Expose only bounded canonical installation facts."""
+
+    manifest = json.loads(prepared.baseline)["manifest"]
+    return PersonalContextActivationReceipt(
+        activation_id=prepared.activation_id,
+        baseline_digest=prepared.baseline_digest,
+        purge_generation=prepared.purge_generation,
+        publication_watermark=prepared.publication_watermark,
+        home_server_cursor=prepared.home_server_cursor or 0,
+        home_manifest_revision=manifest["revision"],
+        home_manifest_version_id=manifest["current_version_id"],
+        state=prepared.state,
+    )
+
+
+def prepare_activation(
+    service: SyncV2Service,
+    *,
+    user_id: str,
+    device_id: str,
+    required_schema_version: int | None = None,
+    required_quotas: Mapping[str, int] | None = None,
+    expected_purge_generation: int | None = None,
+) -> PersonalContextBootstrap:
+    """Prepare, install and verify a linked device baseline without enabling rollout."""
+
+    device = service._require_registered_device(user_id, device_id)
+    capability = service.capabilities(user_id=user_id).personal_context
+    if not capability.available or not service._personal_context_domains_ready():
+        raise SyncStoreError("personal_context_capability_unavailable")
+    if required_schema_version is not None and not (
+        capability.min_schema_version <= required_schema_version <= capability.max_schema_version
+    ):
+        raise SyncStoreError("personal_context_schema_incompatible")
+    quotas = _personal_context_bootstrap_quotas(capability)
+    if not _personal_context_quotas_compatible(required_quotas, quotas):
+        raise SyncStoreError("personal_context_quota_incompatible")
+    canonical = service._personal_context_service_for_user(user_id)
+    repository = canonical._repository
+    manifest = canonical.get_manifest()
+    if expected_purge_generation is not None and expected_purge_generation != manifest.purge_generation:
+        raise SyncStoreError("personal_context_purge_generation_stale")
+    dataset = service.store.personal_context_dataset_for_profile(user_id=user_id, profile_id=manifest.profile_id)
+    if dataset is None:
+        raise SyncStoreError("personal_context_activation_required")
+    dataset = service._require_dataset_access(user_id=user_id, dataset_id=dataset.dataset_id)
+    integrity_key_id, integrity_key = canonical.sync_integrity_key(manifest.profile_id)
+    activations = PersonalContextActivationService(repository)
+    if not service.store.has_personal_context_link_receipt(
+        user_id=user_id,
+        dataset_id=dataset.dataset_id,
+        device_id=device_id,
+        profile_id=manifest.profile_id,
+        integrity_key_id=integrity_key_id,
+        purge_generation=manifest.purge_generation,
+    ):
+        raise SyncStoreError("personal_context_activation_required")
+    if service.personal_context_relay is not None:
+        service.personal_context_relay.relay_profile(
+            user_id=user_id,
+            profile_id=manifest.profile_id,
+            dataset_id=dataset.dataset_id,
+            after_server_cursor=None,
+        )
+    prepared = activations.prepare(manifest.profile_id, device_id=device_id)
+    identity = _identity(prepared, dataset, user_id)
+    cipher = _cipher(service, dataset)
+    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
+        stored = guarded.get_personal_context_activation(prepared.activation_id)
+        if stored is not None and _expired(stored):
+            if not _verify_install(prepared, stored, identity, cipher):
+                raise SyncStoreError("personal_context_activation_receipt_mismatch")
+            with activations.publications.profile_lease(prepared.profile_id) as lease:
+                repository.expire_activation(
+                    prepared.activation_id, prepared.baseline_digest, sync_receipt_id=stored["receipt_id"], lease=lease
+                )
+            prepared = None
+    if prepared is None:
+        if service.personal_context_relay is not None:
+            service.personal_context_relay.relay_profile(
+                user_id=user_id, profile_id=manifest.profile_id, dataset_id=dataset.dataset_id, after_server_cursor=None
+            )
+        prepared = activations.prepare(manifest.profile_id, device_id=device_id)
+        identity = _identity(prepared, dataset, user_id)
+    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
+
+        def install(current: PreparedPersonalContextActivation) -> Mapping[str, Any]:
+            """Commit Sync while the verified canonical generation guard remains held."""
+
+            stored = guarded.get_personal_context_activation(current.activation_id)
+            if stored is None:
+                history = guarded.get_dataset_envelope_range(dataset.dataset_id)
+                values = {
+                    **identity,
+                    "home_server_cursor": history.through_server_sequence or 0,
+                    "envelopes_json": _protected_baseline(current, identity, cipher),
+                    "expires_at": (
+                        _activation_now() + timedelta(seconds=_PERSONAL_CONTEXT_BOOTSTRAP_TOKEN_TTL_SECONDS)
+                    ).isoformat(),
+                }
+                values["receipt_id"] = hashlib.sha256(canonical_json_bytes(values)).hexdigest()
+                stored = guarded.install_personal_context_activation(**values)
+            if not _verify_install(current, stored, identity, cipher):
+                raise SyncStoreError("personal_context_activation_receipt_mismatch")
+            if _expired(stored):
+                raise SyncStoreError("personal_context_activation_required")
+            guarded.commit_personal_context_authority()
+            return stored
+
+        installed = activations.install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            install=install,
+            verify=lambda current, row: _verify_install(current, row, identity, cipher),
+        )
+    with service.store.personal_context_authority_guard(dataset.dataset_id, prepared.profile_id) as guarded:
+        with activations.publications.profile_lease(prepared.profile_id) as lease:
+            with repository.activation_install_guard(installed.activation_id, installed.baseline_digest, lease=lease):
+                guarded.mirror_personal_context_activation(
+                    dataset_id=dataset.dataset_id,
+                    user_id=user_id,
+                    profile_id=installed.profile_id,
+                    purge_generation=installed.purge_generation,
+                    activation_epoch=installed.activation_epoch,
+                    continuity_token=installed.continuity_token,
+                )
+                guarded.commit_personal_context_authority()
+    baseline = json.loads(installed.baseline)
+    streams = service._pull_adapter_streams(device, list(PERSONAL_CONTEXT_SYNC_DOMAINS))
+    watermarks = dict.fromkeys(streams, installed.home_server_cursor or 0)
+    cursor = service._encode_pull_token(
+        dataset_id=dataset.dataset_id,
+        device_id=device_id,
+        version_set=service._pull_version_set(device),
+        watermarks=watermarks,
+        ttl_seconds=max(service.settings.pull_token_ttl_seconds, _PERSONAL_CONTEXT_BOOTSTRAP_TOKEN_TTL_SECONDS),
+    )
+    manifest = ProfileManifest.model_validate(baseline["manifest"])
+    scopes = tuple(ProfileScope.model_validate(x) for x in baseline["scopes"])
+    records = tuple(ProfileRecord.model_validate(x) for x in baseline["records"])
+    proposals = tuple(ProfileProposal.model_validate(x) for x in baseline["proposals"])
+    bootstrap_cursor = canonical._sync_bootstrap_cursor(
+        manifest=manifest, scopes=scopes, records=records, proposals=proposals, integrity_key_id=integrity_key_id
+    )
+    key_record = service._profile_manager()._device_integrity_key_record(
+        user_id=user_id,
+        dataset=dataset,
+        device=device,
+        integrity_key_id=integrity_key_id,
+        integrity_key=integrity_key,
+        bootstrap_cursor=bootstrap_cursor,
+        transport_watermarks=watermarks,
+    )
+    return PersonalContextBootstrap(
+        dataset_id=dataset.dataset_id,
+        authority_id=service.personal_context_authority_id,
+        manifest=manifest,
+        scopes=scopes,
+        records=records,
+        proposals=proposals,
+        purge_generation=manifest.purge_generation,
+        schema_version=capability.max_schema_version,
+        quotas=quotas,
+        cursor=bootstrap_cursor,
+        link_state="complete",
+        integrity_key=PersonalContextBootstrapIntegrityKey(
+            integrity_key_id=integrity_key_id,
+            key_record_id=key_record.key_record_id,
+            wrapped_key_blob=key_record.wrapped_key_blob,
+        ),
+        sync_transport_cursor=cursor,
+        activation=_receipt(installed),
+        personal_context_exchange=PersonalContextExchangeProof(
+            ongoing_sync_version=1,
+            activation_epoch=installed.activation_epoch,
+            continuity_token=installed.continuity_token,
+        ),
+    )
+
+
+def acknowledge_activation(
+    service: SyncV2Service,
+    *,
+    user_id: str,
+    dataset_id: str,
+    device_id: str,
+    activation_id: str,
+    baseline_digest: str,
+    local_receipt_id: str,
+    exchange: PersonalContextExchangeProof,
+) -> tuple[PersonalContextActivationReceipt, PersonalContextExchangeProof]:
+    """Commit the exact Sync acknowledgment before marking the canonical device active."""
+
+    dataset = service._require_dataset_access(user_id=user_id, dataset_id=dataset_id)
+    service._require_registered_device(user_id, device_id)
+    repository = service._personal_context_service_for_user(user_id)._repository
+    activations = PersonalContextActivationService(repository)
+    prepared = repository.load_activation(activation_id)
+    identity = _identity(prepared, dataset, user_id)
+    cipher = _cipher(service, dataset)
+    current = PersonalContextExchangeProof(
+        ongoing_sync_version=1, activation_epoch=prepared.activation_epoch, continuity_token=prepared.continuity_token
+    )
+    if (
+        prepared.device_id != device_id
+        or prepared.baseline_digest != baseline_digest
+        or not hmac.compare_digest(current.activation_epoch, exchange.activation_epoch)
+        or not hmac.compare_digest(current.continuity_token, exchange.continuity_token)
+    ):
+        raise SyncStoreError("personal_context_activation_required")
+    with service.store.personal_context_authority_guard(dataset_id, prepared.profile_id) as guarded:
+        with activations.publications.profile_lease(prepared.profile_id) as lease:
+            with repository.activation_install_guard(activation_id, baseline_digest, lease=lease) as live:
+                stored = guarded.get_personal_context_activation(activation_id)
+                if stored is None or not _verify_install(live, stored, identity, cipher):
+                    raise SyncStoreError("personal_context_activation_receipt_mismatch")
+                if _expired(stored):
+                    raise SyncStoreError("personal_context_activation_required")
+                ack = guarded.acknowledge_personal_context_activation(
+                    activation_id=activation_id,
+                    dataset_id=dataset_id,
+                    user_id=user_id,
+                    device_id=device_id,
+                    baseline_digest=baseline_digest,
+                    local_receipt_id=local_receipt_id,
+                )
+                guarded.commit_personal_context_authority()
+            active = repository.confirm_activation_device(
+                activation_id,
+                baseline_digest,
+                device_id,
+                ack["receipt_id"],
+                local_receipt_id=local_receipt_id,
+                dataset_id=dataset_id,
+            )
+    return _receipt(active), current

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_relay.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_relay.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from tldw_Server_API.app.core.exceptions import (
     PersonalContextAuthoritySourceError,
+    PublicationActivationPending,
     PublicationRelayPoisoned,
 )
 from tldw_Server_API.app.core.Personalization.personal_context_publication import (
@@ -141,6 +142,8 @@ class PersonalContextRelay:
                             dataset_id=dataset_id,
                             budget=budget,
                         )
+            except PublicationActivationPending:
+                result = self._pending()
             except PublicationRelayPoisoned:
                 result = PersonalContextRelayResult(0, False, False, "relay_poisoned")
             except Exception:  # noqa: BLE001 - DB/lease/adapter races remain retryable.
@@ -200,6 +203,8 @@ class PersonalContextRelay:
                 budget=budget,
             )
             if batch is None:
+                if not budget.can_inspect():
+                    return self._pending(staged)
                 return PersonalContextRelayResult(
                     staged, True, False, "complete"
                 )

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_relay.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_relay.py
@@ -131,7 +131,9 @@ class PersonalContextRelay:
             operation="personal_context_relay", relay_attempt_id=uuid4().hex
         ):
             try:
-                with self.publications.profile_lease(profile_id) as lease:
+                # A synchronous after-commit hook may still hold its outer Sync
+                # transaction. Never wait here for an installer staging into Sync.
+                with self.publications.profile_lease(profile_id, blocking=False) as lease:
                     if lease is None:
                         result = self._pending()
                     else:

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -35,6 +35,7 @@ from .notes_moodboard_studio_readiness import (
     parse_notes_moodboard_studio_readiness_record,
 )
 from .notes_task_readiness import parse_notes_task_readiness_record
+from .personal_context_ongoing_contract import PersonalContextActivationReceipt, PersonalContextExchangeProof
 from .store import SyncV2Store
 
 SYNC_V2_M1_PROTOCOL_VERSION = "sync-v2-m1"
@@ -87,6 +88,8 @@ class PersonalContextBootstrap:
     sync_transport_cursor: str
     integrity_key: PersonalContextBootstrapIntegrityKey
     link_state: str
+    activation: PersonalContextActivationReceipt | None = None
+    personal_context_exchange: PersonalContextExchangeProof | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -147,6 +147,7 @@ from .notes_task_readiness import (
     redact_notes_task_server_metadata,
 )
 from .personal_context_ongoing_contract import (
+    PersonalContextActivationReceipt,
     PersonalContextAuthorityMetadata,
     PersonalContextExchangeProof,
     PersonalContextRelayContinuation,
@@ -1390,7 +1391,7 @@ class SyncV2Service:
                 or type(getattr(exchange, "ongoing_sync_version", None)) is not int
             ):
                 raise ValueError("Personal Context activation version is invalid")
-            persisted = PersonalContextExchangeProof.model_validate(
+            stored = PersonalContextExchangeProof.model_validate(
                 {
                     "ongoing_sync_version": state.get("ongoing_sync_version"),
                     "activation_epoch": state.get("activation_epoch"),
@@ -1399,21 +1400,38 @@ class SyncV2Service:
             )
             supplied = PersonalContextExchangeProof.model_validate(
                 {
-                    "ongoing_sync_version": getattr(
-                        exchange, "ongoing_sync_version", None
-                    ),
+                    "ongoing_sync_version": getattr(exchange, "ongoing_sync_version", None),
                     "activation_epoch": getattr(exchange, "activation_epoch", None),
                     "continuity_token": getattr(exchange, "continuity_token", None),
                 }
             )
-            proof_matches = hmac.compare_digest(
-                persisted.activation_epoch.encode("ascii"),
-                supplied.activation_epoch.encode("ascii"),
-            ) and hmac.compare_digest(
-                persisted.continuity_token.encode("ascii"),
-                supplied.continuity_token.encode("ascii"),
+            canonical = self._personal_context_service_for_user(user_id)
+            persisted = canonical._repository.validate_activation_exchange(
+                profile_id=state.get("profile_id"),
+                dataset_id=dataset.dataset_id,
+                device_id=device_id,
+                activation_epoch=supplied.activation_epoch,
+                continuity_token=supplied.continuity_token,
             )
-        except (TypeError, UnicodeError, ValueError):
+            proof_matches = (
+                hmac.compare_digest(
+                    persisted.activation_epoch.encode("ascii"),
+                    supplied.activation_epoch.encode("ascii"),
+                )
+                and hmac.compare_digest(
+                    persisted.continuity_token.encode("ascii"),
+                    supplied.continuity_token.encode("ascii"),
+                )
+                and hmac.compare_digest(
+                    stored.activation_epoch.encode("ascii"),
+                    supplied.activation_epoch.encode("ascii"),
+                )
+                and hmac.compare_digest(
+                    stored.continuity_token.encode("ascii"),
+                    supplied.continuity_token.encode("ascii"),
+                )
+            )
+        except (AttributeError, KeyError, RuntimeError, SyncStoreError, TypeError, UnicodeError, ValueError):
             proof_matches = False
         if (
             not isinstance(state, Mapping)
@@ -3663,6 +3681,64 @@ class SyncV2Service:
             required_quotas=required_quotas,
             expected_purge_generation=expected_purge_generation,
         )
+
+    def prepare_personal_context_activation(
+        self,
+        *,
+        user_id: str,
+        device_id: str,
+        required_schema_version: int | None = None,
+        required_quotas: Mapping[str, int] | None = None,
+        expected_purge_generation: int | None = None,
+    ) -> PersonalContextBootstrap:
+        """Install a canonical activation baseline through protected Sync storage."""
+
+        from .personal_context_activation import prepare_activation
+
+        try:
+            return prepare_activation(
+                self,
+                user_id=user_id,
+                device_id=device_id,
+                required_schema_version=required_schema_version,
+                required_quotas=required_quotas,
+                expected_purge_generation=expected_purge_generation,
+            )
+        except (ValueError, RuntimeError) as exc:
+            if isinstance(exc, SyncStoreError):
+                raise
+            raise SyncStoreError("personal_context_activation_required") from exc
+
+    def acknowledge_personal_context_activation(
+        self,
+        *,
+        user_id: str,
+        dataset_id: str,
+        device_id: str,
+        activation_id: str,
+        baseline_digest: str,
+        local_receipt_id: str,
+        exchange: PersonalContextExchangeProof,
+    ) -> tuple[PersonalContextActivationReceipt, PersonalContextExchangeProof]:
+        """Record an exact device acknowledgment across both durable journals."""
+
+        from .personal_context_activation import acknowledge_activation
+
+        try:
+            return acknowledge_activation(
+                self,
+                user_id=user_id,
+                dataset_id=dataset_id,
+                device_id=device_id,
+                activation_id=activation_id,
+                baseline_digest=baseline_digest,
+                local_receipt_id=local_receipt_id,
+                exchange=exchange,
+            )
+        except (ValueError, RuntimeError) as exc:
+            if isinstance(exc, SyncStoreError):
+                raise
+            raise SyncStoreError("personal_context_activation_required") from exc
 
     def complete_personal_context_link(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -3670,8 +3670,41 @@ class SyncV2Service:
         required_schema_version: int | None = None,
         required_quotas: Mapping[str, int] | None = None,
         expected_purge_generation: int | None = None,
+        ongoing_sync_version: int | None = None,
     ) -> PersonalContextBootstrap:
-        """Return an authenticated device's canonical first-link snapshot."""
+        """Dispatch first linking or activation under the current rollout gate.
+
+        Args:
+            user_id: Authenticated owner of the profile and registered device.
+            device_id: Device requesting the baseline.
+            required_schema_version: Optional client schema requirement.
+            required_quotas: Optional client quota requirements.
+            expected_purge_generation: Optional generation the client expects.
+            ongoing_sync_version: None or zero for first linking; one for activation.
+
+        Returns:
+            The canonical snapshot and its protected device delivery metadata.
+
+        Raises:
+            SyncStoreError: The requested ongoing version is unavailable or
+                activation cannot establish valid continuity.
+            PersonalContextBootstrapError: Device, schema, quota, generation,
+                custody, or snapshot requirements cannot be satisfied.
+        """
+
+        if ongoing_sync_version not in (None, 0):
+            if (
+                ongoing_sync_version != 1
+                or self.capabilities(user_id=user_id).personal_context.ongoing_sync_version != 1
+            ):
+                raise SyncStoreError("personal_context_ongoing_sync_unavailable")
+            return self.prepare_personal_context_activation(
+                user_id=user_id,
+                device_id=device_id,
+                required_schema_version=required_schema_version,
+                required_quotas=required_quotas,
+                expected_purge_generation=expected_purge_generation,
+            )
 
         return self._profile_manager().bootstrap_personal_context(
             user_id=user_id,
@@ -3693,6 +3726,8 @@ class SyncV2Service:
     ) -> PersonalContextBootstrap:
         """Install a canonical activation baseline through protected Sync storage."""
 
+        from tldw_Server_API.app.core.exceptions import PersonalContextActivationError
+
         from .personal_context_activation import prepare_activation
 
         try:
@@ -3704,6 +3739,8 @@ class SyncV2Service:
                 required_quotas=required_quotas,
                 expected_purge_generation=expected_purge_generation,
             )
+        except PersonalContextActivationError as exc:
+            raise SyncStoreError("personal_context_activation_required") from exc
         except (ValueError, RuntimeError) as exc:
             if isinstance(exc, SyncStoreError):
                 raise
@@ -3722,6 +3759,8 @@ class SyncV2Service:
     ) -> tuple[PersonalContextActivationReceipt, PersonalContextExchangeProof]:
         """Record an exact device acknowledgment across both durable journals."""
 
+        from tldw_Server_API.app.core.exceptions import PersonalContextActivationError
+
         from .personal_context_activation import acknowledge_activation
 
         try:
@@ -3735,6 +3774,8 @@ class SyncV2Service:
                 local_receipt_id=local_receipt_id,
                 exchange=exchange,
             )
+        except PersonalContextActivationError as exc:
+            raise SyncStoreError("personal_context_activation_required") from exc
         except (ValueError, RuntimeError) as exc:
             if isinstance(exc, SyncStoreError):
                 raise

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -394,9 +394,40 @@ class SyncV2Store:
             bootstrap_cursor=bootstrap_cursor,
         )
 
+    def mirror_personal_context_activation(self, **values: Any) -> None:
+        """Mirror a verified canonical pair without changing readiness."""
+
+        self.db.mirror_personal_context_activation(connection=self._connection, **values)
+
+    def install_personal_context_activation(self, **values: Any) -> dict[str, Any]:
+        """Persist immutable protected bootstrap envelopes under an active guard."""
+
+        return self.db.install_personal_context_activation(connection=self._connection, **values)
+
+    def get_personal_context_activation(self, activation_id: str) -> dict[str, Any] | None:
+        """Read the durable protected bootstrap installation."""
+
+        return self.db.get_personal_context_activation(activation_id, connection=self._connection)
+
+    def acknowledge_personal_context_activation(self, **values: Any) -> dict[str, Any]:
+        """Persist one device's exact local installation receipt."""
+
+        return self.db.acknowledge_personal_context_activation(connection=self._connection, **values)
+
+    def get_personal_context_activation_ack(self, activation_id: str, device_id: str) -> dict[str, Any] | None:
+        """Read one exact device acknowledgment."""
+
+        return self.db.get_personal_context_activation_ack(activation_id, device_id, connection=self._connection)
+
     def has_personal_context_link_receipt(
-        self, *, user_id: str, dataset_id: str, device_id: str, profile_id: str,
-        integrity_key_id: str, purge_generation: int,
+        self,
+        *,
+        user_id: str,
+        dataset_id: str,
+        device_id: str,
+        profile_id: str,
+        integrity_key_id: str,
+        purge_generation: int,
     ) -> bool:
         """Return whether this exact device has the current server-owned receipt."""
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -204,6 +204,10 @@ class PublicationRelayPoisoned(PersonalContextError):
     """Content-free durable attention state for the earliest corrupt batch."""
 
 
+class PublicationActivationPending(PersonalContextError):
+    """A live prepared baseline temporarily fences ordinary publication relay."""
+
+
 class PersonalContextAuthoritySourceError(PersonalContextError):
     """Authenticated source content is malformed and requires durable attention."""
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -200,6 +200,26 @@ class PersonalContextError(RuntimeError):
     """Base error for canonical Personal Context operations."""
 
 
+class PersonalContextActivationError(PersonalContextError, ValueError):
+    """Base activation failure retaining compatibility with ValueError callers."""
+
+
+class PersonalContextActivationInputError(PersonalContextActivationError):
+    """Activation input or installation receipt fields are invalid."""
+
+
+class PersonalContextActivationPendingError(PersonalContextActivationError):
+    """Existing activation or publication work must finish before preparation."""
+
+
+class PersonalContextActivationMissingError(PersonalContextActivationError):
+    """The requested activation or current device acknowledgment is absent."""
+
+
+class PersonalContextActivationStaleError(PersonalContextActivationError):
+    """Activation lease, generation, digest, receipt or continuity is no longer valid."""
+
+
 class PublicationRelayPoisoned(PersonalContextError):
     """Content-free durable attention state for the earliest corrupt batch."""
 

--- a/tldw_Server_API/tests/Personalization/test_personal_context_activation.py
+++ b/tldw_Server_API/tests/Personalization/test_personal_context_activation.py
@@ -1,0 +1,874 @@
+"""Activation preparation and coverage survive real Personalization restarts."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
+from tldw_Server_API.app.core.exceptions import PublicationActivationPending
+from tldw_Server_API.app.core.Personalization.personal_context_publication import (
+    PersonalContextPublicationJournal,
+    PersonalContextPublicationRelayStore,
+    PublicationObject,
+    PublicationRelayLease,
+)
+from tldw_Server_API.app.core.Personalization.personal_context_repository import (
+    PersonalContextRepository,
+)
+from tldw_Server_API.app.core.Personalization.personal_context_service import (
+    PersonalContextService,
+)
+from tldw_Server_API.tests.Personalization.personal_context_test_support import (
+    encoded_master_key,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_abandoned_preparation_expires_without_covering_source(service: PersonalContextService, legacy: bool) -> None:
+    """Another device's relay retires a stale baseline without losing queued writes."""
+    from tldw_Server_API.app.core.Sync.v2.personal_context_relay import PersonalContextRelay
+
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    if legacy:
+        with repository.database.transaction(immediate=True) as connection:
+            connection.execute("DELETE FROM personal_context_publication_rows")
+            connection.execute("DELETE FROM personal_context_publication_batches")
+            connection.execute("DELETE FROM personal_context_publication_profiles")
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="abandoned-device", lease=lease)
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_activations SET created_at = '2000-01-01T00:00:00.000Z'")
+        before = [tuple(row) for row in connection.execute("SELECT * FROM personal_context_publication_rows")]
+    relay = PersonalContextRelay(publications=publications, stage_authority=lambda *_args: None)
+    result = relay.relay_profile(
+        user_id="user-a",
+        profile_id=manifest.profile_id,
+        dataset_id="dataset-a",
+        after_server_cursor=None,
+        row_budget=1,
+    )
+    assert result.continuation == "personal_context_relay_pending"
+    assert result.inspected_rows == 1
+    with repository.database.transaction() as connection:
+        row = connection.execute("SELECT * FROM personal_context_activations").fetchone()
+        assert row["state"] == "expired"
+        assert row["activation_id"] == prepared.activation_id
+        assert row["baseline_digest"] == prepared.baseline_digest
+        assert row["ciphertext"] == row["wrapped_dek"] == row["nonce"] == row["wrapped_dek_nonce"] == b""
+        assert [tuple(row) for row in connection.execute("SELECT * FROM personal_context_publication_rows")] == before
+        profile = connection.execute(
+            "SELECT activation_covered_through_sequence FROM personal_context_publication_profiles"
+        ).fetchone()
+        assert profile is None if legacy else profile[0] == 0
+    with publications.profile_lease(manifest.profile_id) as lease:
+        with pytest.raises(ValueError, match="activation_required"):
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                "orphan-sync-receipt",
+                home_server_cursor=0,
+                lease=lease,
+            )
+        batch = publications.earliest_nonterminal_batch(manifest.profile_id, row_limit=100, lease=lease)
+        assert (batch is None) is legacy
+        fresh = repository.prepare_activation(manifest.profile_id, device_id="another-device", lease=lease)
+        assert fresh.activation_id != prepared.activation_id
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.confirm_activation_device(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "abandoned-device",
+            "orphan-ack",
+            local_receipt_id="local-receipt",
+            dataset_id="dataset-a",
+        )
+
+
+def test_live_preparation_reports_pending_instead_of_drained(service: PersonalContextService) -> None:
+    """A live baseline fence is retryable pending, even before ordinary source lookup."""
+    from tldw_Server_API.app.core.Sync.v2.personal_context_relay import PersonalContextRelay
+
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    result = PersonalContextRelay(publications=publications, stage_authority=lambda *_args: None).relay_profile(
+        user_id="user-a",
+        profile_id=manifest.profile_id,
+        dataset_id="dataset-a",
+        after_server_cursor=None,
+    )
+    assert result.continuation == "personal_context_relay_pending"
+    assert not result.source_exhausted
+
+
+@pytest.mark.parametrize("unowned", [None, PublicationRelayLease("wrong-profile", "wrong-owner")])
+def test_abandoned_preparation_requires_current_lease(
+    service: PersonalContextService,
+    unowned: PublicationRelayLease | None,
+) -> None:
+    """Neither a lease-free caller nor a stale owner may shred a prepared baseline."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_activations SET created_at = '2000-01-01T00:00:00.000Z'")
+    with pytest.raises(RuntimeError):
+        publications.earliest_nonterminal_batch(manifest.profile_id, row_limit=1, lease=unowned)
+    assert repository.load_activation(prepared.activation_id) == prepared
+
+
+@pytest.fixture()
+def service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PersonalContextService:
+    """Create a real encrypted canonical profile under the trusted pytest root."""
+    monkeypatch.setenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY", encoded_master_key())
+    return PersonalContextService(PersonalContextRepository(PersonalizationDB.for_path(tmp_path / "activation.db")))
+
+
+def test_prepare_restarts_at_whole_batch_watermark(service: PersonalContextService) -> None:
+    """A restart returns identical encrypted baseline bytes and an unsplit batch."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    with repository.database.transaction() as connection:
+        last = connection.execute(
+            "SELECT MAX(profile_publication_sequence) FROM personal_context_publication_batches"
+        ).fetchone()[0]
+        ciphertext = connection.execute("SELECT ciphertext FROM personal_context_activations").fetchone()[0]
+    restarted = PersonalContextRepository(PersonalizationDB.for_path(repository.database.db_path))
+    with publications.profile_lease(manifest.profile_id) as lease:
+        replay = restarted.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert prepared == replay
+    assert prepared.publication_watermark == last
+    assert prepared.activation_epoch is None
+    with repository.database.transaction() as connection:
+        assert connection.execute("SELECT ciphertext FROM personal_context_activations").fetchone()[0] == ciphertext
+
+
+def test_coverage_cas_precedes_compaction_and_preserves_terminal_proof(
+    service: PersonalContextService,
+) -> None:
+    """Source bodies cannot disappear before exact install coverage is durable."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        with pytest.raises(ValueError, match="activation"):
+            repository.compact_activation(prepared.activation_id)
+        installed = repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-receipt-0123456789",
+            home_server_cursor=1,
+            lease=lease,
+        )
+    repository.compact_activation(prepared.activation_id)
+    with repository.database.transaction() as connection:
+        proof = connection.execute(
+            "SELECT activation_covered_through_sequence FROM personal_context_publication_profiles"
+        ).fetchone()[0]
+        statuses = connection.execute("SELECT DISTINCT status FROM personal_context_publication_batches").fetchall()
+        bodies = connection.execute("SELECT ciphertext FROM personal_context_publication_rows").fetchall()
+    assert proof == prepared.publication_watermark
+    assert [row[0] for row in statuses] == ["covered_by_activation"]
+    assert all(row[0] == b"" for row in bodies)
+    assert installed.activation_epoch and installed.continuity_token
+    with publications.profile_lease(manifest.profile_id) as lease:
+        assert (
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                "sync-receipt-0123456789",
+                home_server_cursor=1,
+                lease=lease,
+            )
+            == installed
+        )
+
+
+def test_prepared_activation_blocks_relay_until_coverage_commits(service: PersonalContextService) -> None:
+    """A racing canonical edit waits behind the baseline checkpoint after restart."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    service.create_manual_record(
+        scope_id=service.list_scopes()[0].scope_id,
+        payload={"kind": "preference", "subject": "race", "polarity": "like", "value": "racing value"},
+        semantic_key={"namespace": "preference", "subject": "race"},
+        controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+    )
+    assert json.loads(prepared.baseline)["records"] == []
+    with publications.profile_lease(manifest.profile_id) as lease:
+        with pytest.raises(PublicationActivationPending):
+            publications.earliest_nonterminal_batch(manifest.profile_id, row_limit=100, lease=lease)
+        repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-receipt-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    repository.compact_activation(prepared.activation_id)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        batch = publications.earliest_nonterminal_batch(manifest.profile_id, row_limit=100, lease=lease)
+    assert batch is not None
+    assert batch.profile_publication_sequence == prepared.publication_watermark + 1
+    assert b"racing value" in batch.rows[0].canonical
+
+
+def test_baseline_survives_profile_key_rotation(service: PersonalContextService) -> None:
+    """Rotating the profile key must rewrap the pending baseline as well as source rows."""
+    manifest = service.create_profile()
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    repository.rotate_encryption_key(manifest.profile_id)
+    assert repository.load_activation(prepared.activation_id) == prepared
+
+
+def test_acknowledgment_is_device_bound_and_continuity_is_canonical(service: PersonalContextService) -> None:
+    """Only the exact installed device receipt enables the persisted current pair."""
+    manifest = service.create_profile()
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        installed = repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    arguments = {
+        "profile_id": manifest.profile_id,
+        "device_id": "device-a",
+        "dataset_id": "dataset-a",
+        "activation_epoch": installed.activation_epoch,
+        "continuity_token": installed.continuity_token,
+    }
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(**arguments)
+    for _ in range(2):
+        active = repository.confirm_activation_device(
+            installed.activation_id,
+            installed.baseline_digest,
+            "device-a",
+            "sync-ack-0123456789",
+            local_receipt_id="local-ack-0123456789",
+            dataset_id="dataset-a",
+        )
+        assert active.state == "active"
+    assert repository.validate_activation_exchange(**arguments).continuity_token == installed.continuity_token
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(**{**arguments, "device_id": "device-b"})
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(**{**arguments, "dataset_id": "dataset-b"})
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.confirm_activation_device(
+            installed.activation_id,
+            installed.baseline_digest,
+            "device-a",
+            "different-sync-ack",
+            local_receipt_id="local-ack-0123456789",
+            dataset_id="dataset-a",
+        )
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_publication_profiles SET continuity_token = NULL")
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(**arguments)
+
+
+def test_existing_purge_removes_readable_baseline_and_invalidates_pair(service: PersonalContextService) -> None:
+    """The new encrypted store participates in the existing canonical purge boundary."""
+    manifest = service.create_profile()
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    service.purge_profile(mode="everywhere", confirmation="DELETE EVERYWHERE", expected_purge_generation=0)
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.load_activation(prepared.activation_id)
+    with repository.database.transaction() as connection:
+        row = connection.execute(
+            "SELECT activation_epoch, continuity_token FROM personal_context_publication_profiles"
+        ).fetchone()
+    assert tuple(row) == (None, None)
+
+
+def test_new_baseline_required_after_continuity_invalidation(service: PersonalContextService) -> None:
+    """A repeated bootstrap cannot return a permanently invalid installed pair."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        installed = repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_publication_profiles SET continuity_token = NULL")
+    with publications.profile_lease(manifest.profile_id) as lease:
+        replacement = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert replacement.activation_id != installed.activation_id
+    assert replacement.state == "prepared"
+
+
+@pytest.mark.parametrize("installed", [False, True])
+def test_another_device_cannot_cover_unpublished_changes(
+    service: PersonalContextService,
+    installed: bool,
+) -> None:
+    """New baselines cannot hide unpublished edits from devices with an older baseline."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        if installed:
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                "sync-install-0123456789",
+                home_server_cursor=0,
+                lease=lease,
+            )
+    service.create_manual_record(
+        scope_id=service.list_scopes()[0].scope_id,
+        payload={"kind": "preference", "subject": "second", "polarity": "like", "value": "second device"},
+        semantic_key={"namespace": "preference", "subject": "second"},
+        controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+    )
+    with publications.profile_lease(manifest.profile_id) as lease:
+        with pytest.raises(ValueError, match="activation_pending"):
+            repository.prepare_activation(manifest.profile_id, device_id="device-b", lease=lease)
+
+
+def test_service_requires_exact_sync_verification_before_coverage(service: PersonalContextService) -> None:
+    """An unverified independent receipt leaves the encrypted preparation untouched."""
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+
+    manifest = service.create_profile()
+    activation_service = PersonalContextActivationService(service._repository)
+    prepared = activation_service.prepare(manifest.profile_id, device_id="device-a")
+    with pytest.raises(ValueError, match="activation_required"):
+        activation_service.install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            install=lambda _prepared: {"receipt_id": "receipt-0123456789", "home_server_cursor": 0},
+            verify=lambda _prepared, _receipt: False,
+        )
+    assert service._repository.load_activation(prepared.activation_id).state == "prepared"
+
+
+def test_three_row_batch_watermark_is_sequence_not_row_count(service: PersonalContextService) -> None:
+    """A whole committed batch with two semantic objects has one activation sequence."""
+    from tldw_profile_core import canonical_bytes
+
+    manifest = service.create_profile()
+    record = service.create_manual_record(
+        scope_id=service.list_scopes()[0].scope_id,
+        payload={"kind": "preference", "subject": "batch", "polarity": "like", "value": "three rows"},
+        semantic_key={"namespace": "preference", "subject": "batch"},
+        controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+    )
+    repository = service._repository
+    scope = service.list_scopes()[0]
+    head = service.get_manifest()
+    with repository.database.transaction(immediate=True) as connection:
+        journal = PersonalContextPublicationJournal(repository._keys.load(manifest.profile_id, connection=connection))
+        batch = journal.append_batch(
+            connection,
+            profile_id=manifest.profile_id,
+            purge_generation=0,
+            now="2026-09-05T00:00:00Z",
+            objects=(
+                PublicationObject(
+                    "personal_context.scope",
+                    scope.scope_id,
+                    scope.version_id,
+                    "upsert",
+                    "semantic",
+                    canonical_bytes(scope),
+                ),
+                PublicationObject(
+                    "personal_context.record",
+                    record.record_id,
+                    record.version_id,
+                    "upsert",
+                    "semantic",
+                    canonical_bytes(record),
+                ),
+                PublicationObject(
+                    "personal_context.manifest",
+                    head.profile_id,
+                    head.current_version_id,
+                    "upsert",
+                    "manifest",
+                    canonical_bytes(head),
+                ),
+            ),
+        )
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert batch.batch_size == 3
+    assert prepared.publication_watermark == batch.profile_publication_sequence
+    assert len(json.loads(prepared.baseline)["records"]) == 1
+
+
+def test_legacy_exact_heads_prepare_at_zero_without_source_history(service: PersonalContextService) -> None:
+    """A legacy linked profile does not need a fabricated source batch to activate."""
+    manifest = service.create_profile()
+    repository = service._repository
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("DELETE FROM personal_context_publication_rows")
+        connection.execute("DELETE FROM personal_context_publication_batches")
+        connection.execute("DELETE FROM personal_context_publication_profiles")
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        installed = repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    assert prepared.publication_watermark == 0
+    assert installed.state == "installed"
+
+
+def test_baseline_metadata_tampering_is_authenticated(service: PersonalContextService) -> None:
+    """A changed watermark cannot authorize covering unrepresented source batches."""
+    from tldw_Server_API.app.core.Personalization.personal_context_crypto import EnvelopeAuthenticationError
+
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_activations SET publication_watermark = publication_watermark + 1")
+    with pytest.raises(EnvelopeAuthenticationError):
+        repository.load_activation(prepared.activation_id)
+
+
+def test_stale_lease_cannot_commit_coverage(service: PersonalContextService) -> None:
+    """An expired or displaced installer leaves the baseline prepared."""
+    manifest = service.create_profile()
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=PublicationRelayLease(manifest.profile_id, "stale-owner"),
+        )
+    assert repository.load_activation(prepared.activation_id).state == "prepared"
+
+
+def test_activation_storage_never_persists_plaintext_canary(service: PersonalContextService) -> None:
+    """The database and WAL only retain protected baseline and publication bytes."""
+    manifest = service.create_profile()
+    canary = "TASK13162-PROTECTED-CANARY-8ad3c965"
+    service.create_manual_record(
+        scope_id=service.list_scopes()[0].scope_id,
+        payload={"kind": "preference", "subject": "canary", "polarity": "like", "value": canary},
+        semantic_key={"namespace": "preference", "subject": "canary"},
+        controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+    )
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert canary.encode() in prepared.baseline
+    for path in Path(repository.database.db_path).parent.glob("activation.db*"):
+        assert canary.encode() not in path.read_bytes()
+    assert canary not in repr(prepared)
+
+
+def test_missing_publication_journal_rolls_back_canonical_write(
+    service: PersonalContextService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A capability gap may not accept a canonical edit without its source journal."""
+
+    manifest = service.create_profile()
+
+    def unavailable(*args: Any, **kwargs: Any) -> None:
+        """Simulate the durable source store refusing publication."""
+        raise RuntimeError("publication storage unavailable")
+
+    monkeypatch.setattr(PersonalContextPublicationJournal, "append_batch", unavailable)
+    with pytest.raises(RuntimeError, match="publication storage unavailable"):
+        service.create_manual_record(
+            scope_id=service.list_scopes()[0].scope_id,
+            payload={"kind": "preference", "subject": "gap", "polarity": "like", "value": "must roll back"},
+            semantic_key={"namespace": "preference", "subject": "gap"},
+            controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+        )
+    assert service.get_manifest() == manifest
+    assert service.list_records() == ()
+
+
+def test_baseline_install_has_bounded_lease_for_large_snapshot(
+    service: PersonalContextService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An activation may encrypt a full snapshot longer than the ordinary relay budget."""
+    import time
+
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+    from tldw_Server_API.app.core.Personalization.personal_context_repository_models import (
+        PreparedPersonalContextActivation,
+    )
+
+    manifest = service.create_profile()
+    activation_service = PersonalContextActivationService(service._repository)
+    prepared = activation_service.prepare(manifest.profile_id, device_id="device-a")
+    wall = [time.time_ns()]
+    monkeypatch.setattr(time, "time_ns", lambda: wall[0])
+
+    def install(_prepared: PreparedPersonalContextActivation) -> dict[str, Any]:
+        """Advance a deterministic clock across a two-second independent install."""
+        wall[0] += 2_000_000_000
+        return {"receipt_id": "receipt-0123456789", "home_server_cursor": 0}
+
+    installed = activation_service.install(
+        prepared.activation_id,
+        prepared.baseline_digest,
+        install=install,
+        verify=lambda _prepared, _receipt: True,
+    )
+    assert installed.state == "installed"
+
+
+def test_exchange_validation_reads_content_free_activation_proof(
+    service: PersonalContextService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every ordinary exchange validates proof without decrypting the whole baseline."""
+    from tldw_Server_API.app.core.Personalization.personal_context_crypto import (
+        EncryptedEnvelope,
+        EnvelopeCipher,
+    )
+
+    manifest = service.create_profile()
+    repository = service._repository
+    with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        installed = repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    repository.confirm_activation_device(
+        installed.activation_id,
+        installed.baseline_digest,
+        "device-a",
+        "sync-ack-0123456789",
+        local_receipt_id="local-ack-0123456789",
+        dataset_id="dataset-a",
+    )
+    decrypt = EnvelopeCipher.decrypt
+
+    def guarded_decrypt(self: EnvelopeCipher, envelope: EncryptedEnvelope, aad: bytes) -> bytes:
+        """Forbid bulk baseline decryption while retaining ordinary manifest verification."""
+        assert b"personal-context-activation-v1" not in aad
+        return decrypt(self, envelope, aad)
+
+    monkeypatch.setattr(EnvelopeCipher, "decrypt", guarded_decrypt)
+    repository.validate_activation_exchange(
+        profile_id=manifest.profile_id,
+        device_id="device-a",
+        dataset_id="dataset-a",
+        activation_epoch=installed.activation_epoch,
+        continuity_token=installed.continuity_token,
+    )
+
+
+def test_canonical_writer_racing_snapshot_commits_after_its_whole_batch_watermark(
+    service: PersonalContextService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A separate writer cannot commit between the exact-head read and watermark save."""
+    manifest = service.create_profile()
+    repository = service._repository
+    writer = PersonalContextService(
+        PersonalContextRepository(
+            PersonalizationDB.for_path(repository.database.db_path),
+        )
+    )
+    record = writer.build_manual_record(
+        scope_id=writer.list_scopes()[0].scope_id,
+        payload={"kind": "preference", "subject": "racing", "polarity": "like", "value": "after snapshot"},
+        semantic_key={"namespace": "preference", "subject": "racing"},
+        controls={"sync_mode": "syncable", "agent_visibility": "agent_visible"},
+    )
+    snapshot_read, writer_started = Event(), Event()
+    snapshot = repository.sync_bootstrap_snapshot
+
+    def held_snapshot(*args: Any, **kwargs: Any) -> Any:
+        """Expose the interleaving while the canonical read transaction remains live."""
+        result = snapshot(*args, **kwargs)
+        snapshot_read.set()
+        assert writer_started.wait(5)
+        return result
+
+    def racing_write() -> None:
+        """Commit from a separate database instance after activation has read its heads."""
+        assert snapshot_read.wait(5)
+        writer_started.set()
+        writer.create_record(record)
+
+    monkeypatch.setattr(repository, "sync_bootstrap_snapshot", held_snapshot)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        write = executor.submit(racing_write)
+        with PersonalContextPublicationRelayStore(repository.database).profile_lease(manifest.profile_id) as lease:
+            prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        write.result(timeout=10)
+    assert json.loads(prepared.baseline)["records"] == []
+    assert writer.list_records() == (record,)
+    with repository.database.transaction() as connection:
+        sequence = connection.execute(
+            "SELECT MAX(profile_publication_sequence) FROM personal_context_publication_batches"
+        ).fetchone()[0]
+    assert sequence == prepared.publication_watermark + 1
+
+
+def test_same_millisecond_replacement_replays_latest_insert(
+    service: PersonalContextService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Random activation IDs must not decide which durable preparation is current."""
+    from types import SimpleNamespace
+    from uuid import UUID
+
+    from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
+
+    manifest = service.create_profile()
+    repository = service._repository
+    identifiers = iter((UUID(int=2), UUID(int=1)))
+    monkeypatch.setattr(repository_module, "uuid", SimpleNamespace(uuid4=lambda: next(identifiers)))
+    monkeypatch.setattr(repository_module, "_now_text", lambda: "2026-09-05T00:00:00.000Z")
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        old = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        repository.complete_activation_install(
+            old.activation_id,
+            old.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_publication_profiles SET continuity_token = NULL")
+    with publications.profile_lease(manifest.profile_id) as lease:
+        current = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        replay = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert replay == current
+
+
+def test_installed_replay_never_returns_invalidated_continuity(service: PersonalContextService) -> None:
+    """A broken current proof cannot be revived by replaying an older install receipt."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        repository.complete_activation_install(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            "sync-install-0123456789",
+            home_server_cursor=0,
+            lease=lease,
+        )
+    with repository.database.transaction(immediate=True) as connection:
+        connection.execute("UPDATE personal_context_publication_profiles SET continuity_token = NULL")
+    with publications.profile_lease(manifest.profile_id) as lease:
+        with pytest.raises(ValueError, match="activation_required"):
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                "sync-install-0123456789",
+                home_server_cursor=0,
+                lease=lease,
+            )
+
+
+@pytest.mark.parametrize("installed", [False, True])
+def test_expired_sync_baseline_permits_new_preparation_without_losing_coverage(
+    service: PersonalContextService,
+    installed: bool,
+) -> None:
+    """Verified expiry releases one interrupted activation without erasing terminal proof."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        if installed:
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                "sync-install-0123456789",
+                home_server_cursor=0,
+                lease=lease,
+            )
+        for _ in range(2):
+            repository.expire_activation(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                sync_receipt_id="sync-install-0123456789",
+                lease=lease,
+            )
+        fresh = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert fresh.activation_id != prepared.activation_id
+    assert fresh.baseline == prepared.baseline
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.load_activation(prepared.activation_id)
+    with repository.database.transaction() as connection:
+        row = connection.execute(
+            "SELECT state, ciphertext FROM personal_context_activations WHERE activation_id = ?",
+            (prepared.activation_id,),
+        ).fetchone()
+        covered = connection.execute(
+            "SELECT activation_covered_through_sequence FROM personal_context_publication_profiles"
+        ).fetchone()[0]
+    assert tuple(row) == ("expired", b"")
+    assert covered == (prepared.publication_watermark if installed else 0)
+
+
+def test_expiring_one_device_keeps_peers_continuity_and_acknowledgment(service: PersonalContextService) -> None:
+    """Expiration cannot revoke the shared profile pair or another device's receipt."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    active = {}
+    for device_id in ("device-a", "device-b"):
+        with publications.profile_lease(manifest.profile_id) as lease:
+            prepared = repository.prepare_activation(manifest.profile_id, device_id=device_id, lease=lease)
+            repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                f"sync-install-{device_id}",
+                home_server_cursor=0,
+                lease=lease,
+            )
+        active[device_id] = repository.confirm_activation_device(
+            prepared.activation_id,
+            prepared.baseline_digest,
+            device_id,
+            f"sync-ack-{device_id}",
+            local_receipt_id=f"local-ack-{device_id}",
+            dataset_id="dataset-a",
+        )
+    expired = active["device-a"]
+    with publications.profile_lease(manifest.profile_id) as lease:
+        repository.expire_activation(
+            expired.activation_id,
+            expired.baseline_digest,
+            sync_receipt_id="sync-install-device-a",
+            lease=lease,
+        )
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(
+            profile_id=manifest.profile_id,
+            device_id="device-a",
+            dataset_id="dataset-a",
+            activation_epoch=expired.activation_epoch,
+            continuity_token=expired.continuity_token,
+        )
+    peer = active["device-b"]
+    assert (
+        repository.validate_activation_exchange(
+            profile_id=manifest.profile_id,
+            device_id="device-b",
+            dataset_id="dataset-a",
+            activation_epoch=peer.activation_epoch,
+            continuity_token=peer.continuity_token,
+        ).continuity_token
+        == peer.continuity_token
+    )
+    repository.rotate_encryption_key(manifest.profile_id)
+    assert repository.load_activation(peer.activation_id).baseline == peer.baseline
+
+
+def test_expired_latest_activation_cannot_fall_back_to_older_device_ack(service: PersonalContextService) -> None:
+    """A device's superseded receipt is not a route around its expired current baseline."""
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    identifiers = []
+    for index in range(2):
+        with publications.profile_lease(manifest.profile_id) as lease:
+            prepared = repository.prepare_activation(
+                manifest.profile_id,
+                device_id="device-a",
+                fresh=True,
+                lease=lease,
+            )
+            installed = repository.complete_activation_install(
+                prepared.activation_id,
+                prepared.baseline_digest,
+                f"sync-install-0123456789-{index}",
+                home_server_cursor=0,
+                lease=lease,
+            )
+        repository.confirm_activation_device(
+            installed.activation_id,
+            installed.baseline_digest,
+            "device-a",
+            f"sync-ack-0123456789-{index}",
+            local_receipt_id=f"local-ack-0123456789-{index}",
+            dataset_id="dataset-a",
+        )
+        identifiers.append(installed.activation_id)
+    with publications.profile_lease(manifest.profile_id) as lease:
+        repository.expire_activation(
+            installed.activation_id,
+            installed.baseline_digest,
+            sync_receipt_id="sync-install-0123456789-1",
+            lease=lease,
+        )
+    with pytest.raises(ValueError, match="activation_required"):
+        repository.validate_activation_exchange(
+            profile_id=manifest.profile_id,
+            device_id="device-a",
+            dataset_id="dataset-a",
+            activation_epoch=installed.activation_epoch,
+            continuity_token=installed.continuity_token,
+        )
+    with publications.profile_lease(manifest.profile_id) as lease:
+        fresh = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+    assert fresh.activation_id not in identifiers

--- a/tldw_Server_API/tests/Personalization/test_personal_context_activation.py
+++ b/tldw_Server_API/tests/Personalization/test_personal_context_activation.py
@@ -31,6 +31,63 @@ from tldw_Server_API.tests.Personalization.personal_context_test_support import 
 pytestmark = pytest.mark.unit
 
 
+def test_contended_nonblocking_profile_lease_skips_canonical_sql(
+    service: PersonalContextService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller holding Sync must not touch canonical storage while another thread owns the lease."""
+    manifest = service.create_profile()
+    publications = PersonalContextPublicationRelayStore(service._repository.database)
+
+    def no_canonical_sql(*args, **kwargs):
+        raise AssertionError("contended relay must not open a canonical transaction")
+
+    def attempt() -> None:
+        with publications.profile_lease(manifest.profile_id, blocking=False) as lease:
+            assert lease is None
+
+    with publications.profile_lease(manifest.profile_id):
+        with monkeypatch.context() as patch:
+            patch.setattr(service._repository.database, "transaction", no_canonical_sql)
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                executor.submit(attempt).result(timeout=5)
+    with publications.profile_lease(manifest.profile_id, blocking=False) as lease:
+        assert lease is not None
+
+
+def test_activation_failures_have_content_free_domain_types(service: PersonalContextService) -> None:
+    """Callers can distinguish invalid input, missing state, contention, and stale proof."""
+    from tldw_Server_API.app.core import exceptions
+
+    manifest = service.create_profile()
+    repository = service._repository
+    publications = PersonalContextPublicationRelayStore(repository.database)
+    cases = []
+    with publications.profile_lease(manifest.profile_id) as lease:
+        for invoke in (
+            lambda: repository.prepare_activation(manifest.profile_id, device_id="", lease=lease),
+            lambda: repository.load_activation("missing-activation"),
+        ):
+            with pytest.raises(ValueError, match="personal_context_activation_required") as error:
+                invoke()
+            cases.append(error.value)
+        prepared = repository.prepare_activation(manifest.profile_id, device_id="device-a", lease=lease)
+        with pytest.raises(ValueError, match="personal_context_activation_pending") as error:
+            repository.prepare_activation(manifest.profile_id, device_id="device-b", lease=lease)
+        cases.append(error.value)
+    with pytest.raises(ValueError, match="personal_context_activation_required") as error:
+        repository.complete_activation_install(
+            prepared.activation_id, prepared.baseline_digest, "receipt", home_server_cursor=0, lease=lease
+        )
+    cases.append(error.value)
+    assert [type(error).__name__ for error in cases] == [
+        "PersonalContextActivationInputError",
+        "PersonalContextActivationMissingError",
+        "PersonalContextActivationPendingError",
+        "PersonalContextActivationStaleError",
+    ]
+    assert all(isinstance(error, exceptions.PersonalContextActivationError) for error in cases)
+
+
 @pytest.mark.parametrize("legacy", [False, True])
 def test_abandoned_preparation_expires_without_covering_source(service: PersonalContextService, legacy: bool) -> None:
     """Another device's relay retires a stale baseline without losing queued writes."""

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -4,7 +4,9 @@ import base64
 import hashlib
 import hmac
 import json
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -71,6 +73,42 @@ from tldw_Server_API.tests.Personalization.personal_context_test_support import 
 )
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("requested", [None, 0, 1, 2])
+@pytest.mark.parametrize("advertised", [0, 1])
+def test_personal_context_core_dispatch_enforces_rollout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, requested: int | None, advertised: int
+) -> None:
+    service = _build_service(tmp_path)
+    capabilities = service.capabilities(user_id="dispatch-user")
+    capabilities = replace(
+        capabilities,
+        personal_context=replace(capabilities.personal_context, ongoing_sync_version=advertised),
+    )
+    monkeypatch.setattr(service, "capabilities", lambda **_kwargs: capabilities)
+    calls: list[str] = []
+
+    def first_link(**_kwargs: Any) -> None:
+        calls.append("first-link")
+
+    def activation(**_kwargs: Any) -> None:
+        calls.append("activation")
+
+    monkeypatch.setattr(
+        service, "_profile_manager", lambda: SimpleNamespace(bootstrap_personal_context=first_link)
+    )
+    monkeypatch.setattr(service, "prepare_personal_context_activation", activation)
+    arguments = {
+        "user_id": "dispatch-user", "device_id": "dispatch-device", "ongoing_sync_version": requested
+    }
+    if requested == 2 or (requested == 1 and advertised == 0):
+        with pytest.raises(SyncStoreError, match="personal_context_ongoing_sync_unavailable"):
+            service.bootstrap_personal_context(**arguments)
+        assert calls == []
+    else:
+        service.bootstrap_personal_context(**arguments)
+        assert calls == ["activation" if requested == 1 else "first-link"]
 
 
 def _clock() -> str:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -97,17 +97,24 @@ def _seed_persisted_personal_context_exchange(
     service: SyncV2Service,
     dataset_id: str,
 ) -> dict[str, object]:
-    """Seed the future activation owner state without exposing an HTTP route."""
+    """Install real canonical receipts before enabling the test-only exchange gate."""
+
+    baseline = service.prepare_personal_context_activation(user_id="101", device_id="pc-device")
+    _receipt, installed_proof = service.acknowledge_personal_context_activation(
+        user_id="101",
+        dataset_id=dataset_id,
+        device_id="pc-device",
+        activation_id=baseline.activation.activation_id,
+        baseline_digest=baseline.activation.baseline_digest,
+        local_receipt_id="endpoint-local-install-0123456789",
+        exchange=baseline.personal_context_exchange,
+    )
 
     dataset = service.store.get_dataset(dataset_id)
     assert dataset is not None
     metadata = dict(dataset.metadata)
     state = dict(metadata["personal_context"])
-    proof: dict[str, object] = {
-        "ongoing_sync_version": 1,
-        "activation_epoch": "epoch_0123456789abcdef",
-        "continuity_token": "continuity_0123456789abcdef",
-    }
+    proof = installed_proof.model_dump(mode="json")
     state.update(proof)
     metadata["personal_context"] = state
     with service.store.db.backend.transaction() as connection:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_activation.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_activation.py
@@ -450,3 +450,204 @@ def test_protected_sync_baseline_has_no_plaintext_and_survives_rotation(linked_a
     replay = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
     assert replay.activation.activation_id == result.activation.activation_id
     assert replay.records == result.records
+
+
+@pytest.mark.parametrize("expected_generation", [None, 0])
+def test_purge_between_link_authorization_and_preparation_rejects_install(
+    linked_activation, monkeypatch: pytest.MonkeyPatch, expected_generation: int | None
+) -> None:
+    """A receipt for generation zero cannot install a generation-one baseline."""
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+
+    canonical, service = linked_activation
+    prepare = PersonalContextActivationService.prepare
+
+    def purge_then_prepare(self, *args, **kwargs):
+        canonical.purge_profile(mode="everywhere", confirmation="DELETE EVERYWHERE", expected_purge_generation=0)
+        return prepare(self, *args, **kwargs)
+
+    monkeypatch.setattr(PersonalContextActivationService, "prepare", purge_then_prepare)
+    code = "purge_generation_stale" if expected_generation is not None else "activation_required"
+    with pytest.raises(SyncStoreError, match=code):
+        service.prepare_personal_context_activation(
+            user_id=_USER_ID, device_id=_DEVICE_ID, expected_purge_generation=expected_generation
+        )
+    assert not service.store.db.execute("SELECT * FROM sync_personal_context_activations").rows
+    dataset = service.store.personal_context_dataset_for_profile(
+        user_id=_USER_ID, profile_id=canonical.get_manifest().profile_id
+    )
+    assert "activation_epoch" not in dataset.metadata["personal_context"]
+
+
+def test_activation_waiting_for_relay_lease_does_not_hold_sync_transaction(
+    linked_activation, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relay owning the profile lease can finish its Sync stage during install."""
+    from concurrent.futures import ThreadPoolExecutor
+    from contextlib import contextmanager
+    from threading import Event, current_thread
+
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+    from tldw_Server_API.app.core.Personalization.personal_context_publication import (
+        PersonalContextPublicationRelayStore,
+    )
+
+    canonical, service = linked_activation
+    profile_id = canonical.get_manifest().profile_id
+    dataset = service.store.personal_context_dataset_for_profile(user_id=_USER_ID, profile_id=profile_id)
+    prepared, relay_owned, installer_waiting, stage_done = Event(), Event(), Event(), Event()
+    prepare = PersonalContextActivationService.prepare
+    lease_method = PersonalContextPublicationRelayStore.profile_lease
+
+    def prepare_then_pause(self, *args, **kwargs):
+        result = prepare(self, *args, **kwargs)
+        prepared.set()
+        assert relay_owned.wait(5)
+        return result
+
+    @contextmanager
+    def observe_lease(self, requested_profile, **kwargs):
+        if prepared.is_set() and current_thread().name != "relay-stage":
+            installer_waiting.set()
+        with lease_method(self, requested_profile, **kwargs) as lease:
+            yield lease
+
+    def relay_stage():
+        current_thread().name = "relay-stage"
+        assert prepared.wait(5)
+        with lease_method(PersonalContextPublicationRelayStore(canonical._repository.database), profile_id):
+            relay_owned.set()
+            assert installer_waiting.wait(5)
+            with service.store.personal_context_authority_guard(dataset.dataset_id, profile_id):
+                stage_done.set()
+
+    monkeypatch.setattr(PersonalContextActivationService, "prepare", prepare_then_pause)
+    monkeypatch.setattr(PersonalContextPublicationRelayStore, "profile_lease", observe_lease)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        relay = executor.submit(relay_stage)
+        activation = executor.submit(
+            service.prepare_personal_context_activation, user_id=_USER_ID, device_id=_DEVICE_ID
+        )
+        relay.result(timeout=15)
+        result = activation.result(timeout=15)
+    assert stage_done.is_set()
+    assert result.activation.state == "installed"
+
+
+def test_push_after_commit_relay_does_not_wait_for_installers_profile_lease(
+    linked_activation, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real push commits ingress while a competing installer waits for its Sync guard."""
+    import hashlib
+    import hmac
+    from concurrent.futures import ThreadPoolExecutor
+    from contextlib import contextmanager
+    from threading import Event, current_thread
+
+    from tldw_profile_core.canonical import canonical_json_bytes
+
+    from tldw_Server_API.app.core.Personalization.personal_context_publication import (
+        PersonalContextPublicationRelayStore,
+    )
+    from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelopeCreate
+    from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import PersonalContextExchangeProof
+    from tldw_Server_API.tests.Personalization.personal_context_test_support import preference_record
+    from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import _seed_exchange
+
+    canonical, service = linked_activation
+    manifest = canonical.get_manifest()
+    dataset = service.store.personal_context_dataset_for_profile(user_id=_USER_ID, profile_id=manifest.profile_id)
+    exchange = PersonalContextExchangeProof.model_validate(_seed_exchange(service, dataset.dataset_id))
+    key_id, key = canonical.sync_integrity_key(manifest.profile_id)
+    payload = {
+        **preference_record(manifest.profile_id, record_id="racing-ingress-record").model_dump(mode="json"),
+        "scope_id": canonical.list_scopes()[0].scope_id,
+    }
+    clear = canonical_json_bytes(payload)
+    envelope = SyncEnvelopeCreate(
+        dataset_id=dataset.dataset_id,
+        client_envelope_id="racing-push-after-commit",
+        device_id=_DEVICE_ID,
+        domain="personal_context.record",
+        operation="upsert",
+        object_id=payload["record_id"],
+        parent_id=payload["scope_id"],
+        adapter_version=1,
+        schema_version=1,
+        payload=payload,
+        payload_hash="hmac-sha256-v1:" + hmac.new(key, clear, hashlib.sha256).hexdigest(),
+        payload_size_bytes=len(clear),
+        entity_version=payload["version_id"],
+        routing_metadata={"integrity_key_id": key_id, "profile_id": manifest.profile_id, "purge_generation": 0},
+        encryption_metadata={"policy": "server_trusted_v1"},
+    )
+    committed, installer_owned, callback_entered, installer_done = Event(), Event(), Event(), Event()
+    repository_type = type(canonical._repository)
+    apply_ingress = repository_type.apply_ingress_and_publish
+    lease_method = PersonalContextPublicationRelayStore.profile_lease
+    skipped_callback_claims = []
+
+    def pause_after_ingress(self, *args, **kwargs):
+        result = apply_ingress(self, *args, **kwargs)
+        committed.set()
+        assert installer_owned.wait(5)
+        return result
+
+    @contextmanager
+    def observe_callback_lease(self, profile_id, **kwargs):
+        callback = committed.is_set() and current_thread().name == "push-worker"
+        if callback:
+            callback_entered.set()
+        with lease_method(self, profile_id, **kwargs) as lease:
+            if callback and lease is None:
+                skipped_callback_claims.append(profile_id)
+            yield lease
+
+    def installer():
+        assert committed.wait(5)
+        publications = PersonalContextPublicationRelayStore(canonical._repository.database)
+        with lease_method(publications, manifest.profile_id):
+            installer_owned.set()
+            assert callback_entered.wait(5)
+            with service.store.personal_context_authority_guard(dataset.dataset_id, manifest.profile_id):
+                installer_done.set()
+
+    def push():
+        current_thread().name = "push-worker"
+        return service.push(
+            user_id=_USER_ID,
+            dataset_id=dataset.dataset_id,
+            device_id=_DEVICE_ID,
+            envelopes=[envelope],
+            personal_context_exchange=exchange,
+        )
+
+    monkeypatch.setattr(repository_type, "apply_ingress_and_publish", pause_after_ingress)
+    monkeypatch.setattr(PersonalContextPublicationRelayStore, "profile_lease", observe_callback_lease)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        installation = executor.submit(installer)
+        pushed = executor.submit(push)
+        result = pushed.result(timeout=15)
+        assert not result.rejected
+        installation.result(timeout=15)
+    assert installer_done.is_set()
+    assert skipped_callback_claims
+    assert not result.rejected
+    assert len(result.accepted) == 1
+    stored = service.store.get_envelope_by_client_id(dataset.dataset_id, envelope.client_envelope_id)
+    assert stored.apply_status == "applied"
+    assert canonical.get_record(payload["record_id"]).payload == preference_record().payload
+    recovered = service.personal_context_relay.relay_profile(
+        user_id=_USER_ID,
+        profile_id=manifest.profile_id,
+        dataset_id=dataset.dataset_id,
+        after_server_cursor=None,
+        wall_time_ms=1000,
+    )
+    assert recovered.source_exhausted
+    with canonical._repository.database.transaction() as connection:
+        rows = connection.execute(
+            "SELECT row_state FROM personal_context_publication_rows WHERE opaque_object_id = ?",
+            (payload["record_id"],),
+        ).fetchall()
+    assert [row[0] for row in rows] == ["acknowledged"]

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_activation.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_activation.py
@@ -1,0 +1,452 @@
+"""Exercise durable activation installation and exact device acknowledgments."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Personalization.personal_context_service import PersonalContextService
+from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+from tldw_Server_API.app.core.Sync.v2.models import PERSONAL_CONTEXT_SYNC_DOMAINS, SyncDatasetCreate
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import (
+    _DEVICE_ID,
+    _USER_ID,
+    _register_device,
+)
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import (
+    production_factories as production_factories,
+)
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_exchange_gate import _client
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def activation_store(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[SyncV2Store]:
+    """Use the shared isolated PostgreSQL fixture or a real SQLite database."""
+
+    backend = None
+    if request.param == "postgres":
+        backend = DatabaseBackendFactory.create_backend(request.getfixturevalue("pg_database_config"))
+        database = SyncDatabase(backend=backend)
+    else:
+        database = SyncDatabase(sqlite_path=tmp_path / "activation-sync.db")
+    store = SyncV2Store(database)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="activation-dataset",
+            owner_user_id="activation-user",
+            scope_type="personal",
+            encryption_policy="server_trusted_v1",
+            domains=sorted(PERSONAL_CONTEXT_SYNC_DOMAINS),
+        )
+    )
+    try:
+        yield store
+    finally:
+        if backend is not None:
+            backend.get_pool().close_all()
+
+
+def _installation() -> dict[str, object]:
+    """Return content-free install identity plus already-encrypted fixture bytes."""
+
+    return {
+        "activation_id": "activation-0123456789",
+        "dataset_id": "activation-dataset",
+        "user_id": "activation-user",
+        "profile_id": "profile-0123456789",
+        "device_id": "activation-device",
+        "baseline_digest": "a" * 64,
+        "purge_generation": 0,
+        "publication_watermark": 3,
+        "home_server_cursor": 7,
+        "receipt_id": "install-receipt-0123456789",
+        "envelopes_json": '[{"ciphertext":"opaque"}]',
+        "expires_at": "2099-01-01T00:00:00+00:00",
+    }
+
+
+def test_installation_replays_exactly_after_reopening(activation_store: SyncV2Store) -> None:
+    """Restart must retain the first immutable installation, not replace its bytes."""
+
+    with activation_store.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+        first = guarded.install_personal_context_activation(**_installation())
+    reopened = SyncV2Store(activation_store.db)
+    with reopened.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+        replay = guarded.install_personal_context_activation(**_installation())
+    assert replay == first
+    assert replay["home_server_cursor"] == 7
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("baseline_digest", "b" * 64),
+        ("home_server_cursor", 8),
+        ("device_id", "different-device"),
+        ("envelopes_json", "[]"),
+    ],
+)
+def test_changed_installation_replay_is_rejected(activation_store: SyncV2Store, field: str, value: object) -> None:
+    """An activation ID never names a different baseline or checkpoint."""
+
+    with activation_store.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+        guarded.install_personal_context_activation(**_installation())
+    changed = {**_installation(), field: value}
+    with pytest.raises(SyncStoreError, match="activation_receipt_mismatch"):
+        with activation_store.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+            guarded.install_personal_context_activation(**changed)
+
+
+def test_device_acknowledgment_is_exact_and_durable(activation_store: SyncV2Store) -> None:
+    """The same acknowledgment replays; changing its local receipt fails closed."""
+
+    with activation_store.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+        guarded.install_personal_context_activation(**_installation())
+        first = guarded.acknowledge_personal_context_activation(
+            activation_id="activation-0123456789",
+            dataset_id="activation-dataset",
+            user_id="activation-user",
+            device_id="activation-device",
+            baseline_digest="a" * 64,
+            local_receipt_id="local-receipt-0123456789",
+        )
+    with activation_store.personal_context_authority_guard("activation-dataset", "profile-0123456789") as guarded:
+        replay = guarded.acknowledge_personal_context_activation(
+            activation_id="activation-0123456789",
+            dataset_id="activation-dataset",
+            user_id="activation-user",
+            device_id="activation-device",
+            baseline_digest="a" * 64,
+            local_receipt_id="local-receipt-0123456789",
+        )
+        assert replay == first
+        with pytest.raises(SyncStoreError, match="activation_receipt_mismatch"):
+            guarded.acknowledge_personal_context_activation(
+                activation_id="activation-0123456789",
+                dataset_id="activation-dataset",
+                user_id="activation-user",
+                device_id="activation-device",
+                baseline_digest="a" * 64,
+                local_receipt_id="changed-receipt-0123456789",
+            )
+
+
+def _set_exchange_version(service: SyncV2Service, dataset_id: str, version: int) -> None:
+    """Explicitly simulate rollout without creating a forged continuity proof."""
+
+    dataset = service.store.get_dataset(dataset_id)
+    metadata = dataset.metadata
+    metadata["personal_context"]["ongoing_sync_version"] = version
+    with service.store.db.backend.transaction() as connection:
+        service.store.db.execute(
+            "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+            (json.dumps(metadata), dataset_id),
+            connection=connection,
+        )
+
+
+def test_production_activation_requires_ack_and_replays(production_factories) -> None:
+    """Real factories install one baseline, then require an exact local acknowledgment."""
+
+    canonical, service = production_factories
+    canonical.create_profile(runtime_enabled=False)
+    _register_device(service)
+    initial = service.bootstrap_personal_context(user_id=_USER_ID, device_id=_DEVICE_ID)
+    service.complete_personal_context_link(
+        user_id=_USER_ID,
+        device_id=_DEVICE_ID,
+        dataset_id=initial.dataset_id,
+        bootstrap_cursor=initial.cursor,
+    )
+    prepared = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert prepared.activation.state == "installed"
+    _set_exchange_version(service, initial.dataset_id, 1)
+    with pytest.raises(SyncStoreError, match="activation_required"):
+        service.verified_active_exchange(
+            user_id=_USER_ID,
+            dataset_id=initial.dataset_id,
+            device_id=_DEVICE_ID,
+            exchange=prepared.personal_context_exchange,
+        )
+    receipt, proof = service.acknowledge_personal_context_activation(
+        user_id=_USER_ID,
+        dataset_id=initial.dataset_id,
+        device_id=_DEVICE_ID,
+        activation_id=prepared.activation.activation_id,
+        baseline_digest=prepared.activation.baseline_digest,
+        local_receipt_id="local-installation-0123456789",
+        exchange=prepared.personal_context_exchange,
+    )
+    assert receipt.state == "active"
+    assert (
+        service.verified_active_exchange(
+            user_id=_USER_ID,
+            dataset_id=initial.dataset_id,
+            device_id=_DEVICE_ID,
+            exchange=proof,
+        )
+        == proof
+    )
+    _set_exchange_version(service, initial.dataset_id, 0)
+    with pytest.raises(SyncStoreError, match="activation_required"):
+        service.verified_active_exchange(
+            user_id=_USER_ID,
+            dataset_id=initial.dataset_id,
+            device_id=_DEVICE_ID,
+            exchange=proof,
+        )
+    _set_exchange_version(service, initial.dataset_id, 1)
+    assert (
+        service.verified_active_exchange(
+            user_id=_USER_ID,
+            dataset_id=initial.dataset_id,
+            device_id=_DEVICE_ID,
+            exchange=proof,
+        )
+        == proof
+    )
+    replay = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert replay.activation.activation_id == prepared.activation.activation_id
+    assert replay.manifest == prepared.manifest
+    assert service.capabilities().personal_context.ongoing_sync_version == 0
+
+
+def test_ongoing_bootstrap_stays_closed_before_rollout(production_factories) -> None:
+    """An explicit version-one request cannot bypass version-zero readiness."""
+
+    _canonical, service = production_factories
+    with _client(service) as client:
+        response = client.post(
+            "/api/v1/sync/personal-context/bootstrap",
+            json={
+                "device_id": _DEVICE_ID,
+                "ongoing_sync_version": 1,
+            },
+        )
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "personal_context_ongoing_sync_unavailable"
+
+
+@pytest.fixture
+def linked_activation(
+    production_factories: tuple[PersonalContextService, SyncV2Service],
+) -> tuple[PersonalContextService, SyncV2Service]:
+    """Create a reviewed first link through actual canonical and Sync services."""
+
+    canonical, service = production_factories
+    canonical.create_profile(runtime_enabled=False)
+    _register_device(service)
+    initial = service.bootstrap_personal_context(user_id=_USER_ID, device_id=_DEVICE_ID)
+    service.complete_personal_context_link(
+        user_id=_USER_ID, device_id=_DEVICE_ID, dataset_id=initial.dataset_id, bootstrap_cursor=initial.cursor
+    )
+    return canonical, service
+
+
+def test_sync_install_survives_failure_before_canonical_coverage(
+    linked_activation: tuple[PersonalContextService, SyncV2Service], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed coverage CAS reuses the already committed exact Sync baseline."""
+
+    canonical, service = linked_activation
+    repository_type = type(canonical._repository)
+    original = repository_type.complete_activation_install
+
+    def interrupted(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("injected coverage interruption")
+
+    monkeypatch.setattr(repository_type, "complete_activation_install", interrupted)
+    with pytest.raises(SyncStoreError, match="activation_required"):
+        service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    rows = service.store.db.execute("SELECT * FROM sync_personal_context_activations").rows
+    assert len(rows) == 1
+    first = dict(rows[0])
+    monkeypatch.setattr(repository_type, "complete_activation_install", original)
+    result = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert result.activation.activation_id == first["activation_id"]
+    assert service.store.get_personal_context_activation(first["activation_id"]) == first
+
+
+def test_tampered_sync_baseline_cannot_gain_canonical_coverage(
+    linked_activation: tuple[PersonalContextService, SyncV2Service], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ciphertext identity is reverified even when Sync claims installation succeeded."""
+
+    canonical, service = linked_activation
+    repository_type = type(canonical._repository)
+    original = repository_type.complete_activation_install
+
+    def interrupted(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("injected coverage interruption")
+
+    monkeypatch.setattr(repository_type, "complete_activation_install", interrupted)
+    with pytest.raises(SyncStoreError):
+        service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    with service.store.db.backend.transaction() as connection:
+        service.store.db.execute(
+            "UPDATE sync_personal_context_activations SET envelopes_json = ?", ("[]",), connection=connection
+        )
+    monkeypatch.setattr(repository_type, "complete_activation_install", original)
+    with pytest.raises(SyncStoreError, match="activation_receipt_mismatch"):
+        service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+
+
+def test_expired_sync_installation_requires_fresh_baseline(
+    linked_activation: tuple[PersonalContextService, SyncV2Service], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An expired unacknowledged delivery receipt cannot silently reactivate a device."""
+
+    _canonical, service = linked_activation
+    result = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    from tldw_Server_API.app.core.Sync.v2 import personal_context_activation as activation_module
+
+    future = datetime.now(timezone.utc) + timedelta(days=31)
+    monkeypatch.setattr(activation_module, "_activation_now", lambda: future)
+    with pytest.raises(SyncStoreError):
+        service.acknowledge_personal_context_activation(
+            user_id=_USER_ID,
+            device_id=_DEVICE_ID,
+            dataset_id=result.dataset_id,
+            activation_id=result.activation.activation_id,
+            baseline_digest=result.activation.baseline_digest,
+            local_receipt_id="local-receipt-expired-12345",
+            exchange=result.personal_context_exchange,
+        )
+    renewed = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert renewed.activation.activation_id != result.activation.activation_id
+    assert renewed.personal_context_exchange == result.personal_context_exchange
+
+
+def test_sync_ack_survives_failure_before_canonical_ack(linked_activation, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry after an independently committed Sync ack must use the same local receipt."""
+
+    canonical, service = linked_activation
+    result = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    repository_type = type(canonical._repository)
+    original = repository_type.confirm_activation_device
+
+    def interrupted(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("injected acknowledgment interruption")
+
+    monkeypatch.setattr(repository_type, "confirm_activation_device", interrupted)
+    arguments = {
+        "user_id": _USER_ID,
+        "device_id": _DEVICE_ID,
+        "dataset_id": result.dataset_id,
+        "activation_id": result.activation.activation_id,
+        "baseline_digest": result.activation.baseline_digest,
+        "local_receipt_id": "durable-local-ack-0123456789",
+        "exchange": result.personal_context_exchange,
+    }
+    with pytest.raises(SyncStoreError, match="activation_required"):
+        service.acknowledge_personal_context_activation(**arguments)
+    stored = service.store.get_personal_context_activation_ack(result.activation.activation_id, _DEVICE_ID)
+    assert stored is not None
+    monkeypatch.setattr(repository_type, "confirm_activation_device", original)
+    receipt, _proof = service.acknowledge_personal_context_activation(**arguments)
+    assert receipt.state == "active"
+    assert service.store.get_personal_context_activation_ack(result.activation.activation_id, _DEVICE_ID) == stored
+    with pytest.raises(SyncStoreError, match="activation_receipt_mismatch"):
+        service.acknowledge_personal_context_activation(
+            **{**arguments, "local_receipt_id": "different-local-ack-0123456789"}
+        )
+
+
+def test_direct_purge_removes_sync_activation_history(linked_activation) -> None:
+    """Existing authorized purge also removes new encrypted baseline and ack storage."""
+
+    canonical, service = linked_activation
+    result = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    service.acknowledge_personal_context_activation(
+        user_id=_USER_ID,
+        device_id=_DEVICE_ID,
+        dataset_id=result.dataset_id,
+        activation_id=result.activation.activation_id,
+        baseline_digest=result.activation.baseline_digest,
+        local_receipt_id="purge-local-ack-0123456789",
+        exchange=result.personal_context_exchange,
+    )
+    canonical.set_after_commit_purge_cleanup(
+        lambda intent: canonical.cleanup_sync_history(intent, user_id=_USER_ID, sync=service)
+    )
+    canonical.purge_profile(mode="everywhere", confirmation="DELETE EVERYWHERE", expected_purge_generation=0)
+    assert service.store.get_personal_context_activation(result.activation.activation_id) is None
+    assert service.store.get_personal_context_activation_ack(result.activation.activation_id, _DEVICE_ID) is None
+
+
+def test_authenticated_activation_endpoints_use_real_journals(
+    linked_activation, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ready-route branch echoes persisted receipts and rejects another owner."""
+
+    from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+
+    _canonical, service = linked_activation
+    capabilities = service.capabilities
+
+    def ready(**kwargs):
+        current = capabilities(**kwargs)
+        return replace(current, personal_context=replace(current.personal_context, ongoing_sync_version=1))
+
+    monkeypatch.setattr(service, "capabilities", ready)
+    with _client(service) as client:
+        client.app.dependency_overrides[get_request_user] = lambda: User(id=_USER_ID, username="activation-owner")
+        response = client.post(
+            "/api/v1/sync/personal-context/bootstrap", json={"device_id": _DEVICE_ID, "ongoing_sync_version": 1}
+        )
+        assert response.status_code == 200
+        prepared = response.json()
+        arguments = {
+            "dataset_id": prepared["dataset_id"],
+            "device_id": _DEVICE_ID,
+            "activation_id": prepared["activation"]["activation_id"],
+            "baseline_digest": prepared["activation"]["baseline_digest"],
+            "local_receipt_id": "http-local-receipt-0123456789",
+            "personal_context_exchange": prepared["personal_context_exchange"],
+        }
+        response = client.post("/api/v1/sync/personal-context/activation/acknowledge", json=arguments)
+        assert response.status_code == 200
+        assert response.json()["receipt"]["state"] == "active"
+        assert response.json()["personal_context_exchange"] == prepared["personal_context_exchange"]
+        client.app.dependency_overrides[get_request_user] = lambda: User(id="other-owner", username="other-owner")
+        denied = client.post("/api/v1/sync/personal-context/activation/acknowledge", json=arguments)
+        assert denied.status_code in {403, 404}
+
+
+def test_protected_sync_baseline_has_no_plaintext_and_survives_rotation(linked_activation) -> None:
+    """Real Sync files retain ciphertext only and ordinary key rotation preserves replay."""
+
+    from tldw_Server_API.tests.Personalization.personal_context_test_support import preference_record
+
+    canonical, service = linked_activation
+    canary = "activation-private-canary-c5c38e9b"
+    record = preference_record(value=canary)
+    canonical.create_manual_record(
+        scope_id=canonical.list_scopes()[0].scope_id,
+        payload=record.payload,
+        semantic_key=None,
+        controls=record.controls,
+    )
+    result = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert any(item.payload.value == canary for item in result.records)
+    stored = service.store.get_personal_context_activation(result.activation.activation_id)
+    assert canary not in json.dumps(stored)
+    path = Path(service.store.db.backend.config.sqlite_path)
+    for candidate in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if candidate.exists():
+            assert canary.encode() not in candidate.read_bytes()
+    canonical._repository.rotate_encryption_key(canonical.get_manifest().profile_id)
+    replay = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    assert replay.activation.activation_id == result.activation.activation_id
+    assert replay.records == result.records

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_authority_identity.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_authority_identity.py
@@ -80,6 +80,14 @@ class AuthorityHarness:
             id_factory=next_id,
         )
         self.manifest = self.canonical.create_profile()
+        # These tests intentionally retain unacknowledged source publications.
+        # Isolate activation authorization instead of covering their test subjects;
+        # the activation integration suite verifies real cross-store receipts.
+        monkeypatch.setattr(
+            self.canonical._repository,
+            "validate_activation_exchange",
+            self.validate_activation_exchange,
+        )
         key_id, integrity_key = self.canonical.sync_integrity_key(
             self.manifest.profile_id
         )
@@ -121,6 +129,32 @@ class AuthorityHarness:
             )
         )
         self.publications = PersonalContextPublicationRelayStore(self.personal_db)
+
+    def validate_activation_exchange(
+        self,
+        *,
+        profile_id: str,
+        device_id: str,
+        dataset_id: str,
+        activation_epoch: str,
+        continuity_token: str,
+    ) -> PersonalContextExchangeProof:
+        """Authenticate this fixture's fixed proof independently of Sync metadata."""
+        proof = PersonalContextExchangeProof(
+            ongoing_sync_version=1,
+            activation_epoch=activation_epoch,
+            continuity_token=continuity_token,
+        )
+        if (
+            profile_id != self.manifest.profile_id
+            or device_id != "device-a"
+            or dataset_id != "dataset-a"
+            or proof.activation_epoch != "epoch_0123456789abcdef"
+            or proof.continuity_token != "continuity_0123456789abcdef"
+        ):
+            raise ValueError("personal_context_activation_required")
+        return proof
+
     @contextmanager
     def claimed_row(self) -> Iterator[PublicationSourceRow]:
         with self.publications.profile_lease(self.manifest.profile_id) as lease:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py
@@ -1,10 +1,14 @@
+"""Bootstrap compatibility, cursor, and first-link authorization regressions."""
+
 from __future__ import annotations
 
 import base64
 import hashlib
 import hmac
 import inspect
+import json
 import threading
+import uuid
 from concurrent.futures import (
     ThreadPoolExecutor,
 )
@@ -18,10 +22,20 @@ from pathlib import Path
 import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from tldw_profile_core import ProfileRecord
 from tldw_profile_core.canonical import canonical_json_bytes
 
 from tldw_Server_API.app.core.DB_Management import Sync_DB as sync_db_module
+from tldw_Server_API.app.core.DB_Management.Personal_Context_Key_Store import ServerProfileKeyProvider
+from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Personalization.personal_context_publication import (
+    CanonicalApplyReceipt,
+    IngressIdentity,
+    PersonalContextPublicationJournal,
+    PersonalContextPublicationRelayStore,
+    PublicationObject,
+)
 from tldw_Server_API.app.core.Personalization.personal_context_service import (
     PersonalContextService,
 )
@@ -43,9 +57,12 @@ from tldw_Server_API.app.core.Sync.v2.materializers.personal_context import (
 from tldw_Server_API.app.core.Sync.v2.models import (
     PERSONAL_CONTEXT_SYNC_DOMAINS,
     SyncDatasetCreate,
+    SyncEnvelope,
     SyncEnvelopeCreate,
 )
-from tldw_Server_API.app.core.Sync.v2.profile import PersonalContextBootstrapError
+from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import PersonalContextExchangeProof
+from tldw_Server_API.app.core.Sync.v2.personal_context_relay import PersonalContextRelay
+from tldw_Server_API.app.core.Sync.v2.profile import PersonalContextBootstrap, PersonalContextBootstrapError
 from tldw_Server_API.app.core.Sync.v2.security import (
     server_trusted_encryption_status_from_config,
 )
@@ -56,6 +73,7 @@ from tldw_Server_API.app.core.Sync.v2.service import (
 )
 from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
 from tldw_Server_API.tests.Personalization.personal_context_test_support import (
+    encoded_master_key,
     global_scope,
     manifest,
     preference_record,
@@ -66,9 +84,18 @@ pytestmark = pytest.mark.unit
 
 _INTEGRITY_KEY = b"k" * 32
 _PLAINTEXT_CANARY = "bootstrap-private-canary"
+_EXCHANGE = PersonalContextExchangeProof(
+    ongoing_sync_version=1,
+    activation_epoch="epoch_0123456789abcdef",
+    continuity_token="continuity_0123456789abcdef",
+)
 
 
 class _CanonicalService:
+    """Canonical snapshot fake with explicit per-device activation authorization."""
+
+    database: PersonalizationDB
+
     def __init__(self) -> None:
         self.manifest = manifest()
         self.scope = global_scope(profile_id=self.manifest.profile_id)
@@ -86,6 +113,27 @@ class _CanonicalService:
         self.applied: list[object] = []
         self.integrity_key_id = "personal-context-integrity-v1"
         self.integrity_key = _INTEGRITY_KEY
+        self._repository = self
+        self.activated_devices: set[tuple[str, str, str]] = set()
+
+    def validate_activation_exchange(
+        self,
+        *,
+        profile_id: str,
+        device_id: str,
+        dataset_id: str,
+        activation_epoch: str,
+        continuity_token: str,
+    ) -> PersonalContextExchangeProof:
+        """Accept only explicitly acknowledged fixture devices and their exact pair."""
+        proof = PersonalContextExchangeProof(
+            ongoing_sync_version=1,
+            activation_epoch=activation_epoch,
+            continuity_token=continuity_token,
+        )
+        if (profile_id, dataset_id, device_id) not in self.activated_devices or proof != _EXCHANGE:
+            raise ValueError("personal_context_activation_required")
+        return proof
 
     def create_profile(self, *, runtime_enabled: bool = False):
         del runtime_enabled
@@ -119,25 +167,29 @@ class _CanonicalService:
             f"purge:{self.manifest.purge_generation}",
             f"integrity:{self.integrity_key_id}",
             f"scope:{self.scope.scope_id}:{self.scope.version_id}",
+            *(f"record:{item.record_id}:{item.version_id}" for item in self.records),
             *(
-                f"record:{item.record_id}:{item.version_id}" for item in self.records
-            ),
-            *(
-                "proposal:" + item.proposal_id + ":" + hashlib.sha256(
-                    item.model_dump_json().encode("utf-8")
-                ).hexdigest()
+                "proposal:"
+                + item.proposal_id
+                + ":"
+                + hashlib.sha256(item.model_dump_json().encode("utf-8")).hexdigest()
                 for item in self.proposals
             ),
         ]
-        return type("Snapshot", (), {
-            "manifest": self.manifest, "scopes": self.list_scopes(),
-            "records": self.records, "proposals": self.proposals,
-            "integrity_key_id": self.integrity_key_id,
-            "integrity_key": self.integrity_key,
-            "cursor": "personal-context-bootstrap-v1:" + hashlib.sha256(
-                "\x1e".join(sorted(entries)).encode("utf-8")
-            ).hexdigest(),
-        })()
+        return type(
+            "Snapshot",
+            (),
+            {
+                "manifest": self.manifest,
+                "scopes": self.list_scopes(),
+                "records": self.records,
+                "proposals": self.proposals,
+                "integrity_key_id": self.integrity_key_id,
+                "integrity_key": self.integrity_key,
+                "cursor": "personal-context-bootstrap-v1:"
+                + hashlib.sha256("\x1e".join(sorted(entries)).encode("utf-8")).hexdigest(),
+            },
+        )()
 
     def plan_sync_bootstrap(self):
         snapshot = self.sync_bootstrap_snapshot()
@@ -146,10 +198,7 @@ class _CanonicalService:
 
     def materialize_sync_bootstrap(self, *, profile_id: str, bootstrap_cursor: str):
         snapshot = self.plan_sync_bootstrap()
-        if (
-            profile_id != snapshot.manifest.profile_id
-            or bootstrap_cursor != snapshot.cursor
-        ):
+        if profile_id != snapshot.manifest.profile_id or bootstrap_cursor != snapshot.cursor:
             raise ValueError("stale bootstrap plan")
         self.profile_exists = True
         snapshot.materialized = True
@@ -159,9 +208,59 @@ class _CanonicalService:
         self.applied.append(values)
         return values["value"]
 
+    def apply_sync_ingress(
+        self,
+        *,
+        identity: IngressIdentity,
+        domain: str,
+        value: ProfileRecord,
+        base_object_hash: str | None,
+    ) -> CanonicalApplyReceipt:
+        """Exercise real ingress receipt validation around the existing apply fake."""
+        self.apply_sync_object(domain=domain, value=value, base_object_hash=base_object_hash)
+        return CanonicalApplyReceipt(
+            resulting_object_id=value.record_id,
+            resulting_version_id=value.version_id,
+            manifest_revision=self.manifest.revision,
+            manifest_version_id=self.manifest.current_version_id,
+            purge_generation=identity.purge_generation,
+            publication_batch_id="bootstrap-fixture-batch",
+            profile_publication_sequence=1,
+            receipt_id=str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    "tldw:personal-context:ingress:"
+                    f"{identity.dataset_id}:{identity.device_id}:{identity.client_envelope_id}",
+                )
+            ),
+            dataset_id=identity.dataset_id,
+            device_id=identity.device_id,
+            client_envelope_id=identity.client_envelope_id,
+            canonical_payload_digest=identity.canonical_payload_digest,
+            wire_entity_version=identity.wire_entity_version,
+        )
 
-def _service(tmp_path: Path) -> tuple[SyncV2Service, _CanonicalService]:
+
+def _service(
+    tmp_path: Path, *, publication_journal: bool = False, monkeypatch: pytest.MonkeyPatch | None = None
+) -> tuple[SyncV2Service, _CanonicalService]:
+    """Build real Sync storage, optionally with real encrypted authority sources."""
     canonical = _CanonicalService()
+    if publication_journal:
+        assert monkeypatch is not None
+        monkeypatch.setenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY", encoded_master_key())
+        canonical.database = PersonalizationDB.for_path(tmp_path / "publication.db")
+        provider = ServerProfileKeyProvider(canonical.database)
+        with canonical.database.transaction(immediate=True) as connection:
+            keys = provider.create(canonical.manifest.profile_id, connection=connection)
+            provider.replace_encryption_key(
+                canonical.manifest.profile_id,
+                encryption_key=b"e" * 32,
+                integrity_key=_INTEGRITY_KEY,
+                expected_key_version=keys.key_version,
+                integrity_key_version=keys.integrity_key_version,
+                connection=connection,
+            )
     store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
     adapters = SyncAdapterRegistry(
         [
@@ -185,9 +284,7 @@ def _service(tmp_path: Path) -> tuple[SyncV2Service, _CanonicalService]:
         },
         personal_context_service_resolver=lambda _user_id: canonical,
         personal_context_key_wrapper=lambda *, device, integrity_key, integrity_key_id: (
-            "wrapped:"
-            f"{device.device_id}:{integrity_key_id}:"
-            f"{hashlib.sha256(integrity_key).hexdigest()}"
+            f"wrapped:{device.device_id}:{integrity_key_id}:{hashlib.sha256(integrity_key).hexdigest()}"
         ),
         personal_context_key_fingerprint=lambda *, device: f"fingerprint:{device.device_id}",
         settings=SyncV2Settings(
@@ -205,11 +302,7 @@ def _service(tmp_path: Path) -> tuple[SyncV2Service, _CanonicalService]:
         display_name="Chatbook A",
         client_type="chatbook",
         device_id="device-a",
-        capabilities={
-            "supported_adapter_versions": {
-                domain: [1] for domain in PERSONAL_CONTEXT_SYNC_DOMAINS
-            }
-        },
+        capabilities={"supported_adapter_versions": {domain: [1] for domain in PERSONAL_CONTEXT_SYNC_DOMAINS}},
     )
     return service, canonical
 
@@ -225,6 +318,34 @@ def _bootstrap(service: SyncV2Service, **overrides: object):
     return service.bootstrap_personal_context(**values)
 
 
+def _complete_and_activate(
+    service: SyncV2Service,
+    canonical: _CanonicalService,
+    bootstrap: PersonalContextBootstrap,
+    *,
+    device_id: str = "device-a",
+) -> None:
+    """Complete the real link before acknowledging this fake's v1 baseline.
+
+    Snapshot/cursor tests retain their original transport boundaries. Real
+    encrypted activation installation and receipts have separate integration tests.
+    """
+    service.complete_personal_context_link(
+        user_id="user-a",
+        device_id=device_id,
+        dataset_id=bootstrap.dataset_id,
+        bootstrap_cursor=bootstrap.cursor,
+    )
+    canonical.activated_devices.add((bootstrap.manifest.profile_id, bootstrap.dataset_id, device_id))
+    dataset = service.store.get_dataset(bootstrap.dataset_id)
+    metadata = dataset.metadata
+    metadata["personal_context"].update(_EXCHANGE.model_dump(mode="json"))
+    with service.store.db.backend.transaction() as connection:
+        service.store.db.execute(
+            "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+            (json.dumps(metadata), bootstrap.dataset_id),
+            connection=connection,
+        )
 
 
 def _record_envelope(bootstrap) -> SyncEnvelopeCreate:
@@ -277,6 +398,54 @@ def _transport_record_envelope(
     )
 
 
+def _publish_transport_record(
+    service: SyncV2Service, bootstrap: PersonalContextBootstrap, *, revision: int, previous: SyncEnvelope | None = None
+) -> SyncEnvelope:
+    """Publish a real acknowledged encrypted source without fabricating pull authority."""
+    canonical = service._personal_context_service_for_user("user-a")
+    database = canonical.database
+    envelope = _client_transport_record_envelope(bootstrap, revision=revision, previous=previous)
+    keys = ServerProfileKeyProvider(database).load(bootstrap.manifest.profile_id)
+    with database.transaction(immediate=True) as connection:
+        receipt = PersonalContextPublicationJournal(keys).append_batch(
+            connection,
+            profile_id=bootstrap.manifest.profile_id,
+            purge_generation=0,
+            objects=(
+                PublicationObject(
+                    domain=envelope.domain,
+                    object_id=envelope.object_id,
+                    version_id=str(envelope.entity_version),
+                    operation="upsert",
+                    role="semantic",
+                    canonical=canonical_json_bytes(envelope.payload),
+                ),
+            ),
+            now="2026-09-04T12:00:00Z",
+        )
+    result = PersonalContextRelay(
+        publications=PersonalContextPublicationRelayStore(database),
+        stage_authority=service.stage_personal_context_authority,
+        finalize_authority=service.finalize_personal_context_authority,
+        cancel_authority=service.cancel_personal_context_authority,
+    ).relay_profile(
+        user_id="user-a",
+        profile_id=bootstrap.manifest.profile_id,
+        dataset_id=bootstrap.dataset_id,
+        after_server_cursor=None,
+        wall_time_ms=5_000,
+    )
+    assert result.continuation == "complete"
+    with database.transaction() as connection:
+        row = connection.execute(
+            "SELECT sync_server_cursor FROM personal_context_publication_rows WHERE profile_publication_sequence = ?",
+            (receipt.profile_publication_sequence,),
+        ).fetchone()
+    stored = service.store.get_envelope_by_server_cursor(row[0])
+    assert stored is not None
+    return stored
+
+
 def _client_transport_record_envelope(
     bootstrap,
     *,
@@ -289,9 +458,7 @@ def _client_transport_record_envelope(
         profile_id=bootstrap.manifest.profile_id,
         record_id="transport-record",
         version_id=f"transport-record-v{revision}",
-        parent_version_id=(
-            None if revision == 1 else f"transport-record-v{revision - 1}"
-        ),
+        parent_version_id=(None if revision == 1 else f"transport-record-v{revision - 1}"),
         value=f"value-{revision}",
     ).model_dump(mode="json")
     payload_bytes = canonical_json_bytes(payload)
@@ -457,11 +624,13 @@ def test_bootstrap_sync_transport_cursor_is_accepted_by_private_pull_parser(
     service, _canonical = _service(tmp_path)
 
     bootstrap = _bootstrap(service)
+    _complete_and_activate(service, _canonical, bootstrap)
     pulled = service.pull(
         user_id="user-a",
         dataset_id=bootstrap.dataset_id,
         device_id="device-a",
         cursor=bootstrap.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
     )
 
@@ -473,42 +642,30 @@ def test_bootstrap_sync_transport_cursor_is_accepted_by_private_pull_parser(
             dataset_id=bootstrap.dataset_id,
             device_id="device-a",
             cursor=bootstrap.cursor,
+            personal_context_exchange=_EXCHANGE,
             domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
         )
 
 
 def test_bootstrap_transport_watermark_skips_retained_history_and_delivers_later_change(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service, _canonical = _service(tmp_path)
+    service, _canonical = _service(tmp_path, publication_journal=True, monkeypatch=monkeypatch)
     first_device = _bootstrap(service)
-    prior = service.store.insert_envelope(
-        _transport_record_envelope(service, first_device, revision=1)
-    )
-    prior = service.store.insert_envelope(
-        _transport_record_envelope(
-            service,
-            first_device,
-            revision=2,
-            previous=prior,
-        )
-    )
+    prior = _publish_transport_record(service, first_device, revision=1)
+    prior = _publish_transport_record(service, first_device, revision=2, previous=prior)
     _register_transport_device(service, "device-b")
 
     reviewed = _bootstrap(service, device_id="device-b")
-    later = service.store.insert_envelope(
-        _transport_record_envelope(
-            service,
-            first_device,
-            revision=3,
-            previous=prior,
-        )
-    )
+    _complete_and_activate(service, _canonical, reviewed, device_id="device-b")
+    later = _publish_transport_record(service, first_device, revision=3, previous=prior)
     pulled = service.pull(
         user_id="user-a",
         dataset_id=reviewed.dataset_id,
         device_id="device-b",
         cursor=reviewed.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
     )
 
@@ -522,17 +679,20 @@ def test_bootstrap_transport_watermark_skips_retained_history_and_delivers_later
             dataset_id=reviewed.dataset_id,
             device_id="device-b",
             cursor=reviewed.sync_transport_cursor,
+            personal_context_exchange=_EXCHANGE,
             domains=["personal_context.record"],
         )
 
 
 def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_review(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service, _canonical = _service(tmp_path)
+    service, _canonical = _service(tmp_path, publication_journal=True, monkeypatch=monkeypatch)
     now = datetime(2026, 8, 30, tzinfo=timezone.utc)
     service.clock = lambda: now.isoformat()
     first = _bootstrap(service)
+    _complete_and_activate(service, _canonical, first)
     device = service.store.get_device("user-a", "device-a")
     assert device is not None
     streams = service._pull_adapter_streams(device, PERSONAL_CONTEXT_SYNC_DOMAINS)
@@ -544,9 +704,7 @@ def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_r
         version_set=version_set,
         streams=streams,
     )
-    later = service.store.insert_envelope(
-        _transport_record_envelope(service, first, revision=1)
-    )
+    later = _publish_transport_record(service, first, revision=1)
     service.personal_context_key_fingerprint = lambda *, device: (
         f"rotated-fingerprint:{device.device_id}"
     )
@@ -557,10 +715,12 @@ def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_r
         dataset_id=first.dataset_id,
         device_id="device-a",
         cursor=first.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
         include_own_changes=True,
     ).envelopes[0].server_sequence == later.server_sequence
     retry = _bootstrap(service)
+    _complete_and_activate(service, _canonical, retry)
     retry_watermarks = service._decode_pull_token(
         retry.sync_transport_cursor,
         dataset_id=retry.dataset_id,
@@ -578,6 +738,7 @@ def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_r
             dataset_id=first.dataset_id,
             device_id="device-a",
             cursor=first.sync_transport_cursor,
+            personal_context_exchange=_EXCHANGE,
             domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
             include_own_changes=True,
         )
@@ -586,6 +747,7 @@ def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_r
         dataset_id=retry.dataset_id,
         device_id="device-a",
         cursor=retry.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
         include_own_changes=True,
     ).envelopes[0].server_sequence == later.server_sequence
@@ -593,8 +755,9 @@ def test_bootstrap_transport_cursor_retry_preserves_boundary_and_supports_slow_r
 
 def test_bootstrap_transport_snapshot_serializes_concurrent_sqlite_insert(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service, canonical = _service(tmp_path)
+    service, canonical = _service(tmp_path, publication_journal=True, monkeypatch=monkeypatch)
     source = _bootstrap(service)
     _register_transport_device(service, "device-b")
     entered_snapshot = threading.Event()
@@ -611,8 +774,7 @@ def test_bootstrap_transport_snapshot_serializes_concurrent_sqlite_insert(
         bootstrap_future = executor.submit(_bootstrap, service, device_id="device-b")
         assert entered_snapshot.wait(timeout=5)
         insert_future = executor.submit(
-            service.store.insert_envelope,
-            _transport_record_envelope(service, source, revision=1),
+            _publish_transport_record, service, source, revision=1,
         )
         with pytest.raises(FutureTimeoutError):
             insert_future.result(timeout=0.2)
@@ -620,11 +782,13 @@ def test_bootstrap_transport_snapshot_serializes_concurrent_sqlite_insert(
         reviewed = bootstrap_future.result(timeout=5)
         inserted = insert_future.result(timeout=5)
 
+    _complete_and_activate(service, canonical, reviewed, device_id="device-b")
     pulled = service.pull(
         user_id="user-a",
         dataset_id=reviewed.dataset_id,
         device_id="device-b",
         cursor=reviewed.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
     )
     assert [item.server_sequence for item in pulled.envelopes] == [
@@ -646,6 +810,7 @@ def test_bootstrap_rejects_real_push_paused_before_canonical_materialization(
         dataset_id=source.dataset_id,
         bootstrap_cursor=source.cursor,
     )
+    _complete_and_activate(service, canonical, source)
     _register_transport_device(service, "device-b")
     canonical.apply_sync_object = lambda **values: _apply_record_to_fake_canonical(
         canonical, **values
@@ -667,6 +832,7 @@ def test_bootstrap_rejects_real_push_paused_before_canonical_materialization(
             dataset_id=source.dataset_id,
             device_id="device-a",
             envelopes=[_client_transport_record_envelope(source, revision=1)],
+            personal_context_exchange=_EXCHANGE,
         )
         assert entered_materialization.wait(timeout=5)
         try:
@@ -684,11 +850,13 @@ def test_bootstrap_rejects_real_push_paused_before_canonical_materialization(
     assert len(pushed.accepted) == 1
 
     reviewed = _bootstrap(service, device_id="device-b")
+    _complete_and_activate(service, canonical, reviewed, device_id="device-b")
     pulled = service.pull(
         user_id="user-a",
         dataset_id=reviewed.dataset_id,
         device_id="device-b",
         cursor=reviewed.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
     )
     assert pulled.envelopes == []
@@ -708,6 +876,7 @@ def test_failed_materialization_blocks_bootstrap_until_guarded_replay_succeeds(
         dataset_id=source.dataset_id,
         bootstrap_cursor=source.cursor,
     )
+    _complete_and_activate(service, canonical, source)
     _register_transport_device(service, "device-b")
 
     def fail_apply(**_values: object) -> object:
@@ -719,6 +888,7 @@ def test_failed_materialization_blocks_bootstrap_until_guarded_replay_succeeds(
         dataset_id=source.dataset_id,
         device_id="device-a",
         envelopes=[_client_transport_record_envelope(source, revision=1)],
+        personal_context_exchange=_EXCHANGE,
     )
     assert len(pushed.accepted) == 1
     sequence = pushed.accepted[0].server_sequence
@@ -741,7 +911,7 @@ def test_failed_materialization_blocks_bootstrap_until_guarded_replay_succeeds(
         domains=["personal_context.record"],
         failed_only=True,
     )
-    assert replayed.applied_count == 1
+    assert replayed.applied_count == 1, replayed.domain_results
     repaired = service.store.get_envelope_by_server_cursor(sequence)
     assert repaired is not None and repaired.apply_status == "applied"
 
@@ -752,11 +922,13 @@ def test_failed_materialization_blocks_bootstrap_until_guarded_replay_succeeds(
         dataset_id=reviewed.dataset_id,
         bootstrap_cursor=reviewed.cursor,
     )
+    _complete_and_activate(service, canonical, reviewed, device_id="device-b")
     assert service.pull(
         user_id="user-a",
         dataset_id=reviewed.dataset_id,
         device_id="device-b",
         cursor=reviewed.sync_transport_cursor,
+        personal_context_exchange=_EXCHANGE,
         domains=PERSONAL_CONTEXT_SYNC_DOMAINS,
     ).envelopes == []
 
@@ -1244,14 +1416,14 @@ def test_personal_context_push_stays_blocked_until_narrow_completion_transition(
     bootstrap = _bootstrap(service)
     envelope = _record_envelope(bootstrap)
 
-    before = service.push(
-        user_id="user-a",
-        dataset_id=bootstrap.dataset_id,
-        device_id="device-a",
-        envelopes=[envelope],
-    )
-    assert before.accepted == []
-    assert before.rejected[0].error_code == "personal_context_link_incomplete"
+    with pytest.raises(SyncStoreError, match="personal_context_activation_required"):
+        service.push(
+            user_id="user-a",
+            dataset_id=bootstrap.dataset_id,
+            device_id="device-a",
+            envelopes=[envelope],
+        )
+    assert _canonical.applied == []
 
     service.complete_personal_context_link(
         user_id="user-a",
@@ -1259,11 +1431,13 @@ def test_personal_context_push_stays_blocked_until_narrow_completion_transition(
         dataset_id=bootstrap.dataset_id,
         bootstrap_cursor=bootstrap.cursor,
     )
+    _complete_and_activate(service, _canonical, bootstrap)
     after = service.push(
         user_id="user-a",
         dataset_id=bootstrap.dataset_id,
         device_id="device-a",
         envelopes=[envelope],
+        personal_context_exchange=_EXCHANGE,
     )
     assert len(after.accepted) == 1
 
@@ -1283,13 +1457,16 @@ def test_personal_context_push_stays_blocked_until_narrow_completion_transition(
         client_envelope_id="device-b:record:1",
         device_id="device-b",
     )
-    blocked_other_device = service.push(
-        user_id="user-a",
-        dataset_id=bootstrap.dataset_id,
-        device_id="device-b",
-        envelopes=[other_device],
-    )
-    assert blocked_other_device.rejected[0].error_code == "personal_context_link_incomplete"
+    applied_before = list(_canonical.applied)
+    with pytest.raises(SyncStoreError, match="personal_context_activation_required"):
+        service.push(
+            user_id="user-a",
+            dataset_id=bootstrap.dataset_id,
+            device_id="device-b",
+            envelopes=[other_device],
+            personal_context_exchange=_EXCHANGE,
+        )
+    assert _canonical.applied == applied_before
 
 
 def test_generic_enrollment_cannot_forge_personal_context_binding(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_certification.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_certification.py
@@ -407,13 +407,25 @@ def _device_payload(public_key: rsa.RSAPublicKey) -> dict[str, object]:
     }
 
 
-def _seed_exchange(service, dataset_id: str) -> None:
+def _seed_exchange(service, dataset_id: str) -> dict[str, object]:
+    """Install and acknowledge through the real journals before test-only rollout."""
+
+    baseline = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)
+    _receipt, proof = service.acknowledge_personal_context_activation(
+        user_id=_USER_ID,
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        activation_id=baseline.activation.activation_id,
+        baseline_digest=baseline.activation.baseline_digest,
+        local_receipt_id="certification-local-install-0123456789",
+        exchange=baseline.personal_context_exchange,
+    )
     dataset = service.store.get_dataset(dataset_id, owner_user_id=_USER_ID)
     _require(dataset is not None, "seed dataset was not found")
     metadata = dict(dataset.metadata)
     metadata["personal_context"] = {
         **metadata["personal_context"],
-        **_EXCHANGE,
+        **proof.model_dump(),
     }
     with service.store.db.backend.transaction() as connection:
         service.store.db.execute(
@@ -421,6 +433,7 @@ def _seed_exchange(service, dataset_id: str) -> None:
             (json.dumps(metadata, sort_keys=True), dataset_id),
             connection=connection,
         )
+    return proof.model_dump()
 
 
 def _record_body(scope_id: str, value: str) -> dict[str, object]:
@@ -460,13 +473,13 @@ def _publication_state(canonical) -> list[dict[str, object]]:
         ]
 
 
-def _pull_params(dataset_id: str, cursor: str | None = None) -> dict[str, object]:
+def _pull_params(dataset_id: str, cursor: str | None = None, *, exchange: dict[str, object]) -> dict[str, object]:
     params: dict[str, object] = {
         "dataset_id": dataset_id,
         "device_id": _DEVICE_ID,
         "domain": "personal_context.record",
-        "personal_context_activation_epoch": _EXCHANGE["activation_epoch"],
-        "personal_context_continuity_token": _EXCHANGE["continuity_token"],
+        "personal_context_activation_epoch": exchange["activation_epoch"],
+        "personal_context_continuity_token": exchange["continuity_token"],
     }
     if cursor is not None:
         params["cursor"] = cursor
@@ -1317,7 +1330,7 @@ def test_production_http_relay_debt_survives_restart_and_recovers_on_push_and_pu
                 },
             )
             _require_status(complete, 204, "Personal Context link completion failed")
-            _seed_exchange(initial_sync, dataset_id)
+            exchange = _seed_exchange(initial_sync, dataset_id)
             _require(
                 client.get("/api/v1/sync/capabilities").json()["personal_context"][
                     "ongoing_sync_version"
@@ -1492,7 +1505,7 @@ def test_production_http_relay_debt_survives_restart_and_recovers_on_push_and_pu
                 json={
                     "dataset_id": dataset_id,
                     "device_id": _DEVICE_ID,
-                    "personal_context_exchange": _EXCHANGE,
+                    "personal_context_exchange": exchange,
                     "envelopes": [
                         {
                             "dataset_id": dataset_id,
@@ -1636,10 +1649,10 @@ def test_production_http_relay_debt_survives_restart_and_recovers_on_push_and_pu
         with _production_client(production_app) as pull_client:
             zero_limit = pull_client.get(
                 "/api/v1/sync/pull",
-                params={**_pull_params(dataset_id), "page_size": 0},
+                params={**_pull_params(dataset_id, exchange=exchange), "page_size": 0},
             )
             _require_status(zero_limit, 422, "zero pull limit was accepted")
-            pulled = pull_client.get("/api/v1/sync/pull", params=_pull_params(dataset_id))
+            pulled = pull_client.get("/api/v1/sync/pull", params=_pull_params(dataset_id, exchange=exchange))
             responses.append(pulled.text)
             _require_status(pulled, 200, "authority pull failed")
             pull_body = pulled.json()
@@ -1705,7 +1718,7 @@ def test_production_http_relay_debt_survives_restart_and_recovers_on_push_and_pu
 
             repeated = pull_client.get(
                 "/api/v1/sync/pull",
-                params=_pull_params(dataset_id, pull_body["next_cursor"]),
+                params=_pull_params(dataset_id, pull_body["next_cursor"], exchange=exchange),
             )
             responses.append(repeated.text)
             _require_status(repeated, 200, "repeat pull failed")

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_certification.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_certification.py
@@ -407,7 +407,7 @@ def _device_payload(public_key: rsa.RSAPublicKey) -> dict[str, object]:
     }
 
 
-def _seed_exchange(service, dataset_id: str) -> dict[str, object]:
+def _seed_exchange(service: SyncV2Service, dataset_id: str) -> dict[str, object]:
     """Install and acknowledge through the real journals before test-only rollout."""
 
     baseline = service.prepare_personal_context_activation(user_id=_USER_ID, device_id=_DEVICE_ID)

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_exchange_gate.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_exchange_gate.py
@@ -56,6 +56,8 @@ ProofState = Literal[
     "incomplete_link",
     "tampered_stored",
     "version_zero",
+    "canonical_unavailable",
+    "forged_metadata",
 ]
 DeviceState = Literal["active", "paused", "revoked", "unknown"]
 
@@ -138,6 +140,10 @@ def _proof_for_state(state: ProofState) -> PersonalContextExchangeProof | None:
         return EXCHANGE.model_copy(
             update={"continuity_token": "stale_token_0123456789abcdef"}
         )
+    if state == "forged_metadata":
+        return EXCHANGE.model_copy(
+            update={"continuity_token": "forged_continuity_0123456789abcdef"}
+        )
     return EXCHANGE
 
 
@@ -157,6 +163,10 @@ def _prepare_state(
         )
     elif state == "version_zero":
         _set_personal_context_state(service, ongoing_sync_version=0)
+    elif state == "canonical_unavailable":
+        service.personal_context_service_resolver = None
+    elif state == "forged_metadata":
+        _set_personal_context_state(service, continuity_token="forged_continuity_0123456789abcdef")
     return device_id, _proof_for_state(state)
 
 
@@ -447,6 +457,8 @@ def _request_operation(
         "incomplete_link",
         "tampered_stored",
         "version_zero",
+        "canonical_unavailable",
+        "forged_metadata",
     ],
 )
 def test_personal_context_exchange_gate_matrix(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
@@ -1,0 +1,159 @@
+"""Exact ingress receipts permit retryable repair without reviving terminal rows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Personalization.personal_context_publication import CanonicalApplyReceipt
+from tldw_Server_API.app.core.Sync.v2.models import PERSONAL_CONTEXT_SYNC_DOMAINS, SyncDatasetCreate, SyncDeviceUpsert
+from tldw_Server_API.app.core.Sync.v2.store import SyncStoreError, SyncV2Store
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def ingress_store(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> Iterator[tuple[SyncV2Store, int, CanonicalApplyReceipt]]:
+    """Use real SQLite and the shared isolated PostgreSQL database fixture."""
+    backend = None
+    if request.param == "postgres":
+        backend = DatabaseBackendFactory.create_backend(request.getfixturevalue("pg_database_config"))
+        database = SyncDatabase(backend=backend)
+    else:
+        database = SyncDatabase(sqlite_path=tmp_path / "ingress-repair.db")
+    store = SyncV2Store(database)
+    store.upsert_device(
+        SyncDeviceUpsert(
+            device_id="repair-device",
+            user_id="repair-user",
+            display_name="Repair fixture",
+            client_type="chatbook",
+        )
+    )
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="repair-dataset",
+            owner_user_id="repair-user",
+            encryption_policy="server_trusted_v1",
+            domains=sorted(PERSONAL_CONTEXT_SYNC_DOMAINS),
+        )
+    )
+    # Seed this narrow storage fixture directly: ordinary PostgreSQL insertion
+    # currently hits an unrelated _ensure_domain_state placeholder mismatch.
+    # The bootstrap regression covers the complete SQLite push/repair workflow.
+    with database.backend.transaction() as connection:
+        database.execute(
+            """INSERT INTO sync_envelopes (
+               server_sequence, dataset_id, domain, entity_id, operation,
+               client_envelope_id, device_id, server_timestamp, entity_version,
+               routing_metadata_json, payload_ciphertext, payload_hash,
+               payload_size_bytes, adapter_version, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                1,
+                "repair-dataset",
+                "personal_context.record",
+                "repair-record",
+                "upsert",
+                "repair-client-envelope",
+                "repair-device",
+                "2026-09-04T00:00:00Z",
+                '"record-v1"',
+                '{"personal_context_authority":{"role":"client_ingress"}}',
+                "opaque-fixture-ciphertext",
+                "hmac-sha256-v1:" + "a" * 64,
+                24,
+                1,
+                "accepted",
+            ),
+            connection=connection,
+        )
+    receipt = CanonicalApplyReceipt(
+        resulting_object_id="repair-record",
+        resulting_version_id="record-v1",
+        manifest_revision=1,
+        manifest_version_id="manifest-v1",
+        purge_generation=0,
+        publication_batch_id="repair-publication",
+        profile_publication_sequence=1,
+        receipt_id="repair-exact-receipt",
+        dataset_id="repair-dataset",
+        device_id="repair-device",
+        client_envelope_id="repair-client-envelope",
+        canonical_payload_digest="sha256:" + "a" * 64,
+        wire_entity_version="record-v1",
+    )
+    try:
+        yield store, 1, receipt
+    finally:
+        if backend is not None:
+            backend.get_pool().close_all()
+
+
+def _set_apply_state(store: SyncV2Store, cursor: int, state: str) -> None:
+    """Set only the retry state and sanitized failure fields under a real transaction."""
+    with store.db.backend.transaction() as connection:
+        store.db.execute(
+            "UPDATE sync_envelopes SET apply_status = ?, apply_error_code = ?, apply_error_message = ? WHERE server_sequence = ?",
+            (state, "fixture_failure", "fixture failure", cursor),
+            connection=connection,
+        )
+
+
+@pytest.mark.parametrize("state", ["pending", "failed", "applied"])
+def test_verified_receipt_repairs_only_retryable_ingress(
+    ingress_store: tuple[SyncV2Store, int, CanonicalApplyReceipt],
+    state: str,
+) -> None:
+    """Exact failed repair commits once and clears old sanitized error fields."""
+    store, cursor, receipt = ingress_store
+    _set_apply_state(store, cursor, state)
+    applied = store.mark_personal_context_ingress_applied(server_cursor=cursor, receipt=receipt)
+    assert applied.apply_status == "applied"
+    assert applied.apply_error_code is None
+    assert applied.apply_error_message is None
+    stored_receipt = store.get_personal_context_ingress_receipt(cursor)
+    replay = store.mark_personal_context_ingress_applied(server_cursor=cursor, receipt=receipt)
+    assert replay.apply_status == "applied"
+    assert store.get_personal_context_ingress_receipt(cursor) == stored_receipt
+
+
+@pytest.mark.parametrize("state", ["conflict", "superseded", "skipped"])
+def test_verified_receipt_cannot_revive_nonretryable_ingress(
+    ingress_store: tuple[SyncV2Store, int, CanonicalApplyReceipt],
+    state: str,
+) -> None:
+    """Receipt verification never authorizes reviving conflict or terminal states."""
+    store, cursor, receipt = ingress_store
+    _set_apply_state(store, cursor, state)
+    with pytest.raises(SyncStoreError, match="personal_context_ingress_receipt_mismatch"):
+        store.mark_personal_context_ingress_applied(server_cursor=cursor, receipt=receipt)
+    assert store.get_envelope_by_server_cursor(cursor).apply_status == state
+    assert store.get_personal_context_ingress_receipt(cursor) is None
+
+
+@pytest.mark.parametrize(
+    "field", ["dataset_id", "device_id", "wire_entity_version", "canonical_payload_digest", "receipt_id"]
+)
+def test_failed_ingress_repair_rejects_changed_durable_receipt(
+    ingress_store: tuple[SyncV2Store, int, CanonicalApplyReceipt],
+    field: str,
+) -> None:
+    """No mismatched identity or receipt can repair a retryable failed row."""
+    store, cursor, receipt = ingress_store
+    store.mark_personal_context_ingress_applied(server_cursor=cursor, receipt=receipt)
+    original = store.get_personal_context_ingress_receipt(cursor)
+    _set_apply_state(store, cursor, "failed")
+    with pytest.raises(SyncStoreError, match="personal_context_ingress_receipt_mismatch"):
+        store.mark_personal_context_ingress_applied(
+            server_cursor=cursor, receipt=replace(receipt, **{field: "changed-value"})
+        )
+    assert store.get_envelope_by_server_cursor(cursor).apply_status == "failed"
+    assert store.get_personal_context_ingress_receipt(cursor) == original

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_recovery_budget.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_recovery_budget.py
@@ -1371,7 +1371,8 @@ class _ManyBatchSource:
         self.expire_after_selection = expire_after_selection
 
     @contextmanager
-    def profile_lease(self, _profile_id: str):
+    def profile_lease(self, _profile_id: str, *, blocking=True):
+        assert blocking is False
         yield SimpleNamespace(owner_token="owner")
 
     def earliest_nonterminal_batch(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_relay.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_relay.py
@@ -26,7 +26,8 @@ def test_relay_bounds_source_decryption_before_loading_a_batch() -> None:
 
     class BoundedSource:
         @contextmanager
-        def profile_lease(self, _profile_id):
+        def profile_lease(self, _profile_id, *, blocking=True):
+            assert blocking is False
             yield SimpleNamespace(owner_token="owner")
 
         def earliest_nonterminal_batch(
@@ -596,7 +597,8 @@ class _Publications:
         self.failed_after: int | None = None
 
     @contextmanager
-    def profile_lease(self, _profile_id: str):
+    def profile_lease(self, _profile_id: str, *, blocking=True):
+        assert blocking is False
         yield type("Lease", (), {"owner_token": "lease-token"})()
 
     def renew_lease(self, _lease: object) -> bool:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_relay.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_relay.py
@@ -430,10 +430,30 @@ def test_real_relay_extends_current_sync_heads_across_publication_batches(
     )
     updated_payload = updated.model_dump(mode="json")
     updated_canonical = canonical_json_bytes(updated_payload)
+    # This relay test supplies durable canonical receipt fixtures; cross-store
+    # installation verification is exercised by the activation integration suite.
+    with publications.profile_lease(manifest.profile_id) as lease:
+        prepared = canonical._repository.prepare_activation(
+            manifest.profile_id, device_id="device-a", lease=lease
+        )
+        installed = canonical._repository.complete_activation_install(
+            prepared.activation_id, prepared.baseline_digest, "fixture-install-receipt",
+            home_server_cursor=manifest_head.server_cursor, lease=lease,
+        )
+    canonical._repository.confirm_activation_device(
+        prepared.activation_id, prepared.baseline_digest, "device-a", "fixture-sync-ack",
+        local_receipt_id="fixture-local-ack", dataset_id="dataset-a",
+    )
+    with store.personal_context_authority_guard("dataset-a", manifest.profile_id) as guarded:
+        guarded.mirror_personal_context_activation(
+            dataset_id="dataset-a", user_id="user-a", profile_id=manifest.profile_id,
+            purge_generation=0, activation_epoch=installed.activation_epoch,
+            continuity_token=installed.continuity_token,
+        )
     exchange = PersonalContextExchangeProof(
         ongoing_sync_version=1,
-        activation_epoch="epoch_0123456789abcdef",
-        continuity_token="continuity_0123456789abcdef",
+        activation_epoch=installed.activation_epoch,
+        continuity_token=installed.continuity_token,
     )
     pushed = service.push(
         user_id="user-a",

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_transport.py
@@ -1,3 +1,5 @@
+"""Isolated transport validation with explicit canonical activation test doubles."""
+
 from __future__ import annotations
 
 import hashlib
@@ -6,7 +8,6 @@ import sqlite3
 import uuid
 from dataclasses import replace
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from tldw_profile_core.canonical import canonical_json_bytes
@@ -75,11 +76,35 @@ EXCHANGE = PersonalContextExchangeProof(
 )
 
 
+class _RecordingRepository:
+    """Supply only the canonical proof needed by isolated transport scenarios."""
+
+    def __init__(self, database: PersonalizationDB | None) -> None:
+        """Keep the real source database only for authority relay cases."""
+        self.database = database
+
+    def validate_activation_exchange(
+        self, *, profile_id: str, device_id: str, dataset_id: str,
+        activation_epoch: str, continuity_token: str,
+    ) -> PersonalContextExchangeProof:
+        """Model a device's acknowledged canonical receipt independently of Sync metadata."""
+        supplied = PersonalContextExchangeProof(
+            ongoing_sync_version=1, activation_epoch=activation_epoch,
+            continuity_token=continuity_token,
+        )
+        if (profile_id != PROFILE_ID or dataset_id != DATASET_ID
+                or device_id not in {"device-a", "device-b"} or supplied != EXCHANGE):
+            raise ValueError("personal_context_activation_required")
+        return EXCHANGE
+
+
 class _RecordingService:
+    """Record materialization separately from real Sync storage and delivery guards."""
+
     def __init__(self, database: PersonalizationDB | None = None) -> None:
-        self.values = []
-        if database is not None:
-            self._repository = SimpleNamespace(database=database)
+        """Attach the explicit canonical proof double to this recording target."""
+        self.values: list[object] = []
+        self._repository = _RecordingRepository(database)
 
     def sync_integrity_key(self, profile_id: str) -> tuple[str, bytes]:
         assert profile_id == PROFILE_ID
@@ -212,9 +237,7 @@ def _service(
             )
             for domain in PERSONAL_CONTEXT_SYNC_DOMAINS
         },
-        personal_context_service_resolver=(
-            (lambda _user_id: target) if personal_database is not None else None
-        ),
+        personal_context_service_resolver=lambda _user_id: target,
         settings=SyncV2Settings(
             pull_token_signing_secret="test-only-pull-secret",
             server_trusted_encryption=server_trusted_encryption_status_from_config(


### PR DESCRIPTION
## Summary

Implements TASK-13162: replayable activation and per-device continuity fencing for existing Personal Context links.

- Persist an encrypted exact-head baseline at a whole publication-batch watermark. Install it deterministically in Sync, verify its receipt, then commit canonical coverage under the profile lease. Interrupted cross-store work reuses the same bytes and receipts rather than claiming an atomic transaction across databases.
- Require canonical generation-bound continuity and this device's durable acknowledgement for version-one exchanges. Sync metadata alone cannot grant activation. Handle delivery expiry, abandoned preparation, key rotation, and existing authorized purge cleanup.
- Store delivery baselines separately from ordinary publication batches: a profile may exceed their 100-row limit or have watermark zero.
- Repair the exact-receipt failed-ingress transition that otherwise leaves bootstrap blocked. Preserve existing cursor, race, and materialization assertions while updating compatibility fixtures.
- Update API, developer, user and published documentation. ADR-002 governs; shared wire records remain unchanged.

The advertised `ongoing_sync_version` remains **0**. This does not enable the client ongoing-sync lifecycle or implement TASK-13163–13165.

## Review remediation

Head `7bfc74cd98` rebases this PR onto dev `53d683f0ed` and addresses all eight initial Qodo findings (six fixes and two evidence-backed fixture rebuttals). Activation now uses lease → Sync → canonical lock ordering, avoids waiting in the production ingress after-commit relay, and revalidates the exact link receipt and purge generation during installation. Core bootstrap owns rollout dispatch; activation errors, docstrings and fixture typing are explicit. The OpenAPI fingerprint was regenerated for the endpoint-description change; no path or schema count changed.

The final expanded targeted matrix completed: **673 passed**, 53 warnings, zero failures/errors/skips, PostgreSQL required (4739.07 seconds). JUnit: `/private/tmp/task13162-qodo-final.xml`. The affected 172-test activation/recovery and 124-test endpoint gates also passed. Independent specification and code/security reviews are clear. Qodo reported zero bugs/rule violations/skill insights, and every required check passed on prior head `850ead03ee`.

The latest rebase incorporates the unrelated llama.cpp snapshot merge and preserves both testing-lessons entries. A fresh activation gate passed 57 tests (5 warnings, PostgreSQL required, 52.60 seconds) on this base. Range-diff confirms no Personal Context code or test changes; a final documentation commit records the completed matrix. The OpenAPI fingerprint is regenerated for the combined API (`53e1e9a2ef87…`, 2073 paths and 3140 schemas). Fresh current-head CI and review must clear before merge; TASK-13162 remains In Progress until then.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] 659 distinct targeted cases passed across the implementation's three closing runs (279 canonical/authorization, 156 relay/recovery/contracts, 254 integration; overlapping cases counted once).
- [x] The 254-test activation/API/transport/bootstrap/receipt-repair gate rerun after rebasing onto dev.
- [x] SQLite and PostgreSQL receipt/journal cases required, not skipped. Retry regression reproduced on both backends before the fix.
- [x] Scoped Ruff, new-file formatting and diff checks pass; Bandit reports no findings in the 13 changed production files.
- [x] Independent specification and code/security reviews have no remaining P1/P2 findings.
- [x] Documentation and published copies updated.

No full repository test sweep. WebUI, extension, Watchlists accessibility/scale, and flashcard checklists are not applicable: this PR changes no frontend interface.

## Known separate issue

The backend test setup exposed an unchanged PostgreSQL ordinary-ingress insertion error in `_ensure_domain_state` (translated query has five placeholders but six parameters). No unrelated production fix is bundled. The receipt-transition regression seeds valid ingress rows with parameterized SQL before exercising real store/database methods; it does not claim that ordinary PostgreSQL envelope insertion works. SQLite bootstrap repair is exercised end to end.

## Risk & rollback

Security-sensitive storage and cross-database state transitions; version-one public rollout remains gated. Keep the capability at zero if problems arise. Preserve durable activation/publication journals during rollback rather than deleting recovery state; any rollback after future version-one activation requires separate compatibility review.

## Change summary

The requester explicitly waived the human-written Change summary requirement for this PR on 2026-09-05 and authorized latest-dev rebase, review/CI remediation, and merge. This exception applies only to PR #2886; required technical checks and review remediation remain in force.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements TASK-13162: Personal Context link activation is now replayable and fenced per device. Previously Sync metadata alone could grant activation; now an encrypted exact-head baseline is installed in Sync with a verified receipt and canonical continuity proof, so interrupted cross-store work is retryable without pretending to be atomic.

**What changed**
- Stores delivery baselines in a dedicated journal so profiles can exceed the 100-row ordinary batch limit or have a zero watermark.
- Repairs the exact-receipt failed-ingress transition that left bootstrap blocked.
- Fences activation races and relay deadlocks: the relay takes a non-blocking profile lease so an installer staging into Sync never waits on itself.
- Dispatch now rejects activation requests when the advertised ongoing-sync version is zero or the canonical proof is forged or unavailable, returning 409.
- Updates API, developer, and user documentation; shared wire records are unchanged.

**Rollout**
- `ongoing_sync_version` stays 0, so the client ongoing-sync lifecycle and TASK-13163–13165 are not enabled.
- Keep the capability at zero if problems arise; preserve durable activation/publication journals during rollback.
- Known separate issue: an unchanged PostgreSQL ordinary-ingress insertion error in `_ensure_domain_state` was exposed but not fixed here.

<sup>Written for commit 7bfc74cd986ff33bbd8c073ceee8bbbeeb6a1f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

