### PR TITLE
Admin UX audit round 2: fix all 14 findings (#2888–#2899)

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/watchlists.json
+++ b/apps/packages/ui/src/assets/locale/en/watchlists.json
@@ -1728,7 +1728,7 @@
     }
   },
   "items": {
-    "description": "Review collected updates, alert matches, and briefing candidates from this Watchlist.",
+    "description": "Review collected updates, alert matches, and briefing candidates across your watchlists.",
     "sourcesError": "Failed to load sources",
     "fetchError": "Failed to load updates",
     "smartFeeds": "Smart Feeds",

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -382,6 +382,14 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
         )}
         style={chatScreenBackgroundStyle}
       >
+        {/* A bypass link is only useful as the FIRST focusable element -
+            before the sidebar and header it exists to skip (#2889). */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-50 focus:rounded-md focus:bg-surface focus:px-3 focus:py-2 focus:text-sm focus:text-text focus:shadow"
+        >
+          Skip to main content
+        </a>
         {/* Persistent ChatSidebar when feature flag enabled */}
         {shouldRenderChatSidebar && (
           <ChatSidebar
@@ -395,8 +403,10 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
           />
         )}
         <main
+          id="main-content"
+          tabIndex={-1}
           className={classNames(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col outline-none",
             hideHeader ? "bg-bg " : ""
           )}
           data-demo-mode={demoEnabled ? "on" : "off"}

--- a/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
@@ -335,3 +335,27 @@ describe("OptionLayout shell overrides", () => {
     }
   )
 })
