### PR TITLE
feat(prompts): make web article summarization customizable

### DIFF
--- a/Docs/Design/web-summary-service-prompt.md
+++ b/Docs/Design/web-summary-service-prompt.md
@@ -1,0 +1,27 @@
+# Web article summarization Service Prompt
+
+Approved scope: synchronous `/api/v1/media/process-web-scraping`; TASK-13195.
+
+Add `media.web.summarization` with literal `system` and `user` parts to the
+existing registry and shared Settings editor. Resolve saved parts once for the
+authenticated request owner before scraping. Explicit request parts, including
+empty strings, win independently. Do not read prompt storage when summarization
+is disabled or both parts are explicit. Close lookup connections on their worker.
+
+Keep the enhanced individual-URL, enhanced crawl, and legacy fallback defaults
+distinct when no saved override exists. Settings presents the deployed web-article
+defaults and explains that reset restores each engine's existing defaults.
+Carry the request's immutable override mapping through the existing call chain;
+do not persist that transient mapping into scraping-job metadata. Fix the existing
+individual-URL `system_prompt`/`system_message` forwarding mismatch.
+Use the same authenticated owner for media persistence instead of deriving an
+owner from the media database wrapper.
+
+Preserve scraping, extraction, provider settings, output shape, persistence,
+chunking, and rate limits. Direct callers, scheduled workflows and
+`/ingest-web-content` do not resolve Service Prompts in this slice.
+
+Verify model-facing messages through the public adapter; owner isolation,
+independent overrides, defaults/reset, multi-page snapshots, disabled-analysis
+bypass, corruption/connection cleanup, engine/fallback paths and atomic Settings
+editing. Run focused regressions, Bandit and OpenAPI checks before review.

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -67,6 +67,10 @@
         "label": "Video summarization",
         "description": "Controls system instructions and recursive final-summary instructions for synchronous video analysis. Without a saved override, server defaults apply."
       },
+      "mediaWebSummarization": {
+        "label": "Web article summarization",
+        "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
+      },
       "mediaEmailSummarization": {
         "label": "Email summarization",
         "description": "Controls system instructions for synchronous email analysis. Without a saved override, server defaults apply."
@@ -92,6 +96,7 @@
       "emailSummarization": "Synchronous email analysis",
       "audioAnalysis": "Synchronous audio analysis",
       "videoSummarization": "Synchronous video analysis",
+      "webSummarization": "Synchronous web scraping",
       "automaticNotesTitles": "Automatic Notes titles"
     },
     "titleGeneration": {

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -174,6 +174,12 @@ const KNOWN_DEFINITIONS = {
     description:
       "Controls system and user instructions for synchronous audio analysis. Without a saved override, server defaults apply."
   },
+  "media.web.summarization": {
+    key: "mediaWebSummarization",
+    label: "Web article summarization",
+    description:
+      "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
+  },
   "media.email.summarization": {
     key: "mediaEmailSummarization",
     label: "Email summarization",
@@ -239,6 +245,10 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
   "media.video.summarization": {
     key: "videoSummarization",
     label: "Synchronous video analysis"
+  },
+  "media.web.summarization": {
+    key: "webSummarization",
+    label: "Synchronous web scraping"
   },
   "notes.title.generate": {
     key: "automaticNotesTitles",

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -269,6 +269,16 @@ const catalog: ServicePromptCatalogItem[] = [
     affected_workflows: [{ id: "media.video.summarization", label: "Server video workflow" }]
   },
   {
+    id: "media.web.summarization",
+    label: "Server web prompt",
+    description: "Server web description",
+    parts: [
+      { key: "system", label: "System instructions", mode: "literal", required_variables: [] },
+      { key: "user", label: "User instructions", mode: "literal", required_variables: [] }
+    ],
+    affected_workflows: [{ id: "media.web.summarization", label: "Server web workflow" }]
+  },
+  {
     id: "notes.title.generate",
     label: "Server Notes title prompt",
     description: "Server Notes title prompt description",
@@ -300,7 +310,9 @@ const detailFor = (
     parts?: Record<string, string>
   } = {}
 ): ServicePromptDetail => {
-  const defaults = definition.id === "media.video.summarization"
+  const defaults = definition.id === "media.web.summarization"
+    ? { system: "Web system guidance.", user: "Web summary guidance." }
+    : definition.id === "media.video.summarization"
     ? { system: "Video system guidance.", final_summary: "Combine video summaries." }
     : definition.id === "media.audio.analysis"
     ? { system: "Audio system guidance.", user: "Audio user guidance." }
@@ -569,7 +581,7 @@ describe("ServicePromptsSettings", () => {
     renderSettings()
 
     expect(await screen.findAllByTestId("service-prompt-list-item"))
-      .toHaveLength(13)
+      .toHaveLength(14)
     expect(await screen.findByRole("heading", { name: "Text translation" }))
       .toBeInTheDocument()
     expect(screen.getByText("Server default")).toBeInTheDocument()
@@ -629,6 +641,23 @@ describe("ServicePromptsSettings", () => {
     expect(screen.getByText("Synchronous PDF analysis")).toBeVisible()
     expect(screen.getAllByText(/Without a saved override, server defaults apply/)[0]).toBeVisible()
     expect(screen.queryByText("Server PDF prompt")).not.toBeInTheDocument()
+  })
+
+  it("edits web system and summary instructions as one pair", async () => {
+    renderSettings()
+    await openPrompt("Web article summarization")
+    expect(screen.getByLabelText("System instructions")).toHaveValue("Web system guidance.")
+    expect(screen.getByLabelText("User instructions")).toHaveValue("Web summary guidance.")
+    expect(screen.getByText("Synchronous web scraping")).toBeVisible()
+    expect(screen.getByText(/Reset restores each scraping engine/, { selector: "p" })).toBeVisible()
+    fireEvent.change(screen.getByLabelText("System instructions"), { target: { value: "Web {system}" } })
+    fireEvent.change(screen.getByLabelText("User instructions"), { target: { value: "Web {summary}" } })
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }))
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledWith(
+      "media.web.summarization",
+      { parts: { system: "Web {system}", user: "Web {summary}" }, expected_revision: null },
+      { signal: expect.any(AbortSignal), requestScope: scopeOne }
+    ))
   })
 
   it("edits video system and final-summary instructions as one pair", async () => {

--- a/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
+++ b/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
@@ -16,6 +16,7 @@ export type KnownServicePromptId =
   | "media.email.summarization"
   | "media.audio.analysis"
   | "media.video.summarization"
+  | "media.web.summarization"
   | "media.text.translation"
   | "notes.title.generate"
 

--- a/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
+++ b/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
@@ -40,6 +40,10 @@
       "system": "You are an expert translator. Your task is to provide accurate,\nnatural-sounding translations that preserve the original meaning, tone, and formatting.\nDo not add explanations or notes - only provide the translation.",
       "user_template": "Translate the following text to {target_language}.\nPreserve the original formatting, meaning, and tone.\nOnly output the translation, no explanations, notes, or additional text.\n\nText to translate:\n{text}"
     },
+    "media.web.summarization": {
+      "system": "You are a professional summarizer who produces accurate, concise summaries of web content.",
+      "user": "Summarize this article concisely. Focus on the main points, facts, and any actionable insights."
+    },
     "notes.title.generate": {
       "system": "You are a helpful assistant that writes concise document titles.",
       "title_instruction": "Write a descriptive title"

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose synchronous web article summarization in Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-05 22:49'
-updated_date: '2026-09-05 23:41'
+updated_date: '2026-09-06 00:05'
 labels: []
 dependencies: []
 references:
@@ -53,6 +53,8 @@ Published implementation commit d328765206 on codex/web-summary-service-prompt. 
 Qodo review posted: zero bugs and three rule findings. Verified two documentation gaps (legacy test helper docstring; resolver module/parameter/return/cleanup contract). Addressing those without behavior changes. Third finding repeats the documented broader-suite limitation explicitly approved by requester; will reply with evidence and preserve the limitation rather than claim a full green suite.
 
 Qodo documentation fixes verified: 35 web-summary integration tests passed; Ruff and format checks passed; touched resolver Bandit reported zero findings. Only docstrings and tracking notes changed. Replied to the broader-suite finding with the existing requester-approved limitation and evidence; required CI remains enforced.
+
+Rebased cleanly onto newly advanced dev 946e591ee9 (pixel-migu addition). git range-diff confirms all three existing PR patches are unchanged by the rebase. Rebased verification: 129 focused integration/registry/API/strict-contract tests passed; Bandit across all seven touched runtime files found zero issues. Qodo had cleared all findings on the pre-rebase head; publishing the rebased head for current-head review and CI.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -4,9 +4,11 @@ title: Expose synchronous web article summarization in Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-05 22:49'
-updated_date: '2026-09-05 23:28'
+updated_date: '2026-09-05 23:29'
 labels: []
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2907'
 ---
 
 ## Description
@@ -45,6 +47,8 @@ Stopped only this task’s broad pytest run after confirming host resource failu
 Correction after full failure-log inspection: the broad run’s non-semaphore failure was NOT the already-fixed forwarding test. It was unchanged test_phase3_preflight_characterization.py::test_analyzer_and_public_entry_point_signatures_match_current_inventory, whose expected PEP 604 union spelling differs from Python 3.11 inspect output using typing.Optional. Canonical article source and inventory test are unchanged; enhanced scrape_article argument/return AST is byte-for-byte equivalent structurally to base. The other 10 failures are SemLock OSError(28). Fresh strict-forwarding test remains green. Work is staged, not committed; awaiting direction on proceeding with these unrelated verification limitations.
 
 User explicitly approved committing and opening a PR with the documented broader-test limitations. Proceeding to publish against dev; no merge requested in this step.
+
+Published implementation commit d328765206 on codex/web-summary-service-prompt. PR #2907 opened against dev: https://github.com/rmusser01/tldw_server/pull/2907. Verification limitations are explicit in the PR body. Task remains In Progress pending PR review and integration.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose synchronous web article summarization in Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-05 22:49'
-updated_date: '2026-09-06 00:05'
+updated_date: '2026-09-06 00:40'
 labels: []
 dependencies: []
 references:
@@ -55,6 +55,8 @@ Qodo review posted: zero bugs and three rule findings. Verified two documentatio
 Qodo documentation fixes verified: 35 web-summary integration tests passed; Ruff and format checks passed; touched resolver Bandit reported zero findings. Only docstrings and tracking notes changed. Replied to the broader-suite finding with the existing requester-approved limitation and evidence; required CI remains enforced.
 
 Rebased cleanly onto newly advanced dev 946e591ee9 (pixel-migu addition). git range-diff confirms all three existing PR patches are unchanged by the rebase. Rebased verification: 129 focused integration/registry/API/strict-contract tests passed; Bandit across all seven touched runtime files found zero issues. Qodo had cleared all findings on the pre-rebase head; publishing the rebased head for current-head review and CI.
+
+Final merge audit: PR head 9700edeffd on dev 946e591ee9; all seven required CI gates pass; Qodo reports zero bugs and zero rule violations; all review threads are resolved. Remaining repository-local merge gate: the required human-written Change summary is absent from the PR. Existing descriptions were agent/bot-authored. Awaiting requester text explaining what changed and why. This tracking-only note is retained locally without pushing another CI-triggering commit; heartbeat will be deleted while waiting for user input.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose synchronous web article summarization in Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-05 22:49'
-updated_date: '2026-09-05 23:29'
+updated_date: '2026-09-05 23:41'
 labels: []
 dependencies: []
 references:
@@ -49,6 +49,10 @@ Correction after full failure-log inspection: the broad run’s non-semaphore fa
 User explicitly approved committing and opening a PR with the documented broader-test limitations. Proceeding to publish against dev; no merge requested in this step.
 
 Published implementation commit d328765206 on codex/web-summary-service-prompt. PR #2907 opened against dev: https://github.com/rmusser01/tldw_server/pull/2907. Verification limitations are explicit in the PR body. Task remains In Progress pending PR review and integration.
+
+Qodo review posted: zero bugs and three rule findings. Verified two documentation gaps (legacy test helper docstring; resolver module/parameter/return/cleanup contract). Addressing those without behavior changes. Third finding repeats the documented broader-suite limitation explicitly approved by requester; will reply with evidence and preserve the limitation rather than claim a full green suite.
+
+Qodo documentation fixes verified: 35 web-summary integration tests passed; Ruff and format checks passed; touched resolver Bandit reported zero findings. Only docstrings and tracking notes changed. Replied to the broader-suite finding with the existing requester-approved limitation and evidence; required CI remains enforced.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose synchronous web article summarization in Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-05 22:49'
-updated_date: '2026-09-06 00:40'
+updated_date: '2026-09-06 00:47'
 labels: []
 dependencies: []
 references:
@@ -57,6 +57,10 @@ Qodo documentation fixes verified: 35 web-summary integration tests passed; Ruff
 Rebased cleanly onto newly advanced dev 946e591ee9 (pixel-migu addition). git range-diff confirms all three existing PR patches are unchanged by the rebase. Rebased verification: 129 focused integration/registry/API/strict-contract tests passed; Bandit across all seven touched runtime files found zero issues. Qodo had cleared all findings on the pre-rebase head; publishing the rebased head for current-head review and CI.
 
 Final merge audit: PR head 9700edeffd on dev 946e591ee9; all seven required CI gates pass; Qodo reports zero bugs and zero rule violations; all review threads are resolved. Remaining repository-local merge gate: the required human-written Change summary is absent from the PR. Existing descriptions were agent/bot-authored. Awaiting requester text explaining what changed and why. This tracking-only note is retained locally without pushing another CI-triggering commit; heartbeat will be deleted while waiting for user input.
+
+Requester explicitly waived the human-written Change summary requirement for PR #2907 and authorized merge. The approval layer accepted this waiver, but GitHub blocked the normal merge because dev advanced to 36b846628d (admin first-steps PR). Rebasing again and retaining required-check enforcement; the earlier human-summary blocker is superseded by this explicit waiver.
+
+Second rebase onto dev 36b846628d verified: 129 focused tests passed and Bandit on all seven touched runtime files found zero issues. Existing PR patches are unchanged by the rebase; only local tracking records of merge-gate status and explicit waiver are newly included. Publishing with an exact-head lease and enabling normal GitHub auto-merge subject to required checks.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
+++ b/backlog/tasks/task-13195 - Expose-synchronous-web-article-summarization-in-Service-Prompts.md
@@ -1,0 +1,64 @@
+---
+id: TASK-13195
+title: Expose synchronous web article summarization in Service Prompts
+status: In Progress
+assignee: []
+created_date: '2026-09-05 22:49'
+updated_date: '2026-09-05 23:28'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Approved bounded slice: add system and summary instructions to existing shared Service Prompts Settings for /media/process-web-scraping. Resolve one authenticated owner configuration per request, preserve explicit prompts and engine-specific defaults, disabled-analysis and persistence behavior, fix individual-URL system-prompt forwarding, and leave scheduled workflows and /ingest-web-content unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Shared WebUI and extension edit and reset web system and summary instructions using existing storage
+- [x] #2 One owner-specific prompt configuration is reused across pages with independent explicit-part precedence
+- [x] #3 Engine-specific defaults, inactive analysis and persistence behavior remain compatible; individual URL system prompt reaches the model
+- [x] #4 Focused backend and UI regressions, Bandit and independent review pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Record scope and baseline. 2. Add failing model-facing tests for request scope and forwarding; implement minimal core integration. 3. Add registry and shared Settings metadata and tests. 4. Verify defaults, scope isolation, fallback paths, security and API contract; review and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented owner-bound web summary overrides, registry and shared Settings metadata. RED tests caught missing prompt lookup, unnecessary default-file loading, and persistence owner mismatch; fixed all three. Independent review found an outdated strict fallback helper contract test; updating signature and forwarding assertions without weakening it. Shared Settings 76 passed; prompt client/domain 124 passed. Bandit on all seven touched runtime files: zero findings. Broader scraping regression and API validation in progress.
+
+Compatibility consumers: 92 passed (usage events, custom headers, permission claims, media patchpoints, workflow adapters). Strict fallback signature/forwarding regression: 4 passed after review fix. Settings: 76 passed in shared config and 76 passed in WebUI config. OpenAPI export and TypeScript generation succeeded; fingerprint unchanged and check passed. Python compileall passed. Ruff has only two verified pre-existing findings (endpoint B004 and enhanced scraper UP015); new helper/tests clean.
+
+Design: Docs/Design/web-summary-service-prompt.md. Final focused backend run: 125 passed (35 owner/model-facing web integration cases plus 90 registry/API cases). Independent review: no production correctness or over-engineering findings; sole strict-signature test finding fixed and verified. Temporary dependency symlinks removed; existing dependency trees untouched. Broad 2,414-case scraping run still in progress.
+
+Broad regression discovered host-level multiprocessing semaphore exhaustion: fixture-generator tests fail creating multiprocessing.Event with OSError(28), before application code. Reproduced with standalone stdlib-only Python probe both inside and outside sandbox. Disk has 293 GiB free. No host limits changed and no unrelated processes killed. Full broad verification cannot be considered green; implementation remains staged/uncommitted pending this verification limitation.
+
+Stopped only this task’s broad pytest run after confirming host resource failure: 1,224 passed, 2 skipped, 11 failed at interruption. One failure was the strict signature test collected before its fix (fresh rerun 4 passed); remaining failures are being classified from the final trace. No feature commit or PR created.
+
+Correction after full failure-log inspection: the broad run’s non-semaphore failure was NOT the already-fixed forwarding test. It was unchanged test_phase3_preflight_characterization.py::test_analyzer_and_public_entry_point_signatures_match_current_inventory, whose expected PEP 604 union spelling differs from Python 3.11 inspect output using typing.Optional. Canonical article source and inventory test are unchanged; enhanced scrape_article argument/return AST is byte-for-byte equivalent structurally to base. The other 10 failures are SemLock OSError(28). Fresh strict-forwarding test remains green. Work is staged, not committed; awaiting direction on proceeding with these unrelated verification limitations.
+
+User explicitly approved committing and opening a PR with the documented broader-test limitations. Proceeding to publish against dev; no merge requested in this step.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added user-editable web article system and summary instructions through existing Service Prompts storage and shared Settings, scoped to synchronous web scraping. One immutable owner snapshot preserves explicit overrides and engine defaults across pages; persistence uses the same authenticated owner. Added model-facing, API, Settings and compatibility coverage. Focused tests and Bandit pass; broader suite limitations are documented and requester approved PR publication with them.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -5,9 +5,10 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import (
@@ -17,8 +18,10 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
 )
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.schemas.media_request_models import WebScrapingRequest
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
+from tldw_Server_API.app.core.Web_Scraping.summary_prompts import resolve_web_summary_overrides
 from tldw_Server_API.app.services.web_scraping_service import process_web_scraping_task
 
 router = APIRouter()
@@ -56,7 +59,9 @@ def _resolve_process_web_scraping_task() -> WebScrapingTask:
 )
 async def process_web_scraping_endpoint(
     payload: WebScrapingRequest,
+    request: Request,
     db: Any = Depends(get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
     usage_log: UsageEventLogger = Depends(get_usage_event_logger),
 ):
     """
@@ -81,6 +86,9 @@ async def process_web_scraping_endpoint(
             )
 
         task = _resolve_process_web_scraping_task()
+        summary_prompt_overrides = await resolve_web_summary_overrides(
+            payload, lambda: get_prompts_db_for_user(request, current_user)
+        )
 
         result = await task(
             scrape_method=payload.scrape_method,
@@ -95,14 +103,11 @@ async def process_web_scraping_endpoint(
             keywords=payload.keywords or "",
             custom_titles=payload.custom_titles,
             system_prompt=payload.system_prompt,
+            summary_prompt_overrides=summary_prompt_overrides,
             temperature=payload.temperature,
             custom_cookies=payload.custom_cookies,
             mode=payload.mode,
-            user_id=(
-                getattr(getattr(db, "user", None), "id", None)
-                if db is not None
-                else None
-            ),
+            user_id=current_user.id,
             user_agent=payload.user_agent,
             custom_headers=payload.custom_headers,
             crawl_strategy=payload.crawl_strategy,

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -360,6 +360,20 @@ _DEFINITION_SEQUENCE = (
         affected_workflows=(ServicePromptWorkflow(id="media.video.summarization", label="Synchronous video analysis"),),
     ),
     ServicePromptDefinition(
+        id="media.web.summarization",
+        label="Web article summarization",
+        description="Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+        parts=(
+            ServicePromptPart(key="system", label="System instructions", mode="literal", required_variables=()),
+            ServicePromptPart(key="user", label="User instructions", mode="literal", required_variables=()),
+        ),
+        default_parts=MappingProxyType({
+            "system": "You are a professional summarizer who produces accurate, concise summaries of web content.",
+            "user": "Summarize this article concisely. Focus on the main points, facts, and any actionable insights.",
+        }),
+        affected_workflows=(ServicePromptWorkflow(id="media.web.summarization", label="Synchronous web scraping"),),
+    ),
+    ServicePromptDefinition(
         id="media.text.translation",
         label="Text translation",
         description="Controls the visible instructions used by synchronous text translation.",
@@ -599,6 +613,13 @@ def resolve_service_prompt_default(definition: ServicePromptDefinition) -> Resol
         from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import _resolve_default_system_prompt
 
         parts = MappingProxyType({**definition.default_parts, "system": _resolve_default_system_prompt()})
+    elif definition.id == "media.web.summarization":
+        from tldw_Server_API.app.core.Utils.prompt_loader import load_prompt
+
+        parts = MappingProxyType({
+            "system": load_prompt("webscraping", "article_summary_system") or "You are a professional summarizer.",
+            "user": load_prompt("webscraping", "article_summary_user") or "Summarize this article concisely.",
+        })
     elif definition.id == "media.audio.analysis":
         from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import _resolve_default_system_prompt
         from tldw_Server_API.app.core.Utils.prompt_loader import load_prompt

--- a/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
@@ -22,6 +22,7 @@ import json
 import os
 import random
 import tempfile
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from datetime import datetime
@@ -360,6 +361,7 @@ async def scrape_and_summarize_multiple(
     custom_cookies: Optional[list[dict[str, Any]]] = None,
     temperature: float = 0.7,
     allow_llm_extraction: bool = True,
+    summary_prompt_overrides: Optional[Mapping[str, str]] = None,
 ) -> list[dict[str, Any]]:
     urls_list = [url.strip() for url in urls.split('\n') if url.strip()]
     custom_titles = custom_article_titles.split('\n') if custom_article_titles else []
@@ -405,6 +407,9 @@ async def scrape_and_summarize_multiple(
                                                "Act as a professional summarizer and summarize this article."
                         article_custom_prompt = custom_prompt_arg or \
                                                 "Act as a professional summarizer and summarize this article."
+                        if summary_prompt_overrides is not None:
+                            system_message_final = summary_prompt_overrides.get("system", system_message_final)
+                            article_custom_prompt = summary_prompt_overrides.get("user", article_custom_prompt)
 
                         # Summarize the content using the summarize function
                         summary = analyze(

--- a/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+++ b/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
@@ -1882,6 +1882,7 @@ class EnhancedWebScraper:
         **kwargs,
     ) -> list[dict[str, Any]]:
         """Scrape multiple URLs concurrently"""
+        summary_prompt_overrides = kwargs.pop("summary_prompt_overrides", None)
         jobs = []
         futures = []
 
@@ -1929,6 +1930,7 @@ class EnhancedWebScraper:
                 if summarize and result.get('extraction_successful') and result.get('content'):
                     summary = await self._summarize_content(
                         result['content'],
+                        summary_prompt_overrides=summary_prompt_overrides,
                         **kwargs
                     )
                     result['summary'] = summary
@@ -1940,13 +1942,17 @@ class EnhancedWebScraper:
     async def _summarize_content(self, content: str, **kwargs) -> str:
         """Summarize content using LLM"""
         try:
+            overrides = kwargs.get('summary_prompt_overrides') or {}
+            system_default = kwargs.get('system_prompt')
+            if system_default is None:
+                system_default = 'Summarize this article concisely.'
             summary = analyze(
                 input_data=content,
-                custom_prompt_arg=kwargs.get('custom_prompt', ''),
+                custom_prompt_arg=overrides.get('user', kwargs.get('custom_prompt', '')),
                 api_name=kwargs.get('api_name', 'openai'),
                 api_key=kwargs.get('api_key'),
                 temp=kwargs.get('temperature', 0.7),
-                system_message=kwargs.get('system_message', 'Summarize this article concisely.')
+                system_message=overrides.get('system', kwargs.get('system_message', system_default))
             )
             return summary
         except _WEBSCRAPE_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
+++ b/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
@@ -1,0 +1,43 @@
+"""Request-bound overrides for synchronous web article summarization."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from tldw_Server_API.app.core.Prompt_Management.service_prompts import resolve_service_prompt
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
+
+
+async def resolve_web_summary_overrides(
+    payload: Any, get_prompts_db: Callable[[], Awaitable[PromptsDatabase]]
+) -> Mapping[str, str] | None:
+    """Freeze explicit/saved parts while leaving absent engine defaults untouched.
+
+    Only the synchronous HTTP caller supplies owner-bound storage. No lookup is
+    needed for disabled summarization or a complete pair of explicit parts.
+    """
+    if not payload.summarize_checkbox:
+        return None
+    parts = {
+        key: value
+        for key, value in (("system", payload.system_prompt), ("user", payload.custom_prompt))
+        if value is not None
+    }
+    if len(parts) < 2:
+        database = await get_prompts_db()
+
+        def load_saved() -> dict[str, str]:
+            """Read and close on one worker; packaged defaults remain engine-local."""
+            try:
+                resolved = resolve_service_prompt(database, "media.web.summarization")
+                return dict(resolved.parts) if resolved.source == "user" else {}
+            finally:
+                database.close_connection()
+
+        parts = {**await asyncio.to_thread(load_saved), **parts}
+    return MappingProxyType(parts)

--- a/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
+++ b/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
@@ -1,4 +1,9 @@
-"""Request-bound overrides for synchronous web article summarization."""
+"""Resolve request-bound instructions for synchronous web article summarization.
+
+Read saved prompts from caller-supplied owner storage and close the lookup
+connection on its worker, including failed reads. Engine defaults stay local to
+the scraping consumers rather than becoming request overrides.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +25,21 @@ async def resolve_web_summary_overrides(
 
     Only the synchronous HTTP caller supplies owner-bound storage. No lookup is
     needed for disabled summarization or a complete pair of explicit parts.
+
+    Args:
+        payload: Request carrying summarize_checkbox, system_prompt, and
+            custom_prompt. None means an absent part; an empty string is explicit.
+        get_prompts_db: Async factory bound to the authenticated request owner.
+            Its database is read and its worker connection closed in one worker.
+
+    Returns:
+        None when summarization is disabled; otherwise an immutable mapping of
+        saved and explicit system/user parts, with explicit parts taking priority.
+        Missing keys leave the corresponding scraping engine default untouched.
+
+    Raises:
+        ServicePromptCorruptOverride: Saved instructions fail validation.
+        Exception: Database acquisition, lookup, or cleanup errors propagate.
     """
     if not payload.summarize_checkbox:
         return None

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import time
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -159,6 +160,7 @@ class WebScrapingService:
         chunking_mode: Optional[str] = None,
         auto_chunking_goal: str = "balanced",
         auto_chunking_use_llm: bool = False,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """
         Process web scraping task with enhanced features.
@@ -268,6 +270,7 @@ class WebScrapingService:
                     user_agent,
                     custom_headers,
                     user_id=user_id,
+                    summary_prompt_overrides=summary_prompt_overrides,
                 )
 
             elif scrape_method == "Sitemap":
@@ -287,6 +290,7 @@ class WebScrapingService:
                     custom_headers,
                     user_id=user_id,
                     task_id=task_id,
+                    summary_prompt_overrides=summary_prompt_overrides,
                 )
 
             elif scrape_method == "URL Level":
@@ -312,6 +316,7 @@ class WebScrapingService:
                     score_threshold=eff_score_threshold,
                     crawl_strategy=eff_strategy,
                     task_id=task_id,
+                    summary_prompt_overrides=summary_prompt_overrides,
                 )
 
             elif scrape_method == "Recursive Scraping":
@@ -335,6 +340,7 @@ class WebScrapingService:
                     score_threshold=eff_score_threshold,
                     crawl_strategy=eff_strategy,
                     task_id=task_id,
+                    summary_prompt_overrides=summary_prompt_overrides,
                 )
 
             else:
@@ -399,6 +405,7 @@ class WebScrapingService:
         custom_headers: Optional[dict[str, str]],
         *,
         user_id: Optional[int] = None,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Scrape individual URLs with enhanced features"""
         # Parse URLs and titles
@@ -424,6 +431,7 @@ class WebScrapingService:
             api_name=api_name,
             api_key=api_key,
             system_prompt=system_prompt,
+            summary_prompt_overrides=summary_prompt_overrides,
             temperature=temperature,
             custom_cookies=custom_cookies,
             user_agent=user_agent,
@@ -465,6 +473,7 @@ class WebScrapingService:
         *,
         user_id: Optional[int] = None,
         task_id: Optional[str] = None,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Scrape from sitemap with filtering"""
         # Check if scraper is available
@@ -490,7 +499,8 @@ class WebScrapingService:
             for result in results:
                 if result.get("extraction_successful") and result.get("content"):
                     summary = await self._summarize_content(
-                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
+                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature,
+                        summary_prompt_overrides=summary_prompt_overrides,
                     )
                     result["summary"] = summary
 
@@ -524,6 +534,7 @@ class WebScrapingService:
         score_threshold: Optional[float] = None,
         crawl_strategy: Optional[str] = None,
         task_id: Optional[str] = None,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Scrape by URL level"""
 
@@ -556,7 +567,8 @@ class WebScrapingService:
             for result in results:
                 if result.get("extraction_successful") and result.get("content"):
                     summary = await self._summarize_content(
-                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
+                        result["content"], custom_prompt, api_name, api_key, system_prompt, temperature,
+                        summary_prompt_overrides=summary_prompt_overrides,
                     )
                     result["summary"] = summary
 
@@ -590,6 +602,7 @@ class WebScrapingService:
         score_threshold: Optional[float] = None,
         crawl_strategy: Optional[str] = None,
         task_id: Optional[str] = None,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Recursive scraping with progress tracking"""
         # Create progress file for resumability
@@ -619,7 +632,8 @@ class WebScrapingService:
                 for result in results:
                     if result.get("extraction_successful") and result.get("content"):
                         summary = await self._summarize_content(
-                            result["content"], custom_prompt, api_name, api_key, system_prompt, temperature
+                            result["content"], custom_prompt, api_name, api_key, system_prompt, temperature,
+                            summary_prompt_overrides=summary_prompt_overrides,
                         )
                         result["summary"] = summary
 
@@ -648,18 +662,19 @@ class WebScrapingService:
         api_key: Optional[str],
         system_prompt: Optional[str],
         temperature: float,
+        *,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> str:
         """Summarize content using LLM"""
         try:
             # Provide default prompts from Prompts/webscraping if not supplied
-            custom_prompt = (
-                custom_prompt
-                or load_prompt("webscraping", "article_summary_user")
+            overrides = summary_prompt_overrides or {}
+            custom_prompt = overrides["user"] if "user" in overrides else (
+                custom_prompt or load_prompt("webscraping", "article_summary_user")
                 or "Summarize this article concisely."
             )
-            system_prompt = (
-                system_prompt
-                or load_prompt("webscraping", "article_summary_system")
+            system_prompt = overrides["system"] if "system" in overrides else (
+                system_prompt or load_prompt("webscraping", "article_summary_system")
                 or "You are a professional summarizer."
             )
             summary = analyze(

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 import json
 import logging
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, Optional
 
@@ -242,6 +243,7 @@ async def process_web_scraping_task(
     chunking_mode: Optional[str] = None,
     auto_chunking_goal: str = "balanced",
     auto_chunking_use_llm: bool = False,
+    summary_prompt_overrides: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """
     Enhanced web scraping with production features:
@@ -337,6 +339,7 @@ async def process_web_scraping_task(
             keywords=keywords,
             custom_titles=custom_titles,
             system_prompt=system_prompt,
+            summary_prompt_overrides=summary_prompt_overrides,
             temperature=temperature,
             custom_cookies=custom_cookies,
             mode=mode,
@@ -412,6 +415,7 @@ async def process_web_scraping_task(
                     custom_cookies=custom_cookies,
                     temperature=temperature,
                     allow_llm_extraction=summarize_checkbox,
+                    summary_prompt_overrides=summary_prompt_overrides,
                 )
             elif scrape_method == "Sitemap":
                 # Synchronous approach in your code, might need `asyncio.to_thread`
@@ -495,11 +499,11 @@ async def process_web_scraping_task(
                         else:
                             summary = analyze(
                                 input_data=content,
-                                custom_prompt_arg=custom_prompt or "",
+                                custom_prompt_arg=(summary_prompt_overrides or {}).get("user", custom_prompt or ""),
                                 api_name=api_name,
                                 api_key=api_key,
                                 temp=temperature,
-                                system_message=system_prompt or "",
+                                system_message=(summary_prompt_overrides or {}).get("system", system_prompt or ""),
                             )
                             if not _sanitize_analysis_result(article, "summary", summary):
                                 article["summary"] = summary

--- a/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
+++ b/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
@@ -1,0 +1,402 @@
+"""Owner web-summary instructions through real HTTP, storage and model assembly."""
+
+import asyncio
+import json
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
+from tldw_Server_API.app.core.LLM_Calls import Summarization_General_Lib as summary
+from tldw_Server_API.app.core.LLM_Calls.providers.openai_adapter import OpenAIAdapter
+from tldw_Server_API.app.core.Utils import prompt_loader
+from tldw_Server_API.app.core.Web_Scraping import Article_Extractor_Lib as legacy
+from tldw_Server_API.app.core.Web_Scraping import enhanced_web_scraping as scraper_mod
+from tldw_Server_API.app.services import enhanced_web_scraping_service as enhanced
+from tldw_Server_API.app.services import web_scraping_service as service
+from tldw_Server_API.app.services.ephemeral_store import ephemeral_storage
+
+pytestmark = pytest.mark.integration
+PROMPT_ID = "media.web.summarization"
+METHODS = ["Individual URLs", "Sitemap", "URL Level", "Recursive Scraping"]
+
+
+def article(url: str = "https://example.com/a") -> dict[str, Any]:
+    """Return an extracted page without contacting its origin."""
+    return {
+        "url": url,
+        "title": "A report",
+        "content": "Article facts.",
+        "author": "Writer",
+        "extraction_successful": True,
+    }
+
+
+@pytest.fixture
+def context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client_with_single_user: tuple[TestClient, object]
+) -> Iterator[SimpleNamespace]:
+    """Keep orchestration and summarization real; substitute external fetch/model operations."""
+    client, _ = client_with_single_user
+    state = SimpleNamespace(
+        client=client,
+        owner=1,
+        calls=[],
+        reads=[],
+        fetches=[],
+        metadata=[],
+        databases={owner: PromptsDatabase(tmp_path / f"{owner}.sqlite", "web-test") for owner in (1, 2)},
+    )
+
+    async def user() -> User:
+        """Capture the authenticated identity for each request."""
+        return User(id=state.owner, username=f"owner-{state.owner}")
+
+    async def database(request: Request, owner: User) -> PromptsDatabase:
+        """Provide real per-owner storage and record acquisition."""
+        state.reads.append(owner.id)
+        return state.databases[owner.id]
+
+    async def queue(job: Any) -> asyncio.Future:
+        """Complete the external fetch job with an extracted page."""
+        state.fetches.append(job.url)
+        state.metadata.append(json.loads(json.dumps(job.metadata)))
+        future = asyncio.get_running_loop().create_future()
+        future.set_result(article(job.url))
+        return future
+
+    async def pages(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        """Replace remote discovery and extraction for crawl methods."""
+        state.fetches.append(args[0] if args else kwargs["base_url"])
+        return [article(), article("https://example.com/b")]
+
+    async def page(url: str, **kwargs: Any) -> dict[str, Any]:
+        """Replace the legacy external article fetch."""
+        state.fetches.append(url)
+        return article(url)
+
+    async def progress(*args: Any, **kwargs: Any) -> None:
+        """Avoid creating a crawl progress artifact for fake network work."""
+
+    def model(self: OpenAIAdapter, request: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+        """Return model output through the public adapter contract."""
+        state.calls.append(request)
+        return {"choices": [{"message": {"role": "assistant", "content": "Summary result."}, "finish_reason": "stop"}]}
+
+    monkeypatch.setitem(client.app.dependency_overrides, get_request_user, user)
+    monkeypatch.setattr(endpoint, "get_prompts_db_for_user", database, raising=False)
+    monkeypatch.setattr(scraper_mod, "get_database_dir", lambda: str(tmp_path))
+    state.scraper = scraper_mod.EnhancedWebScraper({})
+    monkeypatch.setattr(state.scraper.job_queue, "add_job", queue)
+    monkeypatch.setattr(state.scraper, "scrape_sitemap", pages)
+    monkeypatch.setattr(state.scraper, "recursive_scrape", pages)
+    monkeypatch.setattr(state.scraper, "save_progress", progress)
+    state.service = enhanced.WebScrapingService()
+    state.service.scraper = state.scraper
+    state.service._initialized = True
+    monkeypatch.setattr(service, "get_web_scraping_service", lambda: state.service)
+    monkeypatch.setattr(legacy, "scrape_article", page)
+    monkeypatch.setattr(
+        service, "scrape_from_sitemap", lambda *args, **kwargs: [article(), article("https://example.com/b")]
+    )
+    monkeypatch.setattr(
+        service, "scrape_by_url_level", lambda *args, **kwargs: [article(), article("https://example.com/b")]
+    )
+    monkeypatch.setattr(service, "recursive_scrape", pages)
+    monkeypatch.setattr(summary, "loaded_config_data", {"openai_api": {"model": "test-model"}})
+    monkeypatch.setattr(
+        prompt_loader, "_prompts_dir", lambda: str(Path(__file__).resolve().parents[2] / "Config_Files" / "Prompts")
+    )
+    monkeypatch.setattr(prompt_loader, "get_global_context_integrity_resolver", lambda: None)
+    monkeypatch.setattr(OpenAIAdapter, "chat", model)
+    yield state
+    for database in state.databases.values():
+        database.close_connection()
+
+
+def save(context: SimpleNamespace, owner: int = 1) -> Any:
+    """Save the atomic pair in real owner storage."""
+    return context.databases[owner].save_service_prompt_override(
+        PROMPT_ID, {"system": f"Owner {owner} system {{literal}}", "user": f"Owner {owner} summary {{literal}}"}, None
+    )
+
+
+def process(context: SimpleNamespace, method: str = "Individual URLs", **options: Any) -> dict[str, Any]:
+    """Exercise the authenticated synchronous JSON endpoint."""
+    response = context.client.post(
+        "/api/v1/media/process-web-scraping",
+        json={
+            "scrape_method": method,
+            "url_input": "https://example.com/a\nhttps://example.com/b"
+            if method == "Individual URLs"
+            else "https://example.com",
+            "url_level": 1,
+            "max_pages": 2,
+            "summarize_checkbox": True,
+            "api_name": "openai",
+            "mode": "ephemeral",
+            "perform_chunking": False,
+            **options,
+        },
+    )
+    assert response.status_code == 200, response.text
+    result = response.json()
+    if "ephemeral_id" in result:
+        return ephemeral_storage.get_data(result["ephemeral_id"])["result"]
+    return {"articles": result["results"]}
+
+
+@pytest.mark.parametrize("method", METHODS)
+@pytest.mark.parametrize("fallback", [False, True])
+def test_saved_pair_reaches_all_pages(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, method: str, fallback: bool
+) -> None:
+    """Every supported engine/method must consume both owner instructions."""
+    save(context)
+    if fallback:
+
+        def unavailable() -> None:
+            """Select the existing compatibility engine."""
+            raise RuntimeError("enhanced unavailable")
+
+        monkeypatch.setattr(service, "get_web_scraping_service", unavailable)
+        monkeypatch.setenv("TLDW_ENABLE_LEGACY_WEB_SCRAPING_FALLBACK", "1")
+    result = process(context, method)
+    assert [item["summary"] for item in result["articles"]] == ["Summary result."] * 2
+    assert len(context.calls) == 2
+    assert {call["system_message"] for call in context.calls} == {"Owner 1 system {literal}"}
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts.\n\n\n\nOwner 1 summary {literal}"
+    }
+    assert all("summary_prompt_overrides" not in metadata for metadata in context.metadata)
+
+
+@pytest.mark.parametrize("method", ["Individual URLs", "Sitemap"])
+@pytest.mark.parametrize("part", ["system_prompt", "custom_prompt"])
+@pytest.mark.parametrize("value", ["Explicit {literal}", ""])
+def test_explicit_parts_win_independently(context: SimpleNamespace, method: str, part: str, value: str) -> None:
+    """Explicit empty and literal instructions must not be replaced by saved parts."""
+    save(context)
+    process(context, method, **{part: value})
+    assert {call["system_message"] for call in context.calls} == {
+        value if part == "system_prompt" else "Owner 1 system {literal}"
+    }
+    suffix = value if part == "custom_prompt" else "Owner 1 summary {literal}"
+    expected = "Article facts." + ("\n\n\n\n" + suffix if suffix else "")
+    assert {call["messages"][0]["content"] for call in context.calls} == {expected}
+
+
+@pytest.mark.parametrize("options", [{"summarize_checkbox": False}, {"system_prompt": "", "custom_prompt": ""}])
+def test_irrelevant_corrupt_storage_is_not_read(context: SimpleNamespace, options: dict[str, Any]) -> None:
+    """Disabled analysis or fully explicit parts must bypass saved storage."""
+    context.databases[1].save_service_prompt_override(PROMPT_ID, {"bad": "corrupt"}, None)
+    process(context, **options)
+    assert context.reads == []
+    if options.get("summarize_checkbox") is False:
+        assert context.calls == []
+
+
+def test_owner_isolation(context: SimpleNamespace) -> None:
+    """The request identity, not a database wrapper attribute, selects saved prompts."""
+    save(context, 1)
+    save(context, 2)
+    context.owner = 2
+    process(context)
+    assert context.reads == [2]
+    assert {call["system_message"] for call in context.calls} == {"Owner 2 system {literal}"}
+
+
+def test_snapshot_survives_mid_request_edit(context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All pages use the revision captured before the first fetch."""
+    row = save(context)
+    original = context.scraper.job_queue.add_job
+
+    async def edit(job: Any) -> asyncio.Future:
+        """Edit settings while external scraping is in progress."""
+        if not context.fetches:
+            db = context.databases[1]
+            try:
+                db.save_service_prompt_override(PROMPT_ID, {"system": "Future", "user": "Future"}, row.revision)
+            finally:
+                db.close_connection()
+            context.owner = 2
+        return await original(job)
+
+    monkeypatch.setattr(context.scraper.job_queue, "add_job", edit)
+    process(context)
+    assert context.reads == [1]
+    assert {call["system_message"] for call in context.calls} == {"Owner 1 system {literal}"}
+
+
+@pytest.mark.parametrize("corrupt", [False, True])
+def test_lookup_connection_closes_on_worker(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, corrupt: bool
+) -> None:
+    """Prompt storage cleanup runs on its read thread even when validation fails."""
+    database = context.databases[1]
+    if corrupt:
+        database.save_service_prompt_override(PROMPT_ID, {"bad": "corrupt"}, None)
+    else:
+        save(context)
+    reads, closes = [], []
+    read, close = database.get_service_prompt_override, database.close_connection
+
+    def track_read(definition_id: str) -> Any:
+        """Record the worker performing a real database lookup."""
+        reads.append(threading.get_ident())
+        return read(definition_id)
+
+    def track_close() -> None:
+        """Record cleanup after closing the actual connection."""
+        close()
+        closes.append(threading.get_ident())
+
+    monkeypatch.setattr(database, "get_service_prompt_override", track_read)
+    monkeypatch.setattr(database, "close_connection", track_close)
+    if corrupt:
+        response = context.client.post(
+            "/api/v1/media/process-web-scraping",
+            json={
+                "scrape_method": "Individual URLs",
+                "url_input": "https://example.com",
+                "summarize_checkbox": True,
+                "api_name": "openai",
+            },
+        )
+        assert response.status_code >= 400
+        assert context.fetches == []
+    else:
+        process(context)
+    assert len(reads) == 1
+    assert closes == reads
+
+
+@pytest.mark.parametrize("method", METHODS)
+def test_reset_restores_engine_defaults(context: SimpleNamespace, method: str) -> None:
+    """Saving and resetting must not unify the engines' different no-override prompts."""
+    row = save(context)
+    context.databases[1].reset_service_prompt_override(PROMPT_ID, row.revision)
+    process(context, method)
+    if method == "Individual URLs":
+        assert {call["system_message"] for call in context.calls} == {"Summarize this article concisely."}
+        assert {call["messages"][0]["content"] for call in context.calls} == {"Article facts."}
+    else:
+        assert {call["system_message"] for call in context.calls} == {
+            "You are a professional summarizer who produces accurate, concise summaries of web content."
+        }
+        assert {call["messages"][0]["content"] for call in context.calls} == {
+            "Article facts.\n\n\n\nSummarize this article concisely. Focus on the main points, facts, and any actionable insights."
+        }
+
+
+def test_saved_pair_does_not_load_unused_deployment_defaults(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A valid saved pair must not depend on loading fallback prompt files."""
+    save(context)
+
+    def unavailable(*args: Any, **kwargs: Any) -> str:
+        """Fail only when the unused fallback source is accessed."""
+        raise ValueError("deployment prompt unavailable")
+
+    monkeypatch.setattr(enhanced, "load_prompt", unavailable)
+    result = process(context, "Sitemap")
+    assert [item["summary"] for item in result["articles"]] == ["Summary result."] * 2
+
+
+@pytest.mark.parametrize("method", METHODS)
+def test_legacy_reset_preserves_existing_defaults(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    """Compatibility-engine defaults remain distinct from deployed crawl prompts."""
+    row = save(context)
+    context.databases[1].reset_service_prompt_override(PROMPT_ID, row.revision)
+
+    def unavailable() -> None:
+        raise RuntimeError("enhanced unavailable")
+
+    monkeypatch.setattr(service, "get_web_scraping_service", unavailable)
+    monkeypatch.setenv("TLDW_ENABLE_LEGACY_WEB_SCRAPING_FALLBACK", "1")
+    process(context, method)
+    expected = "Act as a professional summarizer and summarize this article." if method == "Individual URLs" else ""
+    assert {call["system_message"] for call in context.calls} == {expected}
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts." + ("\n\n\n\n" + expected if expected else "")
+    }
+
+
+def test_missing_deployment_assets_preserves_builtin_defaults(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Existing literal fallbacks still work without deployment prompt assets."""
+    monkeypatch.setattr(prompt_loader, "_prompts_dir", lambda: str(tmp_path))
+    process(context, "Sitemap")
+    assert {call["system_message"] for call in context.calls} == {"You are a professional summarizer."}
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts.\n\n\n\nSummarize this article concisely."
+    }
+
+
+def test_explicit_system_reaches_individual_scraper_without_saved_override(
+    context: SimpleNamespace,
+) -> None:
+    """The HTTP system_prompt name reaches the individual scraper's model call."""
+    process(context, system_prompt="Explicit system")
+    assert {call["system_message"] for call in context.calls} == {"Explicit system"}
+
+
+@pytest.mark.asyncio
+async def test_unscoped_caller_keeps_defaults_without_owner_lookup(context: SimpleNamespace) -> None:
+    """Direct service calls stay outside account-specific prompt resolution."""
+    save(context)
+    await context.service.process_web_scraping_task(
+        scrape_method="Sitemap",
+        url_input="https://example.com",
+        summarize_checkbox=True,
+        api_name="openai",
+        mode="ephemeral",
+        perform_chunking=False,
+    )
+    assert context.reads == []
+    assert {call["system_message"] for call in context.calls} == {
+        "You are a professional summarizer who produces accurate, concise summaries of web content."
+    }
+
+
+def test_persistence_uses_authenticated_prompt_owner(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Saved instructions and persisted media must belong to the same authenticated user."""
+    save(context, 2)
+    context.owner = 2
+    owners = []
+
+    def path(owner: int) -> str:
+        """Route real persistence into a per-owner temporary media database."""
+        owners.append(owner)
+        return str(tmp_path / f"media-{owner}.db")
+
+    monkeypatch.setattr(enhanced, "get_user_media_db_path", path)
+    response = context.client.post(
+        "/api/v1/media/process-web-scraping",
+        json={
+            "scrape_method": "Individual URLs",
+            "url_input": "https://example.com/a",
+            "api_name": "openai",
+            "summarize_checkbox": True,
+            "mode": "persist",
+            "perform_chunking": False,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["stored_articles"] == 1
+    assert owners == [2]
+    assert {call["system_message"] for call in context.calls} == {"Owner 2 system {literal}"}

--- a/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
+++ b/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
@@ -321,6 +321,7 @@ def test_legacy_reset_preserves_existing_defaults(
     context.databases[1].reset_service_prompt_override(PROMPT_ID, row.revision)
 
     def unavailable() -> None:
+        """Force selection of the legacy scraping engine."""
         raise RuntimeError("enhanced unavailable")
 
     monkeypatch.setattr(service, "get_web_scraping_service", unavailable)

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -113,6 +113,12 @@ EXPECTED_REGISTRY = {
         ),
         "workflows": (("media.video.summarization", "Synchronous video analysis"),),
     },
+    "media.web.summarization": {
+        "label": "Web article summarization",
+        "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+        "parts": (("system", "System instructions", "literal", ()), ("user", "User instructions", "literal", ())),
+        "workflows": (("media.web.summarization", "Synchronous web scraping"),),
+    },
     "media.text.translation": {
         "label": "Text translation",
         "description": "Controls the visible instructions used by synchronous text translation.",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -229,6 +229,16 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
             "affected_workflows": [{"id": "media.video.summarization", "label": "Synchronous video analysis"}],
         },
         {
+            "id": "media.web.summarization",
+            "label": "Web article summarization",
+            "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+            "parts": [
+                {"key": "system", "label": "System instructions", "mode": "literal", "required_variables": []},
+                {"key": "user", "label": "User instructions", "mode": "literal", "required_variables": []},
+            ],
+            "affected_workflows": [{"id": "media.web.summarization", "label": "Synchronous web scraping"}],
+        },
+        {
             "id": "media.text.translation",
             "label": "Text translation",
             "description": ("Controls the visible instructions used by synchronous text translation."),
@@ -283,6 +293,32 @@ def test_service_prompt_detail_returns_packaged_state_without_caching(api_contex
     assert body["saved_parts"] is None
     assert body["effective_parts"] == body["default_parts"]
     assert set(body["default_parts"]) == {"system", "user_template"}
+
+
+def test_web_settings_save_pair_atomically_and_reset_deployment_defaults(
+    api_context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Web instructions share atomic updates and expose the deployed article defaults."""
+    from tldw_Server_API.app.core.Utils import prompt_loader
+
+    (tmp_path / "webscraping.prompts.yaml").write_text(
+        "article_summary_system: Deployment system\narticle_summary_user: Deployment summary\n"
+    )
+    monkeypatch.setattr(prompt_loader, "_prompts_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(prompt_loader, "get_global_context_integrity_resolver", lambda: None)
+    path = "/api/v1/service-prompts/media.web.summarization"
+    defaults = {"system": "Deployment system", "user": "Deployment summary"}
+    assert api_context.client.get(path).json()["effective_parts"] == defaults
+    parts = {"system": "System {literal}", "user": "Summary {literal}"}
+    saved = api_context.client.put(path, json={"parts": parts, "expected_revision": None})
+    assert saved.status_code == 200
+    revision = saved.json()["revision"]
+    partial = api_context.client.put(path, json={"parts": {"user": "Incomplete"}, "expected_revision": revision})
+    assert partial.status_code == 422
+    assert api_context.client.get(path).json()["effective_parts"] == parts
+    reset = api_context.client.delete(path, params={"expected_revision": revision})
+    assert reset.status_code == 200
+    assert reset.json()["effective_parts"] == defaults
 
 
 def test_video_settings_save_pair_atomically_and_reset_defaults(

--- a/tldw_Server_API/tests/Web_Scraping/test_phase4_consumer_imports.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_phase4_consumer_imports.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -157,6 +158,7 @@ async def test_legacy_fallback_forwards_system_message_with_real_helper_signatur
         custom_cookies: list[dict[str, Any]] | None = None,
         temperature: float = 0.7,
         allow_llm_extraction: bool = True,
+        summary_prompt_overrides: Mapping[str, str] | None = None,
     ) -> list[dict[str, Any]]:
         received.update(
             {
@@ -171,6 +173,7 @@ async def test_legacy_fallback_forwards_system_message_with_real_helper_signatur
                 "custom_cookies": custom_cookies,
                 "temperature": temperature,
                 "allow_llm_extraction": allow_llm_extraction,
+                "summary_prompt_overrides": summary_prompt_overrides,
             }
         )
         return [
@@ -221,6 +224,7 @@ async def test_legacy_fallback_forwards_system_message_with_real_helper_signatur
         mode="ephemeral",
         user_id=1,
         perform_chunking=False,
+        summary_prompt_overrides={"system": "Saved system", "user": "Saved summary"},
     )
 
     assert result["status"] == "ephemeral-ok"
@@ -236,4 +240,5 @@ async def test_legacy_fallback_forwards_system_message_with_real_helper_signatur
         "custom_cookies": [{"name": "session", "value": "cookie-value"}],
         "temperature": 0.2,
         "allow_llm_extraction": True,
+        "summary_prompt_overrides": {"system": "Saved system", "user": "Saved summary"},
     }


### PR DESCRIPTION
## Summary

- What changed: add `media.web.summarization` to the existing Service Prompts registry and shared WebUI/extension Settings editor, with literal system and user instructions for synchronous `/api/v1/media/process-web-scraping`.
- Why: reuse the current storage and editor instead of creating another configuration system. Capture one immutable authenticated-owner configuration per scrape so all pages use the same instructions, while explicit request parts (including empty strings) retain precedence and reset preserves each scraping engine's existing defaults.
- Carry the snapshot through all four enhanced and legacy scraping methods, close prompt lookup connections on their worker, fix individual-URL system-prompt forwarding, and use the authenticated owner for media persistence.
- Scheduled workflows and `/ingest-web-content` remain outside this slice. Provider configuration, output shape, and disabled-analysis behavior remain unchanged.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] Focused backend checks: **221 passed** (125 feature/registry/API, 92 permission/usage/workflow compatibility, 4 strict fallback contract tests).
- [x] UI checks: **276 passed** (76 shared Settings, 76 WebUI Settings, 124 prompt client/domain tests).
- [x] Independent code review completed; the strict helper-signature test finding was fixed and verified.
- [x] Bandit on all seven touched runtime files: **zero findings**. Python compileall and whitespace checks passed.
- [x] OpenAPI export and TypeScript generation succeeded; the checked-in API fingerprint is unchanged and its check passed.
- [x] Design and Backlog task updated.

### Broader verification limitations

The requester explicitly approved committing and opening this PR with these limitations documented:

- The 2,414-case broad scraping run was stopped after **1,224 passed, 2 skipped, and 11 failed**; it was not a complete green run.
- Ten failures came from host-level multiprocessing semaphore allocation (`SemLock`, `OSError: [Errno 28] No space left on device`). A standalone standard-library-only `multiprocessing.Event()` probe reproduced the failure both inside and outside the sandbox, while disk space remained available. No host limits were changed and no unrelated processes were killed.
- One unchanged signature-inventory test expects PEP 604 union spelling while this Python 3.11 environment renders `typing.Optional`. The canonical article implementation and inventory test are unchanged, and the enhanced public scraper signature AST matches the base revision.
- Ruff reports only two verified pre-existing findings: endpoint B004 and enhanced scraper UP015. New helper and test code pass the focused lint checks.

## UX Audit Checklist

- [x] WebUI/extension parity validated for the shared Settings addition in both test configurations.
- Full browser smoke/all-pages audits were not run; this change adds metadata and reuses the existing editor. No claim is made about live-browser console audits.
- Flashcards and Watchlists checklists are not applicable; neither feature was changed.

## Risk & Rollback

- Risk level: Medium — modifies prompt selection and authenticated ownership at the synchronous scraping boundary; covered by owner isolation, persistence, explicit override, reset, disabled-analysis, and multi-page tests.
- Rollback plan: revert this PR. No new database schema or migration is introduced.

## Tracking

- TASK-13195
- Design: `Docs/Design/web-summary-service-prompt.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-editable system and user instructions for synchronous web article summarization through the existing Service Prompts registry and shared Settings editor, covering TASK-13195.

- Resolved instructions are captured once per request for the authenticated owner, so every page in a scrape uses the same snapshot.
- Explicit system and user parts in the request, including empty strings, take precedence over saved instructions.
- Reset restores each scraping engine's existing defaults instead of unifying them.
- Fixes explicit system prompts not being forwarded for individual-URL scrapes and uses the authenticated owner for media persistence.
- Scheduled workflows and `/ingest-web-content` are unchanged.

<sup>Written for commit b238899b8f9de428a86130bd2a96d04c32f359f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