+
+describe("OptionLayout bypass block (#2889)", () => {
+  it("renders a skip link as the first focusable element, targeting the main region", () => {
+    const view = render(
+      <MemoryRouter>
+        <OptionLayout>
+          <div data-testid="route-content">Content</div>
+        </OptionLayout>
+      </MemoryRouter>
+    )
+
+    const firstFocusable = view.container.querySelector(
+      "a[href], button, [tabindex]:not([tabindex='-1'])"
+    ) as HTMLElement
+    expect(firstFocusable).toBeTruthy()
+    expect(firstFocusable.tagName).toBe("A")
+    expect(firstFocusable).toHaveTextContent("Skip to main content")
+    expect(firstFocusable).toHaveAttribute("href", "#main-content")
+
+    const main = view.container.querySelector("main")
+    expect(main).toHaveAttribute("id", "main-content")
+    expect(main).toHaveAttribute("tabindex", "-1")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { PageShell } from "@/components/Common/PageShell"
+import { useConnectionState } from "@/hooks/useConnectionState"
 import {
   ADMIN_MODULE_GROUPS,
   ADMIN_MODULES,
@@ -18,12 +19,16 @@ const groupedModules = ADMIN_MODULE_GROUPS.map((group: AdminModuleGroup) => ({
 const SIGNAL_DOT_COLOR: Record<AdminModuleSignal["state"], string> = {
   healthy: "var(--state-ready, #2f9e6e)",
   attention: "var(--state-degraded, #d98324)",
-  unavailable: "var(--state-unavailable, #8a8fa3)"
+  unavailable: "var(--state-unavailable, #8a8fa3)",
+  // "off" is a deliberate state (module not configured), quieter than an
+  // outage so it never reads as something to fix (#2894).
+  off: "var(--state-off, #5c6170)"
 }
 
-const ModuleSignalBadge: React.FC<{ signal: AdminModuleSignal | undefined }> = ({
-  signal
-}) => {
+const ModuleSignalBadge: React.FC<{
+  signal: AdminModuleSignal | undefined
+  route: string
+}> = ({ signal, route }) => {
   if (!signal) return null
   return (
     <p
@@ -35,7 +40,10 @@ const ModuleSignalBadge: React.FC<{ signal: AdminModuleSignal | undefined }> = (
         className="inline-block h-2 w-2 shrink-0 rounded-full"
         style={{ backgroundColor: SIGNAL_DOT_COLOR[signal.state] }}
       />
-      {signal.detail}
+      {/* The status is the reason to visit the module - make it the link. */}
+      <a className="hover:text-text hover:underline" href={route}>
+        {signal.detail}
+      </a>
     </p>
   )
 }
@@ -44,6 +52,7 @@ export const AdminOperationsOverviewPage: React.FC = () => {
   const [signals, setSignals] = React.useState<
     Record<string, AdminModuleSignal>
   >({})
+  const { serverUrl } = useConnectionState()
 
   React.useEffect(() => {
     let cancelled = false
@@ -57,6 +66,24 @@ export const AdminOperationsOverviewPage: React.FC = () => {
 
   return (
     <PageShell maxWidthClassName="max-w-6xl" className="py-8">
+      {!serverUrl ? (
+        <div
+          role="status"
+          data-testid="admin-not-connected-banner"
+          className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-surface px-4 py-3"
+        >
+          <p className="m-0 text-sm text-text">
+            Not connected to a tldw server, so module signals are unavailable.
+            Connect to a server to administer it.
+          </p>
+          <a
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primaryStrong"
+            href="/setup"
+          >
+            Connect
+          </a>
+        </div>
+      ) : null}
       <header className="space-y-3">
         <p className="text-sm font-semibold uppercase tracking-wide text-text-muted">
           Admin
@@ -94,7 +121,10 @@ export const AdminOperationsOverviewPage: React.FC = () => {
                   <p className="mt-1.5 text-sm text-text-muted">
                     {module.description}
                   </p>
-                  <ModuleSignalBadge signal={signals[module.route]} />
+                  <ModuleSignalBadge
+                    signal={signals[module.route]}
+                    route={module.route}
+                  />
                 </article>
               ))}
             </div>

--- a/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminOperationsOverviewPage.tsx
@@ -117,6 +117,11 @@ export const AdminOperationsOverviewPage: React.FC = () => {
                     <a className="hover:text-primary" href={module.route}>
                       {module.label}
                     </a>
+                    {module.comingSoon ? (
+                      <span className="ml-2 rounded-full border border-border px-2 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide text-text-muted">
+                        Coming soon
+                      </span>
+                    ) : null}
                   </h3>
                   <p className="mt-1.5 text-sm text-text-muted">
                     {module.description}

--- a/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
@@ -44,7 +44,10 @@ export const AdminRouteShell: React.FC<{
         aria-label="Admin modules"
         className="border-b border-border bg-surface px-4 py-2"
       >
-        <div className="flex items-center gap-1 overflow-x-auto whitespace-nowrap text-sm">
+        {/* flex-wrap keeps every module reachable at any viewport width; a
+            nowrap row clipped a third of the modules with no affordance
+            that more existed (#2888). */}
+        <div className="flex flex-wrap items-center gap-1 text-sm">
           <Link
             to="/admin"
             aria-current={onOverview ? "page" : undefined}

--- a/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/AdminRouteShell.tsx
@@ -77,6 +77,11 @@ export const AdminRouteShell: React.FC<{
                 }
               >
                 {module.label}
+                {module.comingSoon ? (
+                  <span className="ml-1 rounded-full border border-border px-1.5 py-px align-middle text-[10px] uppercase tracking-wide text-text-muted">
+                    Soon
+                  </span>
+                ) : null}
               </Link>
             )
           })}

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -376,7 +376,18 @@ const ApiKeyManagementPage: React.FC = () => {
           <Form.Item name="name" label={t("settings:adminApiKeys.keyNameLabel", "Key Name (optional)")}>
             <Input placeholder={t("settings:adminApiKeys.keyNamePlaceholder", "e.g. Production Key")} />
           </Form.Item>
-          <Form.Item name="rate_limit" label={t("settings:adminApiKeys.rateLimitLabel", "Rate Limit (requests/minute, optional)")}>
+          <Form.Item
+            name="rate_limit"
+            label={t("settings:adminApiKeys.rateLimitLabel", "Rate Limit (requests/minute, optional)")}
+            extra={
+              <a href="/admin/rate-limiting">
+                {t(
+                  "settings:adminApiKeys.rateLimitCrossLink",
+                  "Baseline limits and endpoint coverage live in Rate Limiting."
+                )}
+              </a>
+            }
+          >
             <Input type="number" placeholder={t("settings:adminApiKeys.rateLimitDefault", "Default")} />
           </Form.Item>
         </Form>

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -284,14 +284,27 @@ const ApiKeyManagementPage: React.FC = () => {
                 size="small"
                 type="primary"
                 onClick={() => {
-                  void navigator.clipboard?.writeText(newKeyValue).then(() => {
-                    message.success(
-                      t("settings:adminApiKeys.newKeyCopied", "Key copied")
-                    )
-                  })
-                  // Masking after copy keeps the secret off screen while the
-                  // operator finishes the rest of the page.
-                  setNewKeyRevealed(false)
+                  void (async () => {
+                    try {
+                      if (!navigator.clipboard?.writeText) {
+                        throw new Error("Clipboard unavailable")
+                      }
+                      await navigator.clipboard.writeText(newKeyValue)
+                      message.success(
+                        t("settings:adminApiKeys.newKeyCopied", "Key copied")
+                      )
+                      // Mask only once the copy actually succeeded - a denied
+                      // clipboard must never hide the only visible credential.
+                      setNewKeyRevealed(false)
+                    } catch {
+                      message.error(
+                        t(
+                          "settings:adminApiKeys.newKeyCopyFailed",
+                          "Could not access the clipboard - select and copy the key manually."
+                        )
+                      )
+                    }
+                  })()
                 }}
               >
                 {t("settings:adminApiKeys.newKeyCopy", "Copy key")}

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -43,6 +43,9 @@ const ApiKeyManagementPage: React.FC = () => {
 
   // New key display (shown after creation with the raw key value)
   const [newKeyValue, setNewKeyValue] = useState<string | null>(null)
+  // The plaintext key shows once, then masks after copy (or on demand) so it
+  // does not linger on screen for shoulder-surfers (#2898 L3).
+  const [newKeyRevealed, setNewKeyRevealed] = useState(true)
 
   const initialLoadRef = useRef(false)
 
@@ -118,6 +121,7 @@ const ApiKeyManagementPage: React.FC = () => {
       // Show the new key value (only visible once)
       if (result?.key || result?.api_key) {
         setNewKeyValue(result.key || result.api_key)
+        setNewKeyRevealed(true)
       }
       createForm.resetFields()
       setCreateModalOpen(false)
@@ -149,6 +153,7 @@ const ApiKeyManagementPage: React.FC = () => {
       const result = await tldwClient.rotateUserApiKey(selectedUserId, keyId)
       if (result?.key || result?.api_key) {
         setNewKeyValue(result.key || result.api_key)
+        setNewKeyRevealed(true)
       }
       message.success(t("settings:adminApiKeys.rotated", "API key rotated"))
       await loadKeys(selectedUserId)
@@ -201,10 +206,19 @@ const ApiKeyManagementPage: React.FC = () => {
       key: "actions",
       render: (_: any, record: any) => (
         <Space size="small">
-          <Popconfirm title={t("settings:adminApiKeys.rotateConfirm", "Rotate this key?")} onConfirm={() => handleRotateKey(record.id)}>
+          <Popconfirm
+            title={t("settings:adminApiKeys.rotateConfirm", "Rotate this key?")}
+            okText={t("settings:adminApiKeys.rotateOk", "Rotate key")}
+            onConfirm={() => handleRotateKey(record.id)}
+          >
             <Button size="small">{t("settings:adminApiKeys.rotate", "Rotate")}</Button>
           </Popconfirm>
-          <Popconfirm title={t("settings:adminApiKeys.revokeConfirm", "Revoke this key? This cannot be undone.")} onConfirm={() => handleRevokeKey(record.id)}>
+          <Popconfirm
+            title={t("settings:adminApiKeys.revokeConfirm", "Revoke this key? This cannot be undone.")}
+            okText={t("settings:adminApiKeys.revokeOk", "Revoke key")}
+            okButtonProps={{ danger: true }}
+            onConfirm={() => handleRevokeKey(record.id)}
+          >
             <Button size="small" danger>{t("settings:adminApiKeys.revoke", "Revoke")}</Button>
           </Popconfirm>
         </Space>
@@ -261,8 +275,33 @@ const ApiKeyManagementPage: React.FC = () => {
           <div>
             <p>{t("settings:adminApiKeys.newKeyCopyHint", "Copy this key now -- it will not be shown again:")}</p>
             <code className="block break-all rounded border border-border bg-surface2 px-3 py-2 font-mono text-sm text-foreground">
-              {newKeyValue}
+              {newKeyRevealed
+                ? newKeyValue
+                : `${newKeyValue.slice(0, 12)}${"•".repeat(12)}`}
             </code>
+            <Space className="mt-2">
+              <Button
+                size="small"
+                type="primary"
+                onClick={() => {
+                  void navigator.clipboard?.writeText(newKeyValue).then(() => {
+                    message.success(
+                      t("settings:adminApiKeys.newKeyCopied", "Key copied")
+                    )
+                  })
+                  // Masking after copy keeps the secret off screen while the
+                  // operator finishes the rest of the page.
+                  setNewKeyRevealed(false)
+                }}
+              >
+                {t("settings:adminApiKeys.newKeyCopy", "Copy key")}
+              </Button>
+              <Button size="small" onClick={() => setNewKeyRevealed((v) => !v)}>
+                {newKeyRevealed
+                  ? t("settings:adminApiKeys.newKeyHide", "Hide")
+                  : t("settings:adminApiKeys.newKeyReveal", "Reveal")}
+              </Button>
+            </Space>
           </div>
         </Alert>
       )}
@@ -329,6 +368,7 @@ const ApiKeyManagementPage: React.FC = () => {
         title={t("settings:adminApiKeys.createModalTitle", "Create API Key")}
         open={createModalOpen}
         onOk={handleCreateKey}
+        okText={t("settings:adminApiKeys.createModalOk", "Create key")}
         onCancel={() => setCreateModalOpen(false)}
         confirmLoading={creating}
       >

--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -523,7 +523,12 @@ const BillingDashboardPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>{t("settings:adminBilling.title", "Billing Dashboard")}</h1>
+      <span style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>{t("settings:adminBilling.title", "Billing Dashboard")}</h1>
+        <a href="/admin/usage" style={{ fontSize: "0.85rem" }}>
+          {t("settings:adminBilling.usageCrossLink", "Request and token volumes live in Usage Analytics")}
+        </a>
+      </span>
       <Tabs defaultActiveKey="overview" items={tabItems} />
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
@@ -287,6 +287,12 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
           loading={loading}
           pagination={backups.length > 20 ? { pageSize: 20 } : false}
           size="small"
+          locale={{
+            emptyText: t(
+              "settings:adminDataOps.backupsEmpty",
+              "No backups yet. Pick a dataset above and create the first one."
+            )
+          }}
         />
       </Card>
 
@@ -298,6 +304,43 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
           </Button>
         }
       >
+        {/* Starter chips fill the form, mirroring the Monitoring alert-rule
+            pattern - the cron syntax stops being a prerequisite (#2899 I1). */}
+        <div style={{ marginBottom: 8 }}>
+          <Space size="small" wrap>
+            {[
+              {
+                label: t(
+                  "settings:adminDataOps.schedulePresetNightly",
+                  "Nightly at 02:00, keep 14 days"
+                ),
+                cron: "0 2 * * *",
+                retention: 14
+              },
+              {
+                label: t(
+                  "settings:adminDataOps.schedulePresetWeekly",
+                  "Weekly on Sunday 03:00, keep 8 weeks"
+                ),
+                cron: "0 3 * * 0",
+                retention: 56
+              }
+            ].map((preset) => (
+              <Tag
+                key={preset.cron}
+                style={{ cursor: "pointer" }}
+                onClick={() =>
+                  scheduleForm.setFieldsValue({
+                    cron: preset.cron,
+                    retention_days: preset.retention
+                  })
+                }
+              >
+                {preset.label}
+              </Tag>
+            ))}
+          </Space>
+        </div>
         <div style={{ marginBottom: 16 }}>
           <Form form={scheduleForm} layout="inline">
             <Form.Item
@@ -340,6 +383,12 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
           loading={schedulesLoading}
           pagination={false}
           size="small"
+          locale={{
+            emptyText: t(
+              "settings:adminDataOps.schedulesEmpty",
+              "No schedules yet. Recurring backups run themselves - add one above (for example: nightly at 02:00)."
+            )
+          }}
         />
       </Card>
     </div>

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -1229,7 +1229,9 @@ export const LlamacppAdminPage: React.FC = () => {
         )}
 
         <div>
-          <Title level={2}>
+          {/* level 1: this is the page heading; it must exist even while the
+              backend is unavailable (#2898 L2). Sized to match level 2. */}
+          <Title level={1} style={{ fontSize: 30 }}>
             {t("option:header.adminLlamacpp", "Llama.cpp Admin")}
           </Title>
           <Text type="secondary">

--- a/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
@@ -305,7 +305,9 @@ export const MlxAdminPage: React.FC = () => {
 
         {/* Page Header */}
         <div>
-          <Title level={2}>
+          {/* level 1: this is the page heading; it must exist even while the
+              backend is unavailable (#2898 L2). Sized to match level 2. */}
+          <Title level={1} style={{ fontSize: 30 }}>
             {t("option:header.adminMlx", "MLX LM Admin")}
           </Title>
           <Text type="secondary">

--- a/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MonitoringDashboardPage.tsx
@@ -661,7 +661,13 @@ const MonitoringDashboardPage: React.FC = () => {
         {t(
           "settings:adminMonitoring.description",
           "Monitor your tldw server's health and set up alerts for important metrics. Create rules below to get notified when something needs attention."
-        )}
+        )}{" "}
+        <a href="/admin/server">
+          {t(
+            "settings:adminMonitoring.serverAdminCrossLink",
+            "Users, storage, and session management live in Server Admin."
+          )}
+        </a>
       </Typography.Paragraph>
 
       {/* System Overview Card */}
@@ -809,7 +815,7 @@ const MonitoringDashboardPage: React.FC = () => {
 
       {/* Alert History Card */}
       <Card title={t("settings:adminMonitoring.alertHistoryTitle", "Alert History")} style={{ marginBottom: 16 }} extra={<Button onClick={() => loadAlertHistory()} size="small">{t("common:refresh", "Refresh")}</Button>}>
-        <Table dataSource={alertHistory} columns={historyColumns} rowKey={(record) => String(record.id ?? record.alert ?? record.triggered_at ?? "unknown")} loading={historyLoading} pagination={{ pageSize: 20 }} size="small" />
+        <Table dataSource={alertHistory} columns={historyColumns} rowKey={(record) => String(record.id ?? record.alert ?? record.triggered_at ?? "unknown")} loading={historyLoading} pagination={{ pageSize: 20 }} size="small" locale={{ emptyText: t("settings:adminMonitoring.alertHistoryEmpty", "No alert activity recorded yet. Actions on alerts (acknowledge, snooze, escalate) appear here.") }} />
       </Card>
 
       {/* Activity (Collapsible) */}

--- a/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
@@ -67,7 +67,9 @@ const RateLimitingPage: React.FC = () => {
   const loadCoverage = useCallback(async () => {
     setCoverageLoading(true)
     try {
-      const result = await tldwClient.getGovernorCoverage()
+      // Request the full route lists - the endpoint's default caps them at
+      // 50, which silently hid most of a 558-route audit (#2890).
+      const result = await tldwClient.getGovernorCoverage({ limit: 5000 })
       setCoverage(result)
     } catch (err) {
       markAdminGuardFromError(err)
@@ -250,6 +252,15 @@ const RateLimitingPage: React.FC = () => {
             </div>
             <div>
               <strong>{t("settings:adminRateLimiting.policyStore", "Store:")}</strong> {policy.store || "file"}
+              {(policy.store || "file") === "file" && (
+                <span style={{ color: "var(--color-text-secondary, #888)" }}>
+                  {" "}
+                  {t(
+                    "settings:adminRateLimiting.policyStoreHint",
+                    "(policies live in the YAML at [ResourceGovernor] policy_path in Config_Files/config.txt; edit on the server and restart)"
+                  )}
+                </span>
+              )}
             </div>
             <div>
               <strong>{t("settings:adminRateLimiting.policyVersion", "Version:")}</strong> {policy.version ?? "\u2014"}
@@ -299,6 +310,20 @@ const RateLimitingPage: React.FC = () => {
             {unprotectedRoutes.length > 0 && (
               <div>
                 <strong>{t("settings:adminRateLimiting.unprotectedRoutes", "Unprotected Routes:")}</strong>
+                {unprotectedRoutes.length < unprotectedCount && (
+                  // Older servers ignore the limit param and still cap the
+                  // list - never present a partial audit as complete (#2890).
+                  <div style={{ color: "var(--color-text-secondary, #888)" }}>
+                    {t(
+                      "settings:adminRateLimiting.unprotectedTruncated",
+                      "Showing the first {{shown}} of {{total}} unprotected routes reported by the server.",
+                      {
+                        shown: unprotectedRoutes.length,
+                        total: unprotectedCount
+                      }
+                    )}
+                  </div>
+                )}
                 <Table
                   dataSource={unprotectedRoutes.map((r: any, i: number) =>
                     typeof r === "string" ? { route: r, key: i } : { ...r, key: i }
@@ -330,7 +355,15 @@ const RateLimitingPage: React.FC = () => {
           {t(
             "settings:adminRateLimiting.overridesDescription",
             "Overrides created for specific users or API keys. Baseline limits come from the resource governor policy above."
-          )}
+          )}{" "}
+          {/* The only UI that creates an override today is the API Keys
+              create dialog - link the workflow instead of dead-ending (#2895). */}
+          <a href="/admin/api-keys">
+            {t(
+              "settings:adminRateLimiting.overridesCreateLink",
+              "Set a per-key limit when creating an API key in API Keys."
+            )}
+          </a>
         </p>
         {rateLimitsError ? (
           <Alert title={rateLimitsError} />

--- a/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
@@ -269,7 +269,12 @@ const UsageAnalyticsPage: React.FC = () => {
   return (
     <div style={{ padding: "24px", maxWidth: 1200 }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
-        <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 600 }}>{t("settings:adminUsage.title", "Usage Analytics")}</h1>
+        <span style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+          <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 600 }}>{t("settings:adminUsage.title", "Usage Analytics")}</h1>
+          <a href="/admin/billing" style={{ fontSize: "0.85rem" }}>
+            {t("settings:adminUsage.billingCrossLink", "Costs and spend live in Billing")}
+          </a>
+        </span>
         <Select
           value={dateRange}
           onChange={(val) => setDateRange(val)}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/AdminOperationsOverviewPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/AdminOperationsOverviewPage.test.tsx
@@ -16,12 +16,21 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: apiMock
 }))
 
+const connectionMock = vi.hoisted(() => ({
+  serverUrl: "http://127.0.0.1:8000" as string | null
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionState: () => ({ serverUrl: connectionMock.serverUrl })
+}))
+
 import { AdminOperationsOverviewPage } from "../AdminOperationsOverviewPage"
 import { ADMIN_MODULES } from "../admin-modules"
 
 describe("AdminOperationsOverviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    connectionMock.serverUrl = "http://127.0.0.1:8000"
     apiMock.getSystemStats.mockResolvedValue({ users: { total: 1 } })
     apiMock.getSecurityAlertStatus.mockResolvedValue({ health: "ok" })
     apiMock.listBackups.mockResolvedValue({ backups: [] })
@@ -77,5 +86,48 @@ describe("AdminOperationsOverviewPage", () => {
       const badges = screen.getAllByTestId("admin-module-signal")
       expect(badges).toHaveLength(6)
     })
+  })
+
+  it("renders a deliberately-disabled backend as 'Not configured', not an outage (#2894)", async () => {
+    apiMock.getLlamacppStatus.mockRejectedValue(
+      new Error(
+        "Managed llama.cpp backend is not configured. Enable [LlamaCpp] enabled=true."
+      )
+    )
+
+    render(<AdminOperationsOverviewPage />)
+
+    expect(await screen.findByText("Not configured")).toBeInTheDocument()
+    expect(screen.queryByText("Status unavailable")).not.toBeInTheDocument()
+  })
+
+  it("links each signal badge to its module (#2899)", async () => {
+    render(<AdminOperationsOverviewPage />)
+
+    const badge = await screen.findByText("1 user")
+    expect(badge.closest("a")).toHaveAttribute("href", "/admin/server")
+  })
+
+  it("shows a connect-first banner when no server is configured (#2893)", async () => {
+    connectionMock.serverUrl = null
+
+    render(<AdminOperationsOverviewPage />)
+
+    const banner = screen.getByTestId("admin-not-connected-banner")
+    expect(banner).toHaveTextContent("Not connected to a tldw server")
+    expect(within(banner).getByRole("link", { name: "Connect" })).toHaveAttribute(
+      "href",
+      "/setup"
+    )
+    // The module map stays visible beneath the banner.
+    expect(screen.getByTestId("admin-operations-modules")).toBeInTheDocument()
+  })
+
+  it("omits the connect banner when a server is configured (#2893)", () => {
+    render(<AdminOperationsOverviewPage />)
+
+    expect(
+      screen.queryByTestId("admin-not-connected-banner")
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
@@ -19,7 +19,13 @@ describe("AdminRouteShell", () => {
 
     const nav = screen.getByRole("navigation", { name: "Admin modules" })
     for (const module of ADMIN_MODULES) {
-      const link = within(nav).getByRole("link", { name: module.label })
+      // Coming-soon modules carry a "Soon" badge inside the link (#2897),
+      // so match on the label prefix rather than the exact accessible name.
+      const link = within(nav).getByRole("link", {
+        name: new RegExp(
+          `^${module.label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`
+        )
+      })
       expect(link).toHaveAttribute("href", module.route)
     }
   })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/AdminRouteShell.test.tsx
@@ -24,6 +24,22 @@ describe("AdminRouteShell", () => {
     }
   })
 
+  it("wraps the module nav instead of clipping modules past the viewport (#2888)", () => {
+    render(
+      <MemoryRouter>
+        <AdminRouteShell path="/admin/server">
+          <div>content</div>
+        </AdminRouteShell>
+      </MemoryRouter>
+    )
+
+    const nav = screen.getByRole("navigation", { name: "Admin modules" })
+    const row = nav.firstElementChild as HTMLElement
+    expect(row.className).toContain("flex-wrap")
+    expect(row.className).not.toContain("whitespace-nowrap")
+    expect(row.className).not.toContain("overflow-x-auto")
+  })
+
   it("marks the current module and titles the document after it", () => {
     render(
       <MemoryRouter>

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
@@ -47,6 +47,7 @@ vi.mock("antd", async () => {
   const Modal = ({
     children,
     confirmLoading,
+    okText,
     onCancel,
     onOk,
     open,
@@ -54,6 +55,7 @@ vi.mock("antd", async () => {
   }: {
     children?: React.ReactNode
     confirmLoading?: boolean
+    okText?: React.ReactNode
     onCancel?: () => void
     onOk?: () => void
     open?: boolean
@@ -65,7 +67,7 @@ vi.mock("antd", async () => {
       <div role="dialog" aria-label={title}>
         {children}
         <button type="button" disabled={confirmLoading} onClick={onOk}>
-          OK
+          {okText ?? "OK"}
         </button>
         <button type="button" onClick={onCancel}>
           Cancel
@@ -175,7 +177,8 @@ describe("ApiKeyManagementPage design-system states", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. Production Key"), {
       target: { value: "Production Key" }
     })
-    fireEvent.click(screen.getByRole("button", { name: "OK" }))
+    // The dialog commits with the verb, not a generic OK (#2892).
+    fireEvent.click(screen.getByRole("button", { name: "Create key" }))
 
     await waitFor(() => {
       expect(apiMock.createUserApiKey).toHaveBeenCalledWith(11, {
@@ -187,6 +190,28 @@ describe("ApiKeyManagementPage design-system states", () => {
     const alert = await expectDesignSystemAlertForText("New API Key Created")
     expect(alert).toHaveAttribute("role", "status")
     expect(alert).toHaveTextContent("Copy this key now -- it will not be shown again:")
+    expect(alert).toHaveTextContent("sk-test-secret")
+  })
+
+  it("masks the created key after copy and supports reveal (#2898 L3)", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    await renderWithUser()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Create Key" }))
+    fireEvent.click(screen.getByRole("button", { name: "Create key" }))
+
+    const alert = await expectDesignSystemAlertForText("New API Key Created")
+    expect(alert).toHaveTextContent("sk-test-secret")
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy key" }))
+    expect(writeText).toHaveBeenCalledWith("sk-test-secret")
+    await waitFor(() => {
+      expect(alert).not.toHaveTextContent("sk-test-secret")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Reveal" }))
     expect(alert).toHaveTextContent("sk-test-secret")
   })
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/admin-module-signals.test.ts
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/admin-module-signals.test.ts
@@ -138,6 +138,39 @@ describe("loadAdminModuleSignals", () => {
     warnSpy.mockRestore()
   })
 
+  it("maps not-configured backend errors to a neutral 'off' signal (#2894)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    apiMock.getLlamacppStatus.mockRejectedValue(
+      new Error(
+        "Managed llama.cpp backend is not configured. Enable [LlamaCpp] enabled=true."
+      )
+    )
+
+    const signals = await loadAdminModuleSignals()
+
+    expect(signals["/admin/llamacpp"]).toEqual({
+      state: "off",
+      detail: "Not configured"
+    })
+    // Deliberate off-states are expected - they must not log at all.
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it("logs each unavailable route once per session, not once per load (#2896)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    apiMock.getGovernorCoverage.mockRejectedValue(new Error("boom"))
+
+    await loadAdminModuleSignals()
+    await loadAdminModuleSignals()
+
+    const governorWarns = warnSpy.mock.calls.filter(([first]) =>
+      String(first).includes("/admin/rate-limiting")
+    )
+    expect(governorWarns).toHaveLength(1)
+    warnSpy.mockRestore()
+  })
+
   it("times out a hung fetcher instead of blocking the overview", async () => {
     vi.useFakeTimers()
     apiMock.getMlxStatus.mockImplementation(() => new Promise(() => {}))

--- a/apps/packages/ui/src/components/Option/Admin/admin-module-signals.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-module-signals.ts
@@ -6,7 +6,11 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
  * anything wrong?" at a glance while degrading to the static map whenever a
  * signal is unavailable.
  */
-export type AdminModuleSignalState = "healthy" | "attention" | "unavailable"
+export type AdminModuleSignalState =
+  | "healthy"
+  | "attention"
+  | "unavailable"
+  | "off"
 
 export interface AdminModuleSignal {
   state: AdminModuleSignalState
@@ -94,6 +98,21 @@ const SIGNAL_FETCHERS: Record<string, () => Promise<AdminModuleSignal>> = {
   }
 }
 
+/**
+ * A backend that answers "this module is not configured/enabled" is off on
+ * purpose - render it as a neutral "off" signal, not as an outage (#2894).
+ */
+const isNotConfiguredError = (reason: unknown): boolean => {
+  const message =
+    reason instanceof Error ? reason.message : String(reason ?? "")
+  return /not configured|not enabled|is disabled/i.test(message)
+}
+
+// One log line per route per session: unavailable signals are expected on
+// servers that leave optional modules off, and the overview reloads on every
+// visit (#2896).
+const loggedSignalFailures = new Set<string>()
+
 export const loadAdminModuleSignals = async (): Promise<
   Record<string, AdminModuleSignal>
 > => {
@@ -108,10 +127,17 @@ export const loadAdminModuleSignals = async (): Promise<
       signals[route] = result.value
       return
     }
-    console.warn(
-      `[admin-signals] signal for ${route} unavailable:`,
-      result.reason
-    )
+    if (isNotConfiguredError(result.reason)) {
+      signals[route] = { state: "off", detail: "Not configured" }
+      return
+    }
+    if (!loggedSignalFailures.has(route)) {
+      loggedSignalFailures.add(route)
+      console.warn(
+        `[admin-signals] signal for ${route} unavailable:`,
+        result.reason
+      )
+    }
     signals[route] = { state: "unavailable", detail: "Status unavailable" }
   })
   return signals

--- a/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
@@ -20,6 +20,9 @@ export interface AdminModule {
   label: string
   description: string
   group: AdminModuleGroup
+  /** Route exists but the surface is a placeholder - badge it so operators
+   *  know before clicking (#2897). */
+  comingSoon?: boolean
 }
 
 export const ADMIN_MODULE_GROUPS: AdminModuleGroup[] = [
@@ -139,7 +142,8 @@ export const ADMIN_MODULES: AdminModule[] = [
     route: "/admin/watchlists-runs",
     label: "Watchlist Runs",
     description: "Run history and job inspection for watchlists (coming soon).",
-    group: "Workspace"
+    group: "Workspace",
+    comingSoon: true
   }
 ]
 

--- a/apps/packages/ui/src/components/Option/Watchlists/ItemsTab/ItemsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/ItemsTab/ItemsTab.tsx
@@ -350,6 +350,11 @@ export const ItemsTab: React.FC = () => {
   const [sources, setSources] = useState<WatchlistSource[]>([])
   const [sourcesLoading, setSourcesLoading] = useState(false)
   const [sourcesLoaded, setSourcesLoaded] = useState(false)
+  // No watchlist feeds exist at all (confirmed by a successful load): there
+  // is nothing to triage, so the saved-views / bulk-action machinery hides
+  // behind the create-first-watchlist empty state (#2899 I5).
+  const trulyEmptyWatchlists =
+    sourcesLoaded && !sourcesLoading && sources.length === 0
   const [sourcesCappedAtLimit, setSourcesCappedAtLimit] = useState(false)
   const [sourceSearch, setSourceSearch] = useState("")
   const [runs, setRuns] = useState<WatchlistRun[]>([])
@@ -2540,6 +2545,8 @@ export const ItemsTab: React.FC = () => {
                 />
               </div>
 
+              {!trulyEmptyWatchlists ? (
+              <>
               <div className="rounded-lg border border-border bg-surface/70 p-2.5">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="text-xs font-semibold uppercase tracking-wide text-text-subtle">
@@ -2752,6 +2759,8 @@ export const ItemsTab: React.FC = () => {
                 </p>
 
               </div>
+              </>
+              ) : null}
             </div>
 
             <div
@@ -2767,7 +2776,7 @@ export const ItemsTab: React.FC = () => {
                 <Empty
                   image={Empty.PRESENTED_IMAGE_SIMPLE}
                   description={
-                    sourcesLoaded && !sourcesLoading && sources.length === 0
+                    trulyEmptyWatchlists
                       ? t(
                           "watchlists:items.emptyNoWatchlists",
                           "No watchlist feeds yet. Create a watchlist to start collecting updates."
@@ -2775,10 +2784,7 @@ export const ItemsTab: React.FC = () => {
                       : t("watchlists:items.empty", "No updates found")
                   }
                 >
-                  {sourcesLoaded &&
-                  !sourcesLoading &&
-                  sources.length === 0 &&
-                  navigate ? (
+                  {trulyEmptyWatchlists && navigate ? (
                     <Button type="primary" onClick={() => navigate("/watchlists")}>
                       {t("watchlists:items.createWatchlist", "Create a watchlist")}
                     </Button>

--- a/apps/packages/ui/src/components/Option/Watchlists/ItemsTab/ItemsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/ItemsTab/ItemsTab.tsx
@@ -2545,7 +2545,10 @@ export const ItemsTab: React.FC = () => {
                 />
               </div>
 
-              {!trulyEmptyWatchlists ? (
+              {/* Hide the triage machinery only when there is genuinely
+                  nothing to triage: no feeds AND no (historical) items -
+                  deleting all sources does not delete collected items. */}
+              {!(trulyEmptyWatchlists && !itemsLoading && items.length === 0) ? (
               <>
               <div className="rounded-lg border border-border bg-surface/70 p-2.5">
                 <div className="flex flex-wrap items-center gap-2">

--- a/apps/packages/ui/src/public/_locales/en/watchlists.json
+++ b/apps/packages/ui/src/public/_locales/en/watchlists.json
@@ -1086,7 +1086,7 @@
     "message": "Error"
   },
   "items_description": {
-    "message": "Review collected updates, alert matches, and briefing candidates from this Watchlist."
+    "message": "Review collected updates, alert matches, and briefing candidates across your watchlists."
   },
   "items_smartFeeds": {
     "message": "Smart Feeds"

--- a/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
+++ b/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
@@ -12,10 +12,10 @@ const OptionAdminWatchlistsItems = () => {
             <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>
               Watchlists Items
             </h1>
+            {/* ItemsTab renders the "review collected updates" line itself;
+                this wrapper only adds the guidance it can't know (#2891). */}
             <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
-              Review collected updates, alert matches, and briefing candidates
-              across your watchlists. Create and configure watchlists on the
-              Watchlists page.
+              Create and configure watchlists on the Watchlists page.
             </p>
             <ItemsTab />
           </div>

--- a/apps/packages/ui/src/routes/option-admin-watchlists-runs.tsx
+++ b/apps/packages/ui/src/routes/option-admin-watchlists-runs.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { Link } from "react-router-dom"
+import OptionLayout from "~/components/Layouts/Layout"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
+import { AdminRouteShell } from "@/components/Option/Admin/AdminRouteShell"
+
+/**
+ * Shared coming-soon surface for /admin/watchlists-runs (#2897): the module
+ * is advertised in the admin nav and overview, so every platform that can
+ * reach the link must render an honest placeholder instead of a router
+ * fallback. The web build serves its own Next-side RoutePlaceholder page;
+ * this route covers the shared registry (extension and friends).
+ */
+const OptionAdminWatchlistsRuns = () => {
+  return (
+    <RouteErrorBoundary
+      routeId="admin-watchlists-runs"
+      routeLabel="Watchlist Runs"
+    >
+      <OptionLayout>
+        <AdminRouteShell path="/admin/watchlists-runs">
+          <div className="flex min-h-[60vh] w-full items-center justify-center px-6 py-12">
+            <div className="w-full max-w-xl rounded-xl border border-border bg-surface p-8 shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                Coming Soon
+              </p>
+              <h1 className="mt-2 text-2xl font-semibold text-text">
+                Watchlist Runs Admin Is Coming Soon
+              </h1>
+              <p className="mt-3 text-sm text-text-muted">
+                Administrative run inspection for watchlists will land on this
+                route. Use Watchlists for current run history and job
+                management.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-2">
+                <Link
+                  to="/watchlists"
+                  className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primaryStrong"
+                >
+                  Open Watchlists
+                </Link>
+                <Link
+                  to="/admin"
+                  className="rounded-md border border-border px-3 py-1.5 text-sm text-text hover:bg-surface2"
+                >
+                  Back to Admin Operations
+                </Link>
+              </div>
+            </div>
+          </div>
+        </AdminRouteShell>
+      </OptionLayout>
+    </RouteErrorBoundary>
+  )
+}
+
+export default OptionAdminWatchlistsRuns

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -114,6 +114,9 @@ const OptionAdminLlamacpp = lazy(() => import("./option-admin-llamacpp"))
 const OptionAdminMlx = lazy(() => import("./option-admin-mlx"))
 const OptionAdminRuntimeConfig = lazy(() => import("./option-admin-runtime-config"))
 const OptionAdminMonitoring = lazy(() => import("./option-admin-monitoring"))
+const OptionAdminWatchlistsRuns = lazy(
+  () => import("./option-admin-watchlists-runs")
+)
 const OptionAdminApiKeys = lazy(() => import("./option-admin-api-keys"))
 const OptionAdminBilling = lazy(() => import("./option-admin-billing"))
 const OptionAdminDataOps = lazy(() => import("./option-admin-data-ops"))
@@ -601,6 +604,12 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
     kind: "options",
     path: "/admin/monitoring",
     element: <OptionAdminMonitoring />,
+    targets: ALL_TARGETS,
+  },
+  {
+    kind: "options",
+    path: "/admin/watchlists-runs",
+    element: <OptionAdminWatchlistsRuns />,
     targets: ALL_TARGETS,
   },
   {

--- a/apps/packages/ui/src/services/integrations-control-plane.ts
+++ b/apps/packages/ui/src/services/integrations-control-plane.ts
@@ -238,14 +238,18 @@ export async function deletePersonalIntegration(
 export async function listWorkspaceIntegrations(): Promise<IntegrationOverviewResponse> {
   return await bgRequest<IntegrationOverviewResponse>({
     path: "/api/v1/integrations/workspace",
-    method: "GET"
+    method: "GET",
+    // Capability probe: absent on servers without the module (#2896).
+    expectedStatuses: [404, 405, 410, 501]
   })
 }
 
 export async function getWorkspaceSlackPolicy(): Promise<SlackWorkspacePolicyResponse> {
   return await bgRequest<SlackWorkspacePolicyResponse>({
     path: "/api/v1/integrations/workspace/slack/policy",
-    method: "GET"
+    method: "GET",
+    // Capability probe: absent on servers without the module (#2896).
+    expectedStatuses: [404, 405, 410, 501]
   })
 }
 
@@ -263,7 +267,9 @@ export async function updateWorkspaceSlackPolicy(
 export async function getWorkspaceDiscordPolicy(): Promise<DiscordWorkspacePolicyResponse> {
   return await bgRequest<DiscordWorkspacePolicyResponse>({
     path: "/api/v1/integrations/workspace/discord/policy",
-    method: "GET"
+    method: "GET",
+    // Capability probe: absent on servers without the module (#2896).
+    expectedStatuses: [404, 405, 410, 501]
   })
 }
 
@@ -281,7 +287,9 @@ export async function updateWorkspaceDiscordPolicy(
 export async function getWorkspaceTelegramBot(): Promise<TelegramBotConfigResponse> {
   return await bgRequest<TelegramBotConfigResponse>({
     path: "/api/v1/integrations/workspace/telegram/bot",
-    method: "GET"
+    method: "GET",
+    // Capability probe: absent on servers without the module (#2896).
+    expectedStatuses: [404, 405, 410, 501]
   })
 }
 
@@ -308,7 +316,9 @@ export async function createWorkspaceTelegramPairingCode(): Promise<TelegramPair
 export async function listWorkspaceTelegramLinkedActors(): Promise<TelegramLinkedActorListResponse> {
   return await bgRequest<TelegramLinkedActorListResponse>({
     path: "/api/v1/integrations/workspace/telegram/linked-actors",
-    method: "GET"
+    method: "GET",
+    // Capability probe: absent on servers without the module (#2896).
+    expectedStatuses: [404, 405, 410, 501]
   })
 }
 

--- a/apps/packages/ui/src/services/tldw/domains/models-audio.ts
+++ b/apps/packages/ui/src/services/tldw/domains/models-audio.ts
@@ -599,7 +599,10 @@ export const modelsAudioMethods = {
   async getLlamacppStatus(): Promise<any> {
     return await bgRequest<any>({
       path: "/api/v1/llamacpp/status",
-      method: "GET"
+      method: "GET",
+      // 503 means the managed backend is deliberately not configured -
+      // callers surface that state in the UI; no console noise (#2896).
+      expectedStatuses: [503]
     })
   },
 

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -2032,8 +2032,16 @@ export const workspaceApiMethods = {
     return await bgRequest<any>({ path: "/api/v1/resource-governor/policy", method: "GET" })
   },
 
-  async getGovernorCoverage(): Promise<any> {
-    return await bgRequest<any>({ path: "/api/v1/diag/coverage", method: "GET" })
+  async getGovernorCoverage(params?: { limit?: number }): Promise<any> {
+    const limit = params?.limit
+    const query =
+      typeof limit === "number" && Number.isFinite(limit)
+        ? `?limit=${Math.max(1, Math.floor(limit))}`
+        : ""
+    return await bgRequest<any>({
+      path: `/api/v1/diag/coverage${query}`,
+      method: "GET"
+    })
   },
 
   async listAdminRateLimits(): Promise<any[]> {

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -953,3 +953,34 @@ describe('WebLayout /chat scroll contract', () => {
     expect(mediaQueryModule.useMediaQuery).toEqual(expect.any(Function));
   });
 });
+
+describe('WebLayout bypass block (#2889)', () => {
+  beforeEach(() => {
+    delete (globalThis as typeof globalThis & { __tldwOptionShell?: unknown }).__tldwOptionShell;
+    vi.clearAllMocks();
+    routerState.location.pathname = '/admin/server';
+    connectionState.value.phase = 'connected';
+    connectionState.value.isConnected = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (globalThis as typeof globalThis & { __tldwOptionShell?: unknown }).__tldwOptionShell;
+  });
+
+  it('renders a skip link as the first focusable element, targeting the main region', () => {
+    const view = render(<OptionLayout><div>Content</div></OptionLayout>);
+
+    const firstFocusable = view.container.querySelector(
+      "a[href], button, [tabindex]:not([tabindex='-1'])"
+    ) as HTMLElement;
+    expect(firstFocusable).toBeTruthy();
+    expect(firstFocusable.tagName).toBe('A');
+    expect(firstFocusable).toHaveTextContent('Skip to main content');
+    expect(firstFocusable).toHaveAttribute('href', '#main-content');
+
+    const main = view.container.querySelector('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/apps/tldw-frontend/__tests__/navigation/route-placeholder-component.test.tsx
+++ b/apps/tldw-frontend/__tests__/navigation/route-placeholder-component.test.tsx
@@ -42,7 +42,9 @@ describe('RoutePlaceholder recovery', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Connector Jobs Is Coming Soon' })).toBeVisible();
-    expect(screen.getAllByText('/connectors/jobs')).toHaveLength(2);
+    // Requested and planned route match here, so the path prints once (#2897).
+    expect(screen.getAllByText('/connectors/jobs')).toHaveLength(1);
+    expect(screen.queryByText('Planned route:')).not.toBeInTheDocument();
     expect(screen.getByTestId('route-placeholder-primary')).toHaveAttribute('href', '/connectors');
     expect(screen.getByTestId('route-placeholder-open-settings')).toHaveAttribute('href', '/settings');
     expect(screen.getByTestId('route-placeholder-go-back')).toBeVisible();
@@ -146,7 +148,7 @@ describe('RoutePlaceholder recovery', () => {
     render(<ProfileRedirectPage />);
 
     expect(screen.getByRole('heading', { level: 1, name: 'Profile Page Is Coming Soon' })).toBeVisible();
-    expect(screen.getAllByText('/profile')).toHaveLength(2);
+    expect(screen.getAllByText('/profile')).toHaveLength(1);
     expect(screen.getByTestId('route-placeholder-primary')).toHaveAttribute('href', '/settings');
     expect(screen.getByTestId('route-placeholder-primary')).toHaveTextContent('Open Settings');
     expect(screen.queryByTestId('route-placeholder-open-settings')).not.toBeInTheDocument();
@@ -158,9 +160,43 @@ describe('RoutePlaceholder recovery', () => {
     render(<ConfigRedirectPage />);
 
     expect(screen.getByRole('heading', { level: 1, name: 'Configuration Center Is Coming Soon' })).toBeVisible();
-    expect(screen.getAllByText('/config')).toHaveLength(2);
+    expect(screen.getAllByText('/config')).toHaveLength(1);
     expect(screen.getByTestId('route-placeholder-primary')).toHaveAttribute('href', '/settings');
     expect(screen.getByTestId('route-placeholder-primary')).toHaveTextContent('Open Settings');
     expect(screen.queryByTestId('route-placeholder-open-settings')).not.toBeInTheDocument();
+  });
+});
+
+describe('RoutePlaceholder planned-route disclosure (#2897)', () => {
+  it('shows the planned route only when it differs from the requested one', () => {
+    mockRouter.asPath = '/old-alias';
+
+    render(
+      <RoutePlaceholder
+        title="Connector Jobs Is Coming Soon"
+        description="Connector job orchestration is planned for this route."
+        plannedPath="/connectors/jobs"
+        primaryCtaHref="/connectors"
+        primaryCtaLabel="Open Connectors Hub"
+      />
+    );
+
+    expect(screen.getByText('Planned route:')).toBeVisible();
+    expect(screen.getByText('/connectors/jobs')).toBeVisible();
+    expect(screen.getByText('/old-alias')).toBeVisible();
+  });
+
+  it('titles the document after the placeholder heading', () => {
+    mockRouter.asPath = '/connectors/jobs';
+
+    render(
+      <RoutePlaceholder
+        title="Connector Jobs Is Coming Soon"
+        description="Connector job orchestration is planned for this route."
+        plannedPath="/connectors/jobs"
+      />
+    );
+
+    expect(document.title).toBe('Connector Jobs Is Coming Soon · tldw');
   });
 });

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -467,6 +467,14 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
         )}
         style={chatScreenBackgroundStyle}
       >
+        {/* A bypass link is only useful as the FIRST focusable element -
+            before the sidebar and header it exists to skip (#2889). */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-50 focus:rounded-md focus:bg-surface focus:px-3 focus:py-2 focus:text-sm focus:text-text focus:shadow"
+        >
+          Skip to main content
+        </a>
         {/* Persistent ChatSidebar when feature flag enabled */}
         {shouldRenderChatSidebar && (
           <ChatSidebar
@@ -480,8 +488,10 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
           />
         )}
         <main
+          id="main-content"
+          tabIndex={-1}
           className={classNames(
-            'relative flex-1 min-w-0 flex flex-col',
+            'relative flex-1 min-w-0 flex flex-col outline-none',
             hideHeader ? 'bg-bg ' : ''
           )}
           data-demo-mode={demoEnabled ? 'on' : 'off'}

--- a/apps/tldw-frontend/components/navigation/RoutePlaceholder.tsx
+++ b/apps/tldw-frontend/components/navigation/RoutePlaceholder.tsx
@@ -20,6 +20,18 @@ export const RoutePlaceholder: React.FC<RoutePlaceholderProps> = ({
   const router = useRouter();
   const routeLabel = String(router.asPath || '/');
   const showSettingsShortcut = !primaryCtaHref.startsWith('/settings');
+  // Placeholder routes were the only pages with no document title (#2897).
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const previous = document.title;
+    document.title = `${title} · tldw`;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+  // When the visitor is already on the planned path, "Requested route" and
+  // "Planned route" print the same value twice - show it once.
+  const plannedDiffers = Boolean(plannedPath) && plannedPath !== routeLabel;
 
   return (
     <div className="flex min-h-[70vh] w-full items-center justify-center px-6 py-12">
@@ -36,7 +48,7 @@ export const RoutePlaceholder: React.FC<RoutePlaceholderProps> = ({
           Requested route:{' '}
           <code className="rounded bg-surface2 px-1 py-0.5">{routeLabel}</code>
         </p>
-        {plannedPath ? (
+        {plannedDiffers ? (
           <p className="mt-1 text-xs text-text-muted">
             Planned route:{' '}
             <code className="rounded bg-surface2 px-1 py-0.5">

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2073,
   "schema_count": 3142,
-  "sha256": "01c4390accc151daa0ec13aaf52d3c72b2bb485dff9ac761711528004bb03489"
+  "sha256": "5c815e778af28b517b73f608b3b458f98c9751313590432e625ea81afe91792c"
 }

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2073,
   "schema_count": 3142,
-  "sha256": "65bab92528ee0dbfb42d33045bbaa85508eb56617591eb5303edef38c40456dd"
+  "sha256": "01c4390accc151daa0ec13aaf52d3c72b2bb485dff9ac761711528004bb03489"
 }

--- a/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
+++ b/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
@@ -573,7 +573,18 @@ async def rg_diag_capabilities():
     dependencies=[Depends(RequireRole("admin"))],
     summary="Resource Governor endpoint coverage audit",
 )
-async def rg_coverage_audit():
+async def rg_coverage_audit(
+    limit: int = Query(
+        50,
+        ge=1,
+        le=5000,
+        description=(
+            "Maximum entries returned in each route list. Counts always "
+            "reflect full totals; compare list length against the counts "
+            "(or route_list_limit) to detect truncation."
+        ),
+    ),
+):
     """Report which endpoints are governor-protected and which are excluded.
 
     Returns coverage percentage and lists of protected/unprotected routes.
@@ -584,7 +595,7 @@ async def rg_coverage_audit():
         )
 
         app = _get_app()
-        result = audit_governor_coverage(app)
+        result = audit_governor_coverage(app, route_limit=limit)
         return JSONResponse(result)
     except Exception:  # noqa: BLE001 - generic 500 handler
         logger.exception("rg_coverage_audit failed")

--- a/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
+++ b/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
@@ -584,10 +584,20 @@ async def rg_coverage_audit(
             "(or route_list_limit) to detect truncation."
         ),
     ),
-):
+) -> JSONResponse:
     """Report which endpoints are governor-protected and which are excluded.
 
-    Returns coverage percentage and lists of protected/unprotected routes.
+    Args:
+        limit: Maximum number of entries returned in each of the
+            ``protected_routes`` / ``unprotected_routes`` lists (1-5000,
+            default 50). The ``*_count`` fields always reflect full totals,
+            so clients can detect a truncated list by comparing lengths
+            against the counts or the echoed ``route_list_limit`` (#2890).
+
+    Returns:
+        JSONResponse with total/protected/unprotected counts, coverage
+        percentage, excluded prefixes, the applied ``route_list_limit``,
+        and the (possibly limited) route lists.
     """
     try:
         from tldw_Server_API.app.core.Resource_Governance.coverage_audit import (

--- a/tldw_Server_API/app/core/Resource_Governance/coverage_audit.py
+++ b/tldw_Server_API/app/core/Resource_Governance/coverage_audit.py
@@ -25,6 +25,7 @@ def audit_governor_coverage(
     app: Any,
     *,
     excluded_prefixes: list[str] | None = None,
+    route_limit: int = 50,
 ) -> dict[str, Any]:
     """Audit which routes are governor-protected.
 
@@ -35,10 +36,13 @@ def audit_governor_coverage(
         app: The FastAPI application instance.
         excluded_prefixes: Route prefixes to consider unprotected.
             Defaults to health/docs routes.
+        route_limit: Maximum number of entries returned in each route list.
+            Counts always reflect the full totals; ``route_list_limit`` in the
+            response lets callers detect a truncated list (#2890).
 
     Returns:
         Dict with total_routes, protected/unprotected counts and lists,
-        coverage percentage, and excluded prefixes.
+        coverage percentage, excluded prefixes, and the applied list limit.
     """
     prefixes = excluded_prefixes if excluded_prefixes is not None else list(DEFAULT_EXCLUDED_PREFIXES)
 
@@ -73,14 +77,16 @@ def audit_governor_coverage(
         coverage,
     )
 
+    safe_limit = max(1, int(route_limit))
     return {
         "total_routes": total,
         "protected_count": len(protected),
         "unprotected_count": len(unprotected),
         "coverage_pct": round(coverage, 1),
         "excluded_prefixes": prefixes,
-        "protected_routes": protected[:50],
-        "unprotected_routes": unprotected[:50],
+        "route_list_limit": safe_limit,
+        "protected_routes": protected[:safe_limit],
+        "unprotected_routes": unprotected[:safe_limit],
     }
 
 

--- a/tldw_Server_API/tests/Resource_Governance/test_coverage_audit.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_coverage_audit.py
@@ -179,6 +179,7 @@ class TestAuditGovernorCoverage:
         assert len(result["protected_routes"]) == 50
         assert result["protected_count"] == 60
 
+    @pytest.mark.unit
     def test_route_limit_returns_full_lists(self):
         """route_limit lets admin callers fetch the complete audit (#2890)."""
         routes = [_MockRoute(f"/docs/page{i}", {"GET"}) for i in range(60)]
@@ -189,6 +190,7 @@ class TestAuditGovernorCoverage:
         assert result["unprotected_count"] == 60
         assert result["route_list_limit"] == 1000
 
+    @pytest.mark.unit
     def test_route_list_limit_reported_for_default_cap(self):
         """Clients can detect truncation from the reported list limit (#2890)."""
         routes = [_MockRoute(f"/docs/page{i}", {"GET"}) for i in range(60)]

--- a/tldw_Server_API/tests/Resource_Governance/test_coverage_audit.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_coverage_audit.py
@@ -179,6 +179,25 @@ class TestAuditGovernorCoverage:
         assert len(result["protected_routes"]) == 50
         assert result["protected_count"] == 60
 
+    def test_route_limit_returns_full_lists(self):
+        """route_limit lets admin callers fetch the complete audit (#2890)."""
+        routes = [_MockRoute(f"/docs/page{i}", {"GET"}) for i in range(60)]
+        app = _MockApp(routes=routes)
+        result = audit_governor_coverage(app, route_limit=1000)
+
+        assert len(result["unprotected_routes"]) == 60
+        assert result["unprotected_count"] == 60
+        assert result["route_list_limit"] == 1000
+
+    def test_route_list_limit_reported_for_default_cap(self):
+        """Clients can detect truncation from the reported list limit (#2890)."""
+        routes = [_MockRoute(f"/docs/page{i}", {"GET"}) for i in range(60)]
+        app = _MockApp(routes=routes)
+        result = audit_governor_coverage(app)
+
+        assert result["route_list_limit"] == 50
+        assert len(result["unprotected_routes"]) == result["route_list_limit"]
+
     def test_routes_without_methods_skipped(self):
         """Routes without methods attribute are skipped (e.g., Mount)."""
 

--- a/tldw_Server_API/tests/Resource_Governance/test_coverage_endpoint_limit.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_coverage_endpoint_limit.py
@@ -1,0 +1,120 @@
+"""Endpoint-level tests for the /diag/coverage route-list limit (#2890).
+
+The core audit function is covered in test_coverage_audit.py; these tests
+exercise the FastAPI layer - query validation bounds and forwarding of the
+``limit`` parameter into ``audit_governor_coverage``.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.rate_limit
+
+
+async def _init_authnz_sqlite(db_path, monkeypatch) -> None:
+    """Point AuthNZ at a throwaway SQLite DB and reset cached pools."""
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+    from tldw_Server_API.app.core.AuthNZ.initialize import (
+        ensure_authnz_schema_ready_once,
+    )
+
+    await ensure_authnz_schema_ready_once()
+
+
+async def _create_admin_api_key(*, username: str, email: str) -> str:
+    """Create an admin user plus API key and return the raw key value."""
+    from uuid import uuid4
+
+    from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    pool = await get_db_pool()
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+    created_user = await users_db.create_user(
+        username=username,
+        email=email,
+        password_hash="x",
+        role="admin",
+        is_active=True,
+        is_superuser=True,
+        storage_quota_mb=5120,
+        uuid_value=uuid4(),
+    )
+    user_id = int(created_user["id"])
+    await AuthnzUsersRepo(db_pool=pool).assign_role_if_missing(
+        user_id=user_id,
+        role_name="admin",
+    )
+    mgr = APIKeyManager(pool)
+    await mgr.initialize()
+    key_rec = await mgr.create_api_key(user_id=user_id, name=f"{username}-key")
+    return str(key_rec["key"])
+
+
+@pytest.mark.asyncio
+async def test_coverage_endpoint_forwards_limit(monkeypatch, tmp_path):
+    """limit is forwarded: larger limits return longer (uncapped) lists."""
+    db_path = tmp_path / "authnz_rg_coverage_limit.db"
+    await _init_authnz_sqlite(db_path, monkeypatch)
+    api_key = await _create_admin_api_key(
+        username="rg-coverage-admin", email="rg-coverage-admin@example.com"
+    )
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    from tldw_Server_API.app.main import app
+
+    with TestClient(app) as client:
+        headers = {"X-API-KEY": api_key}
+
+        default_resp = client.get("/api/v1/diag/coverage", headers=headers)
+        assert default_resp.status_code == 200
+        default_body = default_resp.json()
+        assert default_body["route_list_limit"] == 50
+        assert len(default_body["unprotected_routes"]) <= 50
+
+        full_resp = client.get(
+            "/api/v1/diag/coverage", params={"limit": 5000}, headers=headers
+        )
+        assert full_resp.status_code == 200
+        full_body = full_resp.json()
+        assert full_body["route_list_limit"] == 5000
+        # With the cap lifted, the lists match the reported totals.
+        assert (
+            len(full_body["unprotected_routes"])
+            == full_body["unprotected_count"]
+        )
+        assert len(full_body["protected_routes"]) == full_body["protected_count"]
+
+
+@pytest.mark.asyncio
+async def test_coverage_endpoint_rejects_out_of_bounds_limit(
+    monkeypatch, tmp_path
+):
+    """The FastAPI query bounds (1-5000) reject invalid limits."""
+    db_path = tmp_path / "authnz_rg_coverage_bounds.db"
+    await _init_authnz_sqlite(db_path, monkeypatch)
+    api_key = await _create_admin_api_key(
+        username="rg-coverage-bounds", email="rg-coverage-bounds@example.com"
+    )
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    from tldw_Server_API.app.main import app
+
+    with TestClient(app) as client:
+        headers = {"X-API-KEY": api_key}
+        for bad_limit in (0, 5001):
+            resp = client.get(
+                "/api/v1/diag/coverage",
+                params={"limit": bad_limit},
+                headers=headers,
+            )
+            assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Fixes every finding from the round-2 admin UX audit (report: https://claude.ai/code/artifact/b7170b69-f7aa-4bb2-93af-61ab95ca9084), filed as issues #2888–#2899. Nine commits, grouped by surface:

### High
- **#2888 — nav clipped 6 of 18 modules**: the module nav row was `nowrap` with no overflow affordance; it now wraps so every module is reachable at any width, with a regression test.
- **#2889 — skip link was the ~21st tab stop**: the app shell now renders "Skip to main content" as its first focusable element, targeting the `main` landmark (`id` + `tabIndex=-1`); the admin shell's anchor remains as a secondary in-page link.
- **#2890 — coverage audit silently truncated 558→50**: `diag/coverage` accepts `limit` (default 50, max 5000) and reports `route_list_limit`; the Rate Limiting page requests the full lists and discloses "Showing the first N of M" whenever a server still returns fewer rows than the count.

### Medium
- **#2891**: the stale "from this Watchlist" line came from the locale JSONs overriding the inline i18next default — locale entries updated, and the admin wrapper no longer duplicates ItemsTab's own description.
- **#2892**: Create/Rotate/Revoke dialogs commit with verb labels ("Create key", "Revoke key" danger-styled) instead of generic OK.
- **#2893**: with no configured server, `/admin` shows a connect-first banner above the still-visible module map.
- **#2894**: backends answering "not configured/enabled" render a neutral muted "Not configured" badge instead of the outage-styled "Status unavailable".
- **#2895**: the read-only overrides card links the actual creation path (per-key limit in the API Keys dialog).
- **#2896**: unavailable-signal warnings log once per route per session; the five workspace-integration capability probes and the llamacpp status check mark their known absent/not-configured statuses as expected, eliminating 16 console errors on a healthy Integrations load.
- **#2897**: RoutePlaceholder sets a document title and prints the planned route only when it differs from the requested one; Watchlist Runs is badged "Coming soon" in the nav and on its overview card.

### Low + enhancements
- **#2898**: descriptive empty states on Data-Ops backups/schedules and Monitoring alert history (L1); Llama.cpp/MLX headings are level-1 and always render (L2); the created-key reveal masks after copy with a Reveal/Hide toggle (L3); the governor policy card names where the policy YAML lives (L4).
- **#2899** (partial): signal badges deep-link to their module (I2); schedule starter chips mirror Monitoring's pattern (I1); cross-links between API Keys ↔ Rate Limiting, Usage ↔ Billing, Monitoring → Server Admin (I3); the zero-item Watchlists view hides the bulk/saved-view machinery behind the create-first-watchlist empty state (I5). The I6 first-session checklist remains open on the issue.

## Verification

- `apps/packages/ui`: Admin (138), Watchlists top-level (281), Layout shell, Integrations, and signals suites pass; new tests cover the nav wrap, first-focusable skip link, off-state mapping, log dedupe, connect banner, badge links, verb-labeled dialogs, key masking, and placeholder title/dedupe behavior.
- `tests/Resource_Governance`: 208 passed (including new `route_limit` and `route_list_limit` cases).
- OpenAPI fingerprint regenerated for the new `limit` query param.
- Pre-existing failures confirmed unrelated by replaying suites against origin/dev file contents (OverviewTab/JobsTab/SourcesTab/TemplateEditor async suites and the IntegrationManagementPage zero-quota borderline-timeout fail identically at base).

Closes #2888. Closes #2889. Closes #2890. Closes #2891. Closes #2892. Closes #2893. Closes #2894. Closes #2895. Closes #2896. Closes #2897. Closes #2898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GJqCP5hN77xWHtwJog5M9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all 14 findings from the round-2 admin UX audit (issues #2888–#2899) in the admin shell, overview, API keys, rate limiting, and watchlists.

**Bug fixes**
- Module nav wraps so all 18 modules stay reachable at any width (#2888).
- "Skip to main content" is the first focusable element in both the admin and web shells, targeting the `main` landmark (#2889).
- The coverage audit accepts a `limit` up to 5000 (rejecting out-of-bounds values with 422) and reports `route_list_limit`; Rate Limiting requests the full audit and discloses when a server still truncates it, covered by endpoint and unit tests (#2890).
- Removed the stale duplicated Watchlist description (#2891).
- Create/Rotate/Revoke key dialogs commit with verb labels, not generic OK (#2892).
- `/admin` shows a connect-first banner when no server is configured; not-configured backends render a neutral "Not configured" badge (#2893, #2894).
- The overrides card links to the real creation path, expected capability probes stop logging console errors, and Watchlist Runs is a "Coming soon" placeholder registered across all platforms in the shared route registry (#2895–#2897).

**Polish**
- Empty states on backups/schedules and alert history explain what's missing; Llama.cpp/MLX headings always render; new keys mask only after a successful clipboard copy (denied or unavailable clipboard keeps the key visible) with a Reveal/Hide toggle; the policy card names the YAML file (#2898).
- Signal badges deep-link to their module, schedule starter chips fill the form, related module pages cross-link, and watchlists with neither feeds nor historical items hide triage machinery behind a create-first empty state (#2899).

<sup>Written for commit 1f3bb2ed8366c03264d29a413dabec84074169c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

