### PR TITLE
Fix PostgreSQL CASE placeholders in ordinary Sync ingress

### DIFF
--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -169,6 +169,11 @@ and remote envelopes and has an immutable idempotency key; requests also carry
 the device's activation/continuity proof. A changed candidate requires fresh
 review, not a blind retry with new IDs.
 
+After linking, a client must not push its locally derived manifest. Such ingress
+is invalid, not a user-choice conflict: the server sequences the shared manifest
+from accepted semantic mutations. Initial-link reconciliation and server-issued
+manifest publications remain separate supported paths.
+
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |
 | Keep shared values | `skip` | None |

--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -183,6 +183,11 @@ The losing incoming candidate is accounted for by the resolution receipt rather
 than installed as a duplicate active fact. Clients must construct that explicitly
 reviewed replacement; they must not expect the server to silently rewrite its ID.
 
+The server's internal safety bound is 1,000 active conflicts per profile, not
+1,000 lifetime decisions or a negotiated quota. When full, new conflicts remain
+retryable without evicting existing candidates. Resolution frees an active slot
+while preserving the exact decision receipt for retries.
+
 Until rollout advertises ongoing-sync version 1, these semantics describe the
 client integration contract, not an enabled end-to-end workflow.
 

--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -181,7 +181,8 @@ delete-everywhere." Refresh authoritative state and ask the user to explicitly
 confirm deletion again before creating a new signed request. Never automatically
 rebase deletion or send it to the ordinary conflict resolver. This rejection
 does not delete data or create a conflict candidate. A previously stored
-request can still complete through recovery; exact retries remain supported.
+request remains eligible for recovery; exact retries remain supported. This
+does not complete the currently gated ongoing-ingress purge lifecycle.
 
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |

--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -174,6 +174,15 @@ is invalid, not a user-choice conflict: the server sequences the shared manifest
 from accepted semantic mutations. Initial-link reconciliation and server-issued
 manifest publications remain separate supported paths.
 
+A valid next-generation `personal_context.purge` request with stale Sync
+lineage is rejected with `personal_context_purge_reconfirmation_required`,
+`retryable=false`, and "Refresh Personal Context and explicitly reconfirm
+delete-everywhere." Refresh authoritative state and ask the user to explicitly
+confirm deletion again before creating a new signed request. Never automatically
+rebase deletion or send it to the ordinary conflict resolver. This rejection
+does not delete data or create a conflict candidate. A previously stored
+request can still complete through recovery; exact retries remain supported.
+
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |
 | Keep shared values | `skip` | None |

--- a/Docs/API-related/Personal_Context_API.md
+++ b/Docs/API-related/Personal_Context_API.md
@@ -160,6 +160,32 @@ Retries reuse exact receipts. Delivery baselines expire after 30 days; obtain a
 fresh baseline rather than acknowledging an expired one. Capability downgrade
 preserves stored work and acknowledgements while blocking version-one exchanges.
 
+### User-directed conflict decisions (ongoing-sync contract)
+
+The gated ongoing-sync contract uses the existing
+`POST /api/v1/sync/conflicts/resolve` batch endpoint. Neither peer selects a
+winner automatically. Each Personal Context item identifies the reviewed local
+and remote envelopes and has an immutable idempotency key; requests also carry
+the device's activation/continuity proof. A changed candidate requires fresh
+review, not a blind retry with new IDs.
+
+| User choice | Action | Reviewed replacement |
+| --- | --- | --- |
+| Keep shared values | `skip` | None |
+| Keep local values | `overwrite` | Explicit canonical target with selected local values |
+| Merge | `overwrite` | Explicit canonical target with user-reviewed merged values |
+| Keep both as distinct facts | `duplicate_rename` | New record ID and a noncolliding semantic key |
+
+If two independently created record IDs claim the same semantic key, keep-local
+or merge targets the established shared canonical record ID. The selected values
+win because the user chose them, not because they came from a particular peer.
+The losing incoming candidate is accounted for by the resolution receipt rather
+than installed as a duplicate active fact. Clients must construct that explicitly
+reviewed replacement; they must not expect the server to silently rewrite its ID.
+
+Until rollout advertises ongoing-sync version 1, these semantics describe the
+client integration contract, not an enabled end-to-end workflow.
+
 ## Transport deployment boundary
 
 Deploy non-loopback API access behind authenticated HTTPS. This is an operator

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -239,6 +239,13 @@ timestamps or peer identity. Unresolved candidates remain protected while
 unrelated objects continue. Capability remains gated independently of this
 contract; the current client limitations above still apply.
 
+Active conflict heads and completed receipt heads share the existing encrypted
+object owner but have separate types. The internal 1,000-active-conflict bound
+does not count completed decisions; ordinary freeze checks do not scan completed
+receipt history. Exact receipts are retained, not expired to reclaim capacity.
+This admission bound is not a new negotiated wire quota. A full active set must
+leave new conflicts retryable and preserve every already pinned candidate.
+
 A future client must not infer a complete lifecycle from the presence of Sync
 domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -243,6 +243,8 @@ and obtain explicit delete-everywhere confirmation again before signing a new
 request. Do not synthesize a manifest candidate, merge the purge, or silently
 replace its base envelope. Exact idempotent retry of an earlier stored request
 still supports recovery; rejection of a new stale request does not cancel it.
+The ongoing canonical ingress mutation path does not yet implement purge;
+preserving retry does not claim completed deletion or enable capability v1.
 
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -235,6 +235,15 @@ server advances the shared manifest after semantic writes. Invalid client
 manifest ingress must be rejected before conflict capture. This does not change
 provisional-manifest reconciliation during first linking or authority publication.
 
+Purge is a destructive control request, not an editable object. A valid
+next-generation purge with stale Sync lineage returns the content-free
+`personal_context_purge_reconfirmation_required` error with `retryable=false`.
+Stop automatic retries of that rejected request, refresh authoritative state,
+and obtain explicit delete-everywhere confirmation again before signing a new
+request. Do not synthesize a manifest candidate, merge the purge, or silently
+replace its base envelope. Exact idempotent retry of an earlier stored request
+still supports recovery; rejection of a new stale request does not cancel it.
+
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.
 Canonical identity is not a preference for the server's value. The incoming

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -229,6 +229,12 @@ distinct keep-both to `duplicate_rename`. Use the existing batched Sync endpoint
 expected candidate IDs, and exact-command idempotency; no per-conflict transport
 or ordinary `resolve_conflict` push operation is introduced.
 
+Do not send a linked client's derivative manifest as ongoing ingress. It is a
+local commit barrier, not an independently editable shared object; only the
+server advances the shared manifest after semantic writes. Invalid client
+manifest ingress must be rejected before conflict capture. This does not change
+provisional-manifest reconciliation during first linking or authority publication.
+
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.
 Canonical identity is not a preference for the server's value. The incoming

--- a/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -220,6 +220,25 @@ enabled end-to-end device acknowledgement-completion path.
 
 ## Future-client integration boundaries
 
+### User-owned deconfliction
+
+Conflict detection preserves competing candidates for user review; it is not an
+automatic merge or a last-write-wins policy. The ongoing-sync contract maps keep
+shared to `skip`, keep local or reviewed merge to `overwrite`, and explicitly
+distinct keep-both to `duplicate_rename`. Use the existing batched Sync endpoint,
+expected candidate IDs, and exact-command idempotency; no per-conflict transport
+or ordinary `resolve_conflict` push operation is introduced.
+
+For different IDs claiming the same semantic key, keep-local/merge explicitly
+targets the established shared canonical ID and applies the user-selected values.
+Canonical identity is not a preference for the server's value. The incoming
+duplicate must be terminally accounted for so retries cannot recreate it.
+Keep-both is permitted only after the user chooses distinct facts with different
+keys. Do not silently rename facts, infer user consent, or choose values based on
+timestamps or peer identity. Unresolved candidates remain protected while
+unrelated objects continue. Capability remains gated independently of this
+contract; the current client limitations above still apply.
+
 A future client must not infer a complete lifecycle from the presence of Sync
 domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -169,6 +169,11 @@ and remote envelopes and has an immutable idempotency key; requests also carry
 the device's activation/continuity proof. A changed candidate requires fresh
 review, not a blind retry with new IDs.
 
+After linking, a client must not push its locally derived manifest. Such ingress
+is invalid, not a user-choice conflict: the server sequences the shared manifest
+from accepted semantic mutations. Initial-link reconciliation and server-issued
+manifest publications remain separate supported paths.
+
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |
 | Keep shared values | `skip` | None |

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -183,6 +183,11 @@ The losing incoming candidate is accounted for by the resolution receipt rather
 than installed as a duplicate active fact. Clients must construct that explicitly
 reviewed replacement; they must not expect the server to silently rewrite its ID.
 
+The server's internal safety bound is 1,000 active conflicts per profile, not
+1,000 lifetime decisions or a negotiated quota. When full, new conflicts remain
+retryable without evicting existing candidates. Resolution frees an active slot
+while preserving the exact decision receipt for retries.
+
 Until rollout advertises ongoing-sync version 1, these semantics describe the
 client integration contract, not an enabled end-to-end workflow.
 

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -181,7 +181,8 @@ delete-everywhere." Refresh authoritative state and ask the user to explicitly
 confirm deletion again before creating a new signed request. Never automatically
 rebase deletion or send it to the ordinary conflict resolver. This rejection
 does not delete data or create a conflict candidate. A previously stored
-request can still complete through recovery; exact retries remain supported.
+request remains eligible for recovery; exact retries remain supported. This
+does not complete the currently gated ongoing-ingress purge lifecycle.
 
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -174,6 +174,15 @@ is invalid, not a user-choice conflict: the server sequences the shared manifest
 from accepted semantic mutations. Initial-link reconciliation and server-issued
 manifest publications remain separate supported paths.
 
+A valid next-generation `personal_context.purge` request with stale Sync
+lineage is rejected with `personal_context_purge_reconfirmation_required`,
+`retryable=false`, and "Refresh Personal Context and explicitly reconfirm
+delete-everywhere." Refresh authoritative state and ask the user to explicitly
+confirm deletion again before creating a new signed request. Never automatically
+rebase deletion or send it to the ordinary conflict resolver. This rejection
+does not delete data or create a conflict candidate. A previously stored
+request can still complete through recovery; exact retries remain supported.
+
 | User choice | Action | Reviewed replacement |
 | --- | --- | --- |
 | Keep shared values | `skip` | None |

--- a/Docs/Published/API-related/Personal_Context_API.md
+++ b/Docs/Published/API-related/Personal_Context_API.md
@@ -160,6 +160,32 @@ Retries reuse exact receipts. Delivery baselines expire after 30 days; obtain a
 fresh baseline rather than acknowledging an expired one. Capability downgrade
 preserves stored work and acknowledgements while blocking version-one exchanges.
 
+### User-directed conflict decisions (ongoing-sync contract)
+
+The gated ongoing-sync contract uses the existing
+`POST /api/v1/sync/conflicts/resolve` batch endpoint. Neither peer selects a
+winner automatically. Each Personal Context item identifies the reviewed local
+and remote envelopes and has an immutable idempotency key; requests also carry
+the device's activation/continuity proof. A changed candidate requires fresh
+review, not a blind retry with new IDs.
+
+| User choice | Action | Reviewed replacement |
+| --- | --- | --- |
+| Keep shared values | `skip` | None |
+| Keep local values | `overwrite` | Explicit canonical target with selected local values |
+| Merge | `overwrite` | Explicit canonical target with user-reviewed merged values |
+| Keep both as distinct facts | `duplicate_rename` | New record ID and a noncolliding semantic key |
+
+If two independently created record IDs claim the same semantic key, keep-local
+or merge targets the established shared canonical record ID. The selected values
+win because the user chose them, not because they came from a particular peer.
+The losing incoming candidate is accounted for by the resolution receipt rather
+than installed as a duplicate active fact. Clients must construct that explicitly
+reviewed replacement; they must not expect the server to silently rewrite its ID.
+
+Until rollout advertises ongoing-sync version 1, these semantics describe the
+client integration contract, not an enabled end-to-end workflow.
+
 ## Transport deployment boundary
 
 Deploy non-loopback API access behind authenticated HTTPS. This is an operator

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -239,6 +239,13 @@ timestamps or peer identity. Unresolved candidates remain protected while
 unrelated objects continue. Capability remains gated independently of this
 contract; the current client limitations above still apply.
 
+Active conflict heads and completed receipt heads share the existing encrypted
+object owner but have separate types. The internal 1,000-active-conflict bound
+does not count completed decisions; ordinary freeze checks do not scan completed
+receipt history. Exact receipts are retained, not expired to reclaim capacity.
+This admission bound is not a new negotiated wire quota. A full active set must
+leave new conflicts retryable and preserve every already pinned candidate.
+
 A future client must not infer a complete lifecycle from the presence of Sync
 domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -243,6 +243,8 @@ and obtain explicit delete-everywhere confirmation again before signing a new
 request. Do not synthesize a manifest candidate, merge the purge, or silently
 replace its base envelope. Exact idempotent retry of an earlier stored request
 still supports recovery; rejection of a new stale request does not cancel it.
+The ongoing canonical ingress mutation path does not yet implement purge;
+preserving retry does not claim completed deletion or enable capability v1.
 
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -235,6 +235,15 @@ server advances the shared manifest after semantic writes. Invalid client
 manifest ingress must be rejected before conflict capture. This does not change
 provisional-manifest reconciliation during first linking or authority publication.
 
+Purge is a destructive control request, not an editable object. A valid
+next-generation purge with stale Sync lineage returns the content-free
+`personal_context_purge_reconfirmation_required` error with `retryable=false`.
+Stop automatic retries of that rejected request, refresh authoritative state,
+and obtain explicit delete-everywhere confirmation again before signing a new
+request. Do not synthesize a manifest candidate, merge the purge, or silently
+replace its base envelope. Exact idempotent retry of an earlier stored request
+still supports recovery; rejection of a new stale request does not cancel it.
+
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.
 Canonical identity is not a preference for the server's value. The incoming

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -229,6 +229,12 @@ distinct keep-both to `duplicate_rename`. Use the existing batched Sync endpoint
 expected candidate IDs, and exact-command idempotency; no per-conflict transport
 or ordinary `resolve_conflict` push operation is introduced.
 
+Do not send a linked client's derivative manifest as ongoing ingress. It is a
+local commit barrier, not an independently editable shared object; only the
+server advances the shared manifest after semantic writes. Invalid client
+manifest ingress must be rejected before conflict capture. This does not change
+provisional-manifest reconciliation during first linking or authority publication.
+
 For different IDs claiming the same semantic key, keep-local/merge explicitly
 targets the established shared canonical ID and applies the user-selected values.
 Canonical identity is not a preference for the server's value. The incoming

--- a/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
+++ b/Docs/Published/Code_Documentation/Personal_Context_Developer_Guide.md
@@ -220,6 +220,25 @@ enabled end-to-end device acknowledgement-completion path.
 
 ## Future-client integration boundaries
 
+### User-owned deconfliction
+
+Conflict detection preserves competing candidates for user review; it is not an
+automatic merge or a last-write-wins policy. The ongoing-sync contract maps keep
+shared to `skip`, keep local or reviewed merge to `overwrite`, and explicitly
+distinct keep-both to `duplicate_rename`. Use the existing batched Sync endpoint,
+expected candidate IDs, and exact-command idempotency; no per-conflict transport
+or ordinary `resolve_conflict` push operation is introduced.
+
+For different IDs claiming the same semantic key, keep-local/merge explicitly
+targets the established shared canonical ID and applies the user-selected values.
+Canonical identity is not a preference for the server's value. The incoming
+duplicate must be terminally accounted for so retries cannot recreate it.
+Keep-both is permitted only after the user chooses distinct facts with different
+keys. Do not silently rename facts, infer user consent, or choose values based on
+timestamps or peer identity. Unresolved candidates remain protected while
+unrelated objects continue. Capability remains gated independently of this
+contract; the current client limitations above still apply.
+
 A future client must not infer a complete lifecycle from the presence of Sync
 domains or bootstrap endpoints. Client work owns capability negotiation and
 incompatibility handling, an explicit ongoing Personal Context caller, durable

--- a/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
+++ b/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
@@ -1,0 +1,99 @@
+# TASK-13163 implementation seam update
+
+This refines Task 2 of the approved 2026-09-03 server activation/conflict/purge
+plan against the merged activation and publication implementation. It changes
+no product behavior or wire action vocabulary.
+
+ADR required: no new ADR
+ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
+Reason: implement existing encrypted candidate retention, canonical resolution
+receipts, narrow freezes, and journaled cross-database recovery.
+
+## Current evidence
+
+- The existing ongoing-contract suite passes 12 tests.
+- Batched request fields and endpoint forwarding already exist, but the batch
+  service discards the expected candidate IDs and idempotency key before generic
+  resolution. Personal Context must have its own canonical dispatch there.
+- Both push conflict constructors omit a protected remote candidate.
+- Authority publication staging requires a genuine leased journal row. Never
+  manufacture a publication row or bypass that validation to stage a candidate.
+- Generic retention does not currently fence unresolved conflict references.
+- Generic conflict metadata is plaintext; semantic keys and bodies cannot go
+  there. Existing ingress receipts do not bind conflict/action/expected IDs.
+
+## File ownership correction
+
+In addition to the original Task 2 file list, include:
+
+- `DB_Management/Personalization_DB.py` and `Personal_Context_Repository.py` for
+  durable encrypted conflict state, exact command receipts, and transaction-local
+  object/key-slot guards. Follow existing schema initialization/migration patterns
+  and verify reopen/upgrade. Include new encrypted owners in purge/key-rotation
+  inventories rather than leaving recoverable content outside their lifecycle.
+- `DB_Management/Sync_DB.py` for candidate attachment and retention checks in
+  both preview and guarded destructive revalidation, using SQLite/PostgreSQL parity.
+- `Sync/v2/materializers/personal_context.py` only as needed to preserve structured
+  private collision identity rather than flattening every conflict into one code.
+
+## Execution order and tests
+
+### Confirmed user-directed deconfliction
+
+The user clarified: "there should be deconfliction" and "the user chooses",
+then authorized continuation. Neither peer wins automatically. Competing
+candidates stay unresolved until an explicit user choice: keep shared, keep
+local values, reviewed merge, or keep both as deliberately distinct facts.
+For same-key creations with different IDs, choosing local values or a merge
+updates the established shared canonical identity; it does not silently delete
+an unrelated shared record or leave two active facts for the same key. The
+conflict receipt accounts for the superseded incoming candidate so retry cannot
+resurrect it. The reviewed replacement must name the canonical target explicitly;
+do not rewrite caller-supplied IDs invisibly. Keep both remains duplicate_rename
+with a new ID and noncolliding key. Tests must cover each explicit choice and
+prove no mutation occurs merely from detecting a collision.
+
+### Task 1: Implement TASK-13163
+
+1. Add failing real-repository tests in the new Personal Context conflict suite
+   for deterministic encrypted authority candidate creation/replay, expected-ID
+   rejection, and interrupted canonical resolution before Sync finalization.
+   Reuse production factory/activation fixtures; keep version-one test activation
+   explicit, never weaken production exchange proof or advertise v1.
+2. Persist exact conflict identity, immutable candidates and freeze ownership
+   under the canonical transaction. Ordinary conflicts freeze one object; a key
+   collision freezes both IDs and only its contested semantic-key slot. Store
+   semantic material encrypted. Reuse existing encrypted storage where its owner
+   lifecycle fits; otherwise add narrowly owned tables and migration/reopen tests.
+   Authenticate candidate staging against this durable canonical state or a real
+   existing publication, never caller-supplied source metadata. Attach and protect
+   the exact candidate before a terminal push conflict response; failure remains
+   retryable and restart resumes the same journal identity/bytes.
+3. Pass expected IDs and command idempotency through batch dispatch into a
+   `PersonalContextConflictService`, keeping unrelated Sync domains unchanged.
+   Check ownership, registered device, activation, generation, action, exact
+   candidates and canonical current heads before mutation. Preserve batch savepoint
+   isolation and reject stale items without resolving the generic conflict.
+4. Route overwrite/reviewed merge and duplicate_rename through
+   `PersonalContextService`. Atomically commit result, authoritative manifest,
+   ordered publication batch and an exact conflict/action/candidates/command-digest
+   receipt. Replay equality must reject a changed command, not apply twice. Keep
+   skip canonical-content-neutral, with a replayable decision/release journal if
+   needed for cross-store freeze release. No network/relay wait under a canonical
+   write transaction; preserve the existing lock order and after-commit recovery.
+   Duplicate requires a new ID and free semantic key. Only the authorized exact
+   resolution may bypass/release its own freezes; ordinary direct CRUD and ingress
+   must enforce them inside their write transaction.
+5. Cover restart before/after candidate attachment and canonical receipt, stale
+   reviews, changed idempotency payload, collisions and unrelated writes, partial
+   batches, wrong owner/device/proof, purge/recreation and encrypted-owner lifecycle.
+   Add retention tests proving both candidates survive dry-run and actual guarded
+   compaction until resolved, and plaintext canaries for new storage/log surfaces.
+6. Run targeted conflict, Personalization service/repository, Sync service,
+   materializer, retention, relay, activation and ongoing-contract regressions.
+   Require real PostgreSQL for touched Sync queries. Run affected-code Ruff/Bandit,
+   formatter/diff checks, then independent spec and quality reviews. Document
+   baseline failures separately; do not replace legitimate assertions to get green.
+
+Do not enable ongoing_sync_version=1, implement TASK-13164/13165, alter the shared
+profile contract, introduce a second resolution endpoint, or broaden runtime grants.

--- a/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
+++ b/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
@@ -97,3 +97,29 @@ prove no mutation occurs merely from detecting a collision.
 
 Do not enable ongoing_sync_version=1, implement TASK-13164/13165, alter the shared
 profile contract, introduce a second resolution endpoint, or broaden runtime grants.
+
+## PR #2910 review remediation (2026-09-05)
+
+Mutating choices schedule durable relay after the enclosing Sync batch fence
+commits. Direct canonical service callers retain their ordinary after-commit
+hook; batch dispatch explicitly defers that hook because reentering Sync while
+its savepoint is open invalidates the SQLite savepoint. Relay failure preserves
+the committed decision, and an interrupted Sync finalization still leaves an
+exact canonical receipt available for recovery.
+
+Keep-both validation requires an active replacement with a concrete, free
+semantic key. Invalid choice payloads use the centralized
+`PersonalContextConflictInputError`, retaining ValueError compatibility.
+Retention previews label otherwise ineligible protected rows `conflict_pin`;
+these informational rows do not enter compaction selection. Naturally eligible
+blocked candidates and guarded domain-prefix checks retain the existing
+all-or-nothing policy. This does not introduce generic partial compaction.
+
+Purge review remains open: after a valid next-generation purge is durably stored
+but canonical application temporarily fails, a second signed request can hit
+that Sync head and enter ordinary candidate capture. Canonical purge state is
+a manifest/barrier, with no purge object head to capture. The approved contract
+does not choose rejection with refresh/reconfirmation versus a dedicated
+deletion-conflict review. Do not synthesize a cross-domain candidate or change
+purge policy without that decision. TASK-13163 remains In Progress; version 0
+and the existing rollout gate remain unchanged.

--- a/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
+++ b/Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md
@@ -115,11 +115,34 @@ these informational rows do not enter compaction selection. Naturally eligible
 blocked candidates and guarded domain-prefix checks retain the existing
 all-or-nothing policy. This does not introduce generic partial compaction.
 
-Purge review remains open: after a valid next-generation purge is durably stored
-but canonical application temporarily fails, a second signed request can hit
+Purge review initially remained open: after a valid next-generation purge is durably stored
+but projection fails, a second signed request can hit
 that Sync head and enter ordinary candidate capture. Canonical purge state is
 a manifest/barrier, with no purge object head to capture. The approved contract
 does not choose rejection with refresh/reconfirmation versus a dedicated
 deletion-conflict review. Do not synthesize a cross-domain candidate or change
-purge policy without that decision. TASK-13163 remains In Progress; version 0
-and the existing rollout gate remain unchanged.
+purge policy without that decision.
+
+The user subsequently selected rejection with refresh and explicit
+reconfirmation. Implement the existing ADR-002 amendment by reproducing that
+signed failed-ingress scenario, then rejecting stale-lineage purge control
+requests nonretryably before ordinary conflict candidate capture. Return the
+content-free `personal_context_purge_reconfirmation_required` code with a
+refresh/reconfirmation instruction. Preserve exact idempotent retries, normal
+next-generation validation, and existing generation failures. Targeted adapter,
+purge and ingress/recovery checks must pass before completion; no separate
+deletion review, schema, UI or rollout change is introduced. Version 0 and the
+existing rollout gate remain unchanged.
+
+Cover both preflight lineage checks and the insertion compare-and-swap race;
+neither may route a new stale deletion intent into candidate capture. Preserve
+re-entry of an exact previously stored client-ingress request after rejection:
+the full immutable fingerprint is checked before adapter evaluation and again
+at insertion, with signature, identity, generation and activation checks retained.
+Ongoing canonical ingress still does not implement purge application; this fix
+preserves recovery eligibility without claiming canonical deletion completion.
+The original diagnostic's injected canonical-service outage was not reached:
+purge parsing returns a dict, which the existing materializer passes to the
+model-only canonical serializer before service entry. The final regression
+therefore delegates the real materializer and observes original-request re-entry
+after rejection, rather than pretending the canonical-service fault ran.

--- a/Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md
+++ b/Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md
@@ -1,0 +1,14 @@
+# PostgreSQL CASE placeholder and ordinary ingress repair
+
+Goal: correct the shared placeholder parser so ordinary Sync ingress has backend parity.
+
+ADR required: no
+ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
+Reason: preserve the existing SQL/backend and Sync authority contracts; no schema or policy change.
+
+1. Add failing parameterized CASE-placeholder regressions to `tldw_Server_API/tests/DB_Management/unit/test_postgres_placeholder_prepare.py`. Cover simple/searched/nested CASE, result binds adjacent to THEN/ELSE/END, unchanged parameters, quoted text/identifiers, and JSONB operators within CASE.
+2. Replace the raw envelope insert workaround in `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py` with the ordinary `SyncV2Store` insertion API. Verify the existing SQLite/PostgreSQL fixture reproduces the bind mismatch and add domain watermark non-regression checks.
+3. Minimally correct CASE keyword recognition in `tldw_Server_API/app/core/DB_Management/backends/query_utils.py`; do not rewrite the Sync query or introduce a SQL parser dependency.
+4. Run targeted placeholder/backend-utils and ingress tests with `TLDW_TEST_POSTGRES_REQUIRED=1`, using the shared isolated PostgreSQL fixture. Verify successive ordinary insertions and monotonic watermark behavior on both backends. Run affected-file static checks and self-review; record evidence and obtain independent review before closing the task.
+
+Use the server root `.venv/bin/python` from this isolated worktree and verify source provenance. No full-suite sweep or ongoing-sync capability enablement.

--- a/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
+++ b/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
@@ -775,6 +775,15 @@ The merge editor uses typed fields rather than raw canonical JSON. Restrictive
 values win by default for delete, `user_only`, and other privacy-reducing
 controls; the user must explicitly choose a less restrictive result.
 
+User clarification (2026-09-05): deconfliction is explicitly user-directed;
+neither peer selects a winner automatically. When independently created IDs
+claim the same semantic key, keeping local values or a reviewed merge produces
+one fact under the established shared canonical ID, explicitly targeted by the
+reviewed replacement. The incoming duplicate candidate is terminally accounted
+for by the resolution receipt, not installed as a second active fact. Keeping
+both requires an explicit distinct-fact choice and a noncolliding key. Detecting
+the collision alone never authorizes an overwrite or deletion.
+
 Conflict pages contain at most 20 items. Labels are **Local version** and
 **Shared profile version**, not ambiguous client/server winner language.
 

--- a/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
+++ b/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
@@ -725,7 +725,7 @@ encrypted replay receipts remain available. Exhaustion leaves a new push
 retryable and preserves existing candidates; resolving a conflict frees an
 active slot. Existing negotiated envelope and batch limits still apply.
 
-Every Personal Context push conflict must name and deliver the current
+Every Personal Context object push conflict must name and deliver the current
 canonical authority candidate. Before the server reports the conflict, it:
 
 1. Reads the exact canonical head through the Personal Context service.
@@ -741,6 +741,10 @@ the push item as terminally conflicted or retiring its staged retry. A pull-
 time conflict instead pins the incoming home-authority envelope before cursor
 advancement. Thus review never depends on a future pull or on an envelope that
 retention may already have removed.
+
+Delete-everywhere requests are control operations, not mergeable objects. A
+valid next-generation purge with stale Sync lineage is rejected as described
+under Delete everywhere below; it does not enter this candidate-review flow.
 
 User-facing actions map to the server contract as follows:
 
@@ -901,6 +905,18 @@ stored in SyncState before readable profile keys or content are destroyed.
 The editor freezes while deletion is pending. Every Personal Context ingress,
 source-publication row, authority envelope, conflict candidate, and purge
 barrier carries an explicit purge generation.
+
+A valid next-generation purge whose Sync lineage is stale returns
+`personal_context_purge_reconfirmation_required` with `retryable=false` and
+the content-free message "Refresh Personal Context and explicitly reconfirm
+delete-everywhere." The client must refresh authoritative state and obtain a
+fresh explicit deletion confirmation before constructing a new signed request.
+It must not automatically rebase the request, choose a winner, or route deletion
+through ordinary profile conflict review. No purge object candidate is created.
+This rejection does not itself delete canonical data or advance its generation;
+an earlier durably stored request may still complete through its own recovery.
+Exact idempotent retries of that earlier request remain supported, as do normal
+valid purges and the existing invalid-generation rejections.
 
 For purge ordering, "accepted" means that the canonical Personalization
 transaction committed, not merely that an ingress envelope became durable in

--- a/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
+++ b/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
@@ -914,7 +914,7 @@ fresh explicit deletion confirmation before constructing a new signed request.
 It must not automatically rebase the request, choose a winner, or route deletion
 through ordinary profile conflict review. No purge object candidate is created.
 This rejection does not itself delete canonical data or advance its generation;
-an earlier durably stored request may still complete through its own recovery.
+an earlier durably stored request remains eligible for its own recovery.
 Exact idempotent retries of that earlier request remain supported, as do normal
 valid purges and the existing invalid-generation rejections.
 

--- a/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
+++ b/Docs/superpowers/specs/2026-09-02-personal-context-ongoing-sync-design.md
@@ -718,6 +718,13 @@ cannot durably pin another candidate, it stops before advancing the cursor and
 reports profile attention; it never drops the oldest unresolved candidate to
 make room silently.
 
+The current server implementation also has an internal admission bound of 1,000
+active conflicts per profile. This is not a negotiated concurrent-conflict quota
+or a lifetime limit: resolved decisions leave the active set while their exact
+encrypted replay receipts remain available. Exhaustion leaves a new push
+retryable and preserves existing candidates; resolving a conflict frees an
+active slot. Existing negotiated envelope and batch limits still apply.
+
 Every Personal Context push conflict must name and deliver the current
 canonical authority candidate. Before the server reports the conflict, it:
 

--- a/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
+++ b/backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md
@@ -4,7 +4,7 @@ Status: Accepted
 
 Date: 2026-08-30
 
-Amended: 2026-09-02
+Amended: 2026-09-06
 
 Related Task: [TASK-13144](../tasks/task-13144%20-%20Add-encrypted-server-Personal-Context-repository.md)
 
@@ -82,6 +82,15 @@ advancement. Ordinary conflicts freeze one object; key collisions freeze both
 object IDs and only their contested semantic-key slot. Push conflicts attach a
 deterministic authority candidate before they are reported.
 
+Delete-everywhere is a destructive control request, not a mergeable profile
+object. A valid next-generation purge with stale Sync lineage is rejected with
+the non-retryable `personal_context_purge_reconfirmation_required` code. The
+client must refresh authoritative state and obtain explicit deletion confirmation
+again before constructing a new request; it must not silently rebase or submit
+the request through ordinary conflict resolution. Exact idempotent retries and
+valid purge processing retain their existing recovery behavior. This policy was
+approved for TASK-13163 on 2026-09-06.
+
 ## Context
 
 The existing server Personalization layer stores user response style and
@@ -107,6 +116,10 @@ operator expectations while allowing a fenced migration from legacy tables.
   closed rather than destroy recoverability.
 - Store semantic routing fields in clear columns: rejected because kind,
   visibility, state, and semantic keys disclose sensitive profile facts.
+- Treat stale delete-everywhere requests as ordinary object conflicts: rejected
+  because canonical purge state is a manifest/barrier, not a competing editable
+  object. Inventing a candidate would misrepresent the authority being reviewed;
+  automatically rebasing deletion would reuse consent against changed state.
 
 ## Consequences
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1,5 +1,19 @@
 # Testing Evidence Lessons
 
+## Exercise ordinary ingress after narrow storage repairs
+
+**Incident (TASK-13192, 2026-09-05):** The activation repair fixture seeded
+PostgreSQL envelopes directly because ordinary insertion failed elsewhere.
+Replacing that seed with `SyncV2Store.insert_envelope` reproduced the failure in
+the shared SQL converter: `ELSE ? END` retained a question mark, leaving five
+bind slots for six parameters. SQLite passed the same insertion.
+
+**Evidence and rule:** Directional CASE keyword recognition restored ordinary
+ingress and all receipt-state tests on both backends. Parser regressions also
+retain JSONB operators after `CASE ... END` and before a CASE operand. A narrow
+storage test may isolate a separate defect temporarily, but remove its bypass
+when fixing that defect and prove the public insertion path on each backend.
+
 ## Generic dict lint rules do not apply to `sqlite3.Row`
 
 **Incident (TASK-13144, 2026-08-30):** Ruff's `SIM118` suggestion replaced

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1,5 +1,19 @@
 # Testing Evidence Lessons
 
+## Canonical after-commit may still be inside a Sync savepoint
+
+**Incident (TASK-13163, PR #2910 review, 2026-09-05):** Adding the usual
+Personal Context service after-commit relay to conflict resolution committed
+the canonical choice, then reentered Sync before the enclosing batch savepoint
+closed. A production-factory regression returned a rejected item; exposing the
+savepoint exit showed a SQLite query execution failure at `RELEASE SAVEPOINT`.
+
+**Evidence and rule:** Defer batched relay until the outer Sync fence exits,
+including when canonical commit succeeded but Sync finalization failed. Direct
+service callers still use their ordinary after-commit hook. Verify both stores'
+transaction boundaries and callback failure behavior, rather than treating a
+canonical commit as evidence that every enclosing transaction has finished.
+
 ## A record conflict is not evidence for every Personal Context domain
 
 **Incident (TASK-13163, 2026-09-05):** A 316-test targeted checkpoint passed

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1,5 +1,19 @@
 # Testing Evidence Lessons
 
+## A record conflict is not evidence for every Personal Context domain
+
+**Incident (TASK-13163, 2026-09-05):** A 316-test targeted checkpoint passed
+while the new conflict choices exercised records. Review found that linked
+client manifests could enter the same conflict path, although the approved
+contract forbids pushing those derivative checkpoints. An unrelated semantic
+write advanced the server manifest and stranded its immutable conflict review.
+New stale/current client-manifest rejection tests both failed before the fix.
+
+**Evidence and rule:** Check each domain's authority and lifecycle before applying
+a shared conflict handler. Cover both permitted semantic inputs and prohibited
+derived/control inputs; a broad existing regression count does not establish
+that the new behavior is valid for every domain.
+
 ## Exercise ordinary ingress after narrow storage repairs
 
 **Incident (TASK-13192, 2026-09-05):** The activation repair fixture seeded

--- a/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
+++ b/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13163
 title: Resolve Personal Context conflicts through the batched Sync API
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-06 00:05'
+updated_date: '2026-09-06 00:39'
 labels:
   - personal-context
   - sync
@@ -41,6 +41,8 @@ Extend the existing batched Sync conflict API for ongoing Personal Context confl
 
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no new ADR. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: implement approved ongoing-sync conflict authority and retention. Follow Task 2 in Docs/superpowers/plans/2026-09-03-personal-context-ongoing-sync-02-server-activation-conflict-purge.md after auditing current activation/publication seams. First verify current behavior, identify durable encrypted receipt/freeze storage and migration requirements, and refine exact integration steps without changing approved wire actions. Then add failing candidate retention and replay/stale-review tests, implement canonical batched resolution plus exact freezes, run targeted SQLite/PostgreSQL/canary/authorization tests, and obtain spec and quality review. Keep ongoing_sync_version=0. Isolated branch starts at the verified TASK13192 converter fix 6363466d07; no merge is claimed.
+
+PR #2910 review remediation: verify all ten Qodo findings against approved detail plan and ADR-002; reproduce confirmed relay and duplicate-key bugs before minimal fixes; establish purge reachability and preserve existing retention policy, reporting architectural ambiguity before changing it. Preserve test-only SQL inspection instead of adding production inspection helpers. Run targeted SQLite/PostgreSQL paths with PostgreSQL required, affected Ruff/format/Bandit and diff checks; record per-finding evidence and scoped commit. ADR required: no new ADR for routine fixes; existing ADR-002 governs.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -57,6 +59,12 @@ Verification: final amended candidate/replay/race/PostgreSQL selection 16 passed
 API/developer guides, published copies, approved spec/detail plan and testing lesson updated. ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs the existing storage, authority and conflict boundaries. Plan: Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md. Runtime context builder remains an unwired existing scaffold; the unchanged all-domain scan-watermark length limitation remains outside this task and was not independently baseline-reproduced. Ongoing sync stays version 0. Local branch codex/personal-context-conflict-resolution starts at 6363466d07; no push, PR, merge or destructive cleanup performed.
 
 Publication: opened https://github.com/rmusser01/tldw_server/pull/2910 stacked on PostgreSQL prerequisite PR #2909. Fresh candidate/recovery/race selection: 15 passed and one PostgreSQL sandbox skip; the skipped test then passed with PostgreSQL required and database access (1 passed). Both processes exited 0. Diff check passed. No source changes, rebase, merge or rollout. Merge prerequisite into dev first, then retarget/rebase this PR onto dev and verify integration; human Change summary remains a pre-merge requirement.
+
+PR #2910 review remediation: fixed missing concrete active semantic-key validation and centralized invalid-choice exceptions; direct canonical resolution schedules relay, while batches defer relay until the outer Sync fence/savepoint exits. Real-factory diagnostic proved that a naive in-service callback invalidates the open SQLite savepoint. Informational conflict_pin rows remain visible in retention previews without blocking unrelated domain compaction; naturally eligible blockers and domain-prefix guards keep existing all-or-nothing behavior. Added targeted direct/batch relay failure and replay cases, missing-key cases, mixed retention on SQLite/PostgreSQL, and PostgreSQL skip/overwrite/duplicate decisions; completed docstrings/types in the PR test module and fixed its proposal clock. Shared pg_database_config already provisions a unique per-test database with teardown; retained existing test-only SQL inspection/tamper probes instead of adding production inspection APIs.
+
+Final verification: focused conflict/replay selection22passed exit0, PostgreSQL-required; corrected PostgreSQL fixture selection3passed exit0 (removes introduced serialization warning), existing retention/relay suites75passed exit0. Affected Ruff, scoped formatting, AST docs/types and git diff checks passed. Bandit production scope has zero findings exit0; test scan has expected assertion B101 and the same HEAD-baseline closed-parameter tamper-query B608, no new production findings. Independent scoped review approved remediation source and test fixture correction. No full sweep. Python interpreter cleanup after the22-test summary completed normally before commit.
+
+OPEN review finding1: real factory probe demonstrated a signed next-generation purge persisted accepted/failed during temporary canonical unavailability, then a second valid request hit that Sync head and returned retryable storage_unavailable because canonical purge has no object head. Approved spec does not choose rejection with refresh/reconfirmation versus a dedicated deletion-conflict review. Purge behavior remains unchanged pending owner policy; task stays In Progress and PR readiness is not claimed. ADR required: no new ADR for these routine fixes; existing ADR-002 and approved detail plan govern. Detail plan and testing-evidence lesson updated. No schema/dependency/action/rollout changes; ongoing_sync_version remains0. Parent owns prerequisite restack, publication and GitHub response.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
+++ b/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-13163
 title: Resolve Personal Context conflicts through the batched Sync API
-status: To Do
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
+updated_date: '2026-09-05 21:42'
 labels:
   - personal-context
   - sync
@@ -35,6 +36,20 @@ Extend the existing batched Sync conflict API for ongoing Personal Context confl
 - [ ] #6 Candidate retention, replay, stale-review, key-collision, batch-partial-failure, authorization, and plaintext-canary tests pass.
 - [ ] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs conflict authority and retention.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no new ADR. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: implement approved ongoing-sync conflict authority and retention. Follow Task 2 in Docs/superpowers/plans/2026-09-03-personal-context-ongoing-sync-02-server-activation-conflict-purge.md after auditing current activation/publication seams. First verify current behavior, identify durable encrypted receipt/freeze storage and migration requirements, and refine exact integration steps without changing approved wire actions. Then add failing candidate retention and replay/stale-review tests, implement canonical batched resolution plus exact freezes, run targeted SQLite/PostgreSQL/canary/authorization tests, and obtain spec and quality review. Keep ongoing_sync_version=0. Isolated branch starts at the verified TASK13192 converter fix 6363466d07; no merge is claimed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Continuation checkpoint: approved detail plan Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md adds missing canonical encrypted journal/freeze and Sync retention ownership; independent plan review approved. Existing ongoing wire-contract baseline: 12 passed. Implementation paused before code edits for an owner decision: on a semantic-key collision between distinct local and shared object IDs, does overwrite/Keep local authorize retiring the shared record and installing the local ID, or must that shared record remain and the local copy use duplicate_rename? Approved spec defines duplicate_rename but does not resolve this destructive identity choice. No default deletion, action restriction, or capability enablement introduced. Investigation found generic encrypted object_versions could own private journals under existing purge/rotation inventory; verify in implementation after choice. TASK13192 committed6363466d07 is this isolated branch base, not yet merged.
+
+Owner clarification resolved: user explicitly chooses deconfliction outcome; no automatic local/server winner. Keep shared, keep local values, reviewed merge, or explicitly distinct keep-both. For same-key distinct IDs, keep-local/merge explicitly targets established shared canonical identity; incoming duplicate is accounted for by exact receipt, not silently installed alongside it. Spec and detail plan updated; continuation authorized. Supersedes prior paused-decision checkpoint.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
+++ b/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13163
 title: Resolve Personal Context conflicts through the batched Sync API
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-06 00:39'
+updated_date: '2026-09-06 01:12'
 labels:
   - personal-context
   - sync
@@ -35,6 +35,7 @@ Extend the existing batched Sync conflict API for ongoing Personal Context confl
 - [x] #5 Ordinary conflicts freeze one object; key collisions freeze both object IDs and only the contested semantic-key slot while unrelated objects continue.
 - [x] #6 Candidate retention, replay, stale-review, key-collision, batch-partial-failure, authorization, and plaintext-canary tests pass.
 - [x] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs conflict authority and retention.
+- [x] #8 A signed valid-next-generation delete-everywhere request with stale lineage is rejected nonretryably with a content-free refresh and explicit reconfirmation instruction, without creating an ordinary conflict candidate; exact idempotent retry and valid purge/generation behavior are preserved.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,6 +44,8 @@ Extend the existing batched Sync conflict API for ongoing Personal Context confl
 ADR required: no new ADR. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: implement approved ongoing-sync conflict authority and retention. Follow Task 2 in Docs/superpowers/plans/2026-09-03-personal-context-ongoing-sync-02-server-activation-conflict-purge.md after auditing current activation/publication seams. First verify current behavior, identify durable encrypted receipt/freeze storage and migration requirements, and refine exact integration steps without changing approved wire actions. Then add failing candidate retention and replay/stale-review tests, implement canonical batched resolution plus exact freezes, run targeted SQLite/PostgreSQL/canary/authorization tests, and obtain spec and quality review. Keep ongoing_sync_version=0. Isolated branch starts at the verified TASK13192 converter fix 6363466d07; no merge is claimed.
 
 PR #2910 review remediation: verify all ten Qodo findings against approved detail plan and ADR-002; reproduce confirmed relay and duplicate-key bugs before minimal fixes; establish purge reachability and preserve existing retention policy, reporting architectural ambiguity before changing it. Preserve test-only SQL inspection instead of adding production inspection helpers. Run targeted SQLite/PostgreSQL paths with PostgreSQL required, affected Ruff/format/Bandit and diff checks; record per-finding evidence and scoped commit. ADR required: no new ADR for routine fixes; existing ADR-002 governs.
+
+Approved purge-review follow-up: user selected stale delete-everywhere rejection with refresh and explicit reconfirmation. Reproduce retained real signed failed-ingress scenario as a failing assertion, add focused adapter cases preserving normal next-generation validation and exact retry, then reject stale purge lineage before candidate creation. No schema, rollout, UI or ordinary conflict policy changes. Parent updates ADR-002 and spec; this worker owns adapter/tests/task/detail plan. ADR required: existing ADR-002 amendment records approved control-request policy. Run targeted adapter, purge, ingress/recovery checks and affected Ruff/Bandit/diff; require completed process exits and independent scoped review.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -65,6 +68,10 @@ PR #2910 review remediation: fixed missing concrete active semantic-key validati
 Final verification: focused conflict/replay selection22passed exit0, PostgreSQL-required; corrected PostgreSQL fixture selection3passed exit0 (removes introduced serialization warning), existing retention/relay suites75passed exit0. Affected Ruff, scoped formatting, AST docs/types and git diff checks passed. Bandit production scope has zero findings exit0; test scan has expected assertion B101 and the same HEAD-baseline closed-parameter tamper-query B608, no new production findings. Independent scoped review approved remediation source and test fixture correction. No full sweep. Python interpreter cleanup after the22-test summary completed normally before commit.
 
 OPEN review finding1: real factory probe demonstrated a signed next-generation purge persisted accepted/failed during temporary canonical unavailability, then a second valid request hit that Sync head and returned retryable storage_unavailable because canonical purge has no object head. Approved spec does not choose rejection with refresh/reconfirmation versus a dedicated deletion-conflict review. Purge behavior remains unchanged pending owner policy; task stays In Progress and PR readiness is not claimed. ADR required: no new ADR for these routine fixes; existing ADR-002 and approved detail plan govern. Detail plan and testing-evidence lesson updated. No schema/dependency/action/rollout changes; ongoing_sync_version remains0. Parent owns prerequisite restack, publication and GitHub response.
+
+Approved purge follow-up corrects the earlier diagnostic attribution: the signed request was durably stored with real projection failure, but the injected apply_sync_ingress service outage was never reached. Existing purge materialization parses a dict then passes it to the model-only canonical serializer before service entry; ongoing canonical ingress purge remains unsupported and gated. The regression now delegates real PersonalContextMaterializer.apply and observes original-request re-entry after rejecting the second stale intent. Parent recorded user-approved rejection/reconfirmation in ADR-002 and spec; no canonical purge lifecycle expansion is implemented.
+
+Completed approved stale-purge review follow-up: adapter and generic insertion-CAS boundary reject new stale deletion intents nonretryably with personal_context_purge_reconfirmation_required and refresh/explicit reconfirmation instruction, before ordinary candidate capture. Exact previously stored client ingress retains materializer re-entry under existing full immutable fingerprint, signature, identity, generation and activation checks; changed same-ID entity metadata is rejected. No canonical purge lifecycle, schema, UI, dependencies or rollout added. Verification: final4 SQLite/PostgreSQL preflight/race/retry cases passed exit0; targeted adapter/materializer/ingress-repair/purge-retention107 passed exit0 on final production before test-only fixture corrections. Fresh Ruff, amended range formatting, production Bandit zero findings and diff checks exit0. Independent scoped review approved with no Critical/Important findings. Prior OPEN purge finding is superseded by user-approved ADR-002 amendment, recorded in detail plan. Original canonical-service fault attribution corrected above; existing gated dict serialization and unsupported ongoing canonical purge remain unimplemented. Parent owns publication and prerequisite restack; no merge claimed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
+++ b/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-05 23:51'
+updated_date: '2026-09-06 00:05'
 labels:
   - personal-context
   - sync
@@ -55,12 +55,14 @@ Implemented user-directed Personal Context deconfliction in the existing batched
 Verification: final amended candidate/replay/race/PostgreSQL selection 16 passed and activation 25 passed, both exit 0; preceding classification fix 2 focused plus 35 adapter/materializer passed. Earlier implementation checkpoints: 48 conflict cases, 60 compatibility/activation, 316 targeted regressions and 71 relay/activation passed; these are not claimed as final-source full reruns. Affected Ruff, formatting, Bandit, docs path hygiene and branch diff checks passed. Independent task review and final whole-branch review, including scoped fixes, approved source commit 62e63bf5124628b3e2bb1d7aec745af6f976c3cf. No full suite or live end-to-end rollout certification was run. Known dependency/config warnings remain attributed; the long 48-test interpreter cleanup exited 0 normally.
 
 API/developer guides, published copies, approved spec/detail plan and testing lesson updated. ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs the existing storage, authority and conflict boundaries. Plan: Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md. Runtime context builder remains an unwired existing scaffold; the unchanged all-domain scan-watermark length limitation remains outside this task and was not independently baseline-reproduced. Ongoing sync stays version 0. Local branch codex/personal-context-conflict-resolution starts at 6363466d07; no push, PR, merge or destructive cleanup performed.
+
+Publication: opened https://github.com/rmusser01/tldw_server/pull/2910 stacked on PostgreSQL prerequisite PR #2909. Fresh candidate/recovery/race selection: 15 passed and one PostgreSQL sandbox skip; the skipped test then passed with PostgreSQL required and database access (1 passed). Both processes exited 0. Diff check passed. No source changes, rebase, merge or rollout. Merge prerequisite into dev first, then retarget/rebase this PR onto dev and verify integration; human Change summary remains a pre-merge requirement.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed canonical user-directed conflict resolution with exact encrypted candidates/receipts, guarded retention, restart recovery and transaction-boundary activation checks. Task and final reviews approved all fixes; targeted tests/static/docs checks passed with disclosed baseline warnings. Implementation and documentation are local only; ongoing sync remains gated at version 0.
+Completed canonical user-directed conflict resolution with exact encrypted candidates/receipts, guarded retention, restart recovery and transaction-boundary activation checks. Task and final reviews approved all fixes; targeted verification is recorded with baseline/environment warnings. Published for review in PR #2910, stacked on #2909; not merged, and ongoing sync remains gated at version 0.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
+++ b/backlog/tasks/task-13163 - Resolve-Personal-Context-conflicts-through-the-batched-Sync-API.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13163
 title: Resolve Personal Context conflicts through the batched Sync API
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 13:40'
-updated_date: '2026-09-05 21:42'
+updated_date: '2026-09-05 23:51'
 labels:
   - personal-context
   - sync
@@ -28,13 +28,13 @@ Extend the existing batched Sync conflict API for ongoing Personal Context confl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every Personal Context push conflict creates or reuses a deterministic protected home-authority candidate before returning a terminal conflict result.
-- [ ] #2 Conflict records carry expected local and remote envelope IDs; stale reviews are rejected without mutating canonical state or resolving the generic conflict.
-- [ ] #3 The batched endpoint implements skip, overwrite, and duplicate_rename only, with canonical overwrite, merge payload, and duplicate decisions routed through PersonalContextService.
-- [ ] #4 Mutating decisions use idempotent Personalization replay receipts so interruption cannot duplicate a version, manifest advance, publication batch, merge, or renamed record.
-- [ ] #5 Ordinary conflicts freeze one object; key collisions freeze both object IDs and only the contested semantic-key slot while unrelated objects continue.
-- [ ] #6 Candidate retention, replay, stale-review, key-collision, batch-partial-failure, authorization, and plaintext-canary tests pass.
-- [ ] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs conflict authority and retention.
+- [x] #1 Every Personal Context push conflict creates or reuses a deterministic protected home-authority candidate before returning a terminal conflict result.
+- [x] #2 Conflict records carry expected local and remote envelope IDs; stale reviews are rejected without mutating canonical state or resolving the generic conflict.
+- [x] #3 The batched endpoint implements skip, overwrite, and duplicate_rename only, with canonical overwrite, merge payload, and duplicate decisions routed through PersonalContextService.
+- [x] #4 Mutating decisions use idempotent Personalization replay receipts so interruption cannot duplicate a version, manifest advance, publication batch, merge, or renamed record.
+- [x] #5 Ordinary conflicts freeze one object; key collisions freeze both object IDs and only the contested semantic-key slot while unrelated objects continue.
+- [x] #6 Candidate retention, replay, stale-review, key-collision, batch-partial-failure, authorization, and plaintext-canary tests pass.
+- [x] #7 ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs conflict authority and retention.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,14 +49,26 @@ ADR required: no new ADR. ADR path: backlog/decisions/002-personal-context-profi
 Continuation checkpoint: approved detail plan Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md adds missing canonical encrypted journal/freeze and Sync retention ownership; independent plan review approved. Existing ongoing wire-contract baseline: 12 passed. Implementation paused before code edits for an owner decision: on a semantic-key collision between distinct local and shared object IDs, does overwrite/Keep local authorize retiring the shared record and installing the local ID, or must that shared record remain and the local copy use duplicate_rename? Approved spec defines duplicate_rename but does not resolve this destructive identity choice. No default deletion, action restriction, or capability enablement introduced. Investigation found generic encrypted object_versions could own private journals under existing purge/rotation inventory; verify in implementation after choice. TASK13192 committed6363466d07 is this isolated branch base, not yet merged.
 
 Owner clarification resolved: user explicitly chooses deconfliction outcome; no automatic local/server winner. Keep shared, keep local values, reviewed merge, or explicitly distinct keep-both. For same-key distinct IDs, keep-local/merge explicitly targets established shared canonical identity; incoming duplicate is accounted for by exact receipt, not silently installed alongside it. Spec and detail plan updated; continuation authorized. Supersedes prior paused-decision checkpoint.
+
+Implemented user-directed Personal Context deconfliction in the existing batched Sync endpoint. Protected immutable canonical candidates and narrow object/key-slot freezes share existing encrypted storage; completed exact receipts do not consume the internal 1000-active-conflict bound. Keep-local and merged values explicitly target the established shared canonical ID; duplicate_rename requires a new ID and noncolliding key. Canonical mutation, manifest, publication and exact decision receipt commit together, with recoverable Sync finalization. Candidate identity/body authentication and same-transaction activation checks cover capture, attachment, resolution and replay. Invalid linked manifests and invalid purge generations reject before conflict review. Retention guards include real SQLite/PostgreSQL destructive checks. No schema, dependency, shared profile-core, new endpoint/action or rollout changes.
+
+Verification: final amended candidate/replay/race/PostgreSQL selection 16 passed and activation 25 passed, both exit 0; preceding classification fix 2 focused plus 35 adapter/materializer passed. Earlier implementation checkpoints: 48 conflict cases, 60 compatibility/activation, 316 targeted regressions and 71 relay/activation passed; these are not claimed as final-source full reruns. Affected Ruff, formatting, Bandit, docs path hygiene and branch diff checks passed. Independent task review and final whole-branch review, including scoped fixes, approved source commit 62e63bf5124628b3e2bb1d7aec745af6f976c3cf. No full suite or live end-to-end rollout certification was run. Known dependency/config warnings remain attributed; the long 48-test interpreter cleanup exited 0 normally.
+
+API/developer guides, published copies, approved spec/detail plan and testing lesson updated. ADR required: no new ADR; backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md governs the existing storage, authority and conflict boundaries. Plan: Docs/superpowers/plans/2026-09-05-personal-context-conflict-resolution-detail.md. Runtime context builder remains an unwired existing scaffold; the unchanged all-domain scan-watermark length limitation remains outside this task and was not independently baseline-reproduced. Ongoing sync stays version 0. Local branch codex/personal-context-conflict-resolution starts at 6363466d07; no push, PR, merge or destructive cleanup performed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed canonical user-directed conflict resolution with exact encrypted candidates/receipts, guarded retention, restart recovery and transaction-boundary activation checks. Task and final reviews approved all fixes; targeted tests/static/docs checks passed with disclosed baseline warnings. Implementation and documentation are local only; ongoing sync remains gated at version 0.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
+++ b/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-05 19:50'
-updated_date: '2026-09-05 19:58'
+updated_date: '2026-09-06 00:04'
 labels: []
 dependencies: []
 ---
@@ -33,6 +33,8 @@ ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-autho
 
 <!-- SECTION:NOTES:BEGIN -->
 Corrected directional CASE placeholder recognition in the shared backend converter; preserved JSONB operators before CASE and after END. Ordinary SyncV2Store insertion now seeds receipt repair coverage, with real PostgreSQL/SQLite successive insertion, replay and nondecreasing domain-watermark assertions. Plan: Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md. ADR check: no new decision; existing ADR-002 governs unchanged Personal Context authority. RED: 11 parser failures and real PostgreSQL ordinary insertion failure, SQLite passed. Final focused verification: 109 passed (placeholder helpers, backend utilities, dual-backend ingress repair, bootstrap), TLDW_TEST_POSTGRES_REQUIRED=1. Ruff touched files and test formatting passed; production Bandit no findings; diff check passed. Independent plan and correctness review approved (reviewer additionally ran 18 parser tests). Broader selected store run: 94 passed, one pre-existing fake-backend receipt test failed with personal_context_link_binding_stale; reproduced after loading unchanged HEAD converter in memory, and neither that test nor Sync_DB changed. No full sweep, capability enablement, PR or merge. Added incident-based testing lesson. Backlog MCP search hung; CLI fallback used.
+
+Publication: opened https://github.com/rmusser01/tldw_server/pull/2909 against dev from reviewed source 6363466d07. Fresh pre-publication placeholder check: 18 passed, exit 0, existing warnings; diff check passed. Dependent conflict PR: https://github.com/rmusser01/tldw_server/pull/2910. No rebase or merge; current dev integration and human Change summary remain pre-merge steps.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
+++ b/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-05 19:50'
-updated_date: '2026-09-06 00:04'
+updated_date: '2026-09-06 00:18'
 labels: []
 dependencies: []
 ---
@@ -35,6 +35,12 @@ ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-autho
 Corrected directional CASE placeholder recognition in the shared backend converter; preserved JSONB operators before CASE and after END. Ordinary SyncV2Store insertion now seeds receipt repair coverage, with real PostgreSQL/SQLite successive insertion, replay and nondecreasing domain-watermark assertions. Plan: Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md. ADR check: no new decision; existing ADR-002 governs unchanged Personal Context authority. RED: 11 parser failures and real PostgreSQL ordinary insertion failure, SQLite passed. Final focused verification: 109 passed (placeholder helpers, backend utilities, dual-backend ingress repair, bootstrap), TLDW_TEST_POSTGRES_REQUIRED=1. Ruff touched files and test formatting passed; production Bandit no findings; diff check passed. Independent plan and correctness review approved (reviewer additionally ran 18 parser tests). Broader selected store run: 94 passed, one pre-existing fake-backend receipt test failed with personal_context_link_binding_stale; reproduced after loading unchanged HEAD converter in memory, and neither that test nor Sync_DB changed. No full sweep, capability enablement, PR or merge. Added incident-based testing lesson. Backlog MCP search hung; CLI fallback used.
 
 Publication: opened https://github.com/rmusser01/tldw_server/pull/2909 against dev from reviewed source 6363466d07. Fresh pre-publication placeholder check: 18 passed, exit 0, existing warnings; diff check passed. Dependent conflict PR: https://github.com/rmusser01/tldw_server/pull/2910. No rebase or merge; current dev integration and human Change summary remain pre-merge steps.
+
+PR review round: rebase on current dev; verify all six Qodo findings, add missing test annotations/docstrings/category markers, preserve meaningful lower-sequence coverage, and document fixture/abstraction decisions with evidence. Run PostgreSQL-required ingress and parser tests, static checks and diff review before publication. Existing ADR-002 remains applicable; no new ADR required for test compliance fixes.
+
+Review evidence: rebased onto server dev 946e591ee9. Added CASE test type hints, docstrings and unit markers plus envelope/watermark test docs. Replaced direct private domain updater with public dataset re-enrollment; retained narrow read-only SQL assertion of persisted watermark so an envelope cursor cannot hide domain-state regression. No production inspection helper added solely for a test. The global pg_database_config fixture depends on function-scoped pg_temp_db with unique create/drop lifecycle; AuthNZ isolated_test_environment is a separate AuthNZ-only fixture, so its substitution is not applicable. Fresh two-file parser/ingress selection: 42 passed, 6 existing warnings, PostgreSQL required, exit 0. Ruff, test formatting, production Bandit and diff check passed. Independent scoped review pending.
+
+Independent scoped spec and quality review approved all review fixes and the documented inspection/fixture rationale with no actionable findings. All six Qodo items have a fix or evidence-backed disposition. Publishing this reviewed round only; no merge or capability change.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
+++ b/backlog/tasks/task-13192 - Fix-PostgreSQL-CASE-placeholders-in-ordinary-Sync-ingress.md
@@ -1,0 +1,46 @@
+---
+id: TASK-13192
+title: Fix PostgreSQL CASE placeholders in ordinary Sync ingress
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-05 19:50'
+updated_date: '2026-09-05 19:58'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ordinary PostgreSQL Sync envelope insertion fails because the shared placeholder converter treats CASE result binds as JSONB operators. Restore backend parity without changing Sync authority or conflict policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CASE-expression placeholders convert correctly while JSONB operators and quoted text remain unchanged
+- [x] #2 Real PostgreSQL and SQLite ordinary Personal Context ingress and monotonic domain watermarks are verified
+- [x] #3 Ingress repair tests use ordinary envelope insertion and targeted tests and static checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no. ADR path: backlog/decisions/002-personal-context-profile-authority-sync-and-encryption.md. Reason: preserve existing SQL and Sync contracts; correct shared parameter translation only. First add failing CASE and ordinary-ingress regressions, then minimally correct converter keyword handling, remove the raw-seed workaround, and run targeted backend plus PostgreSQL-required ingress tests. Record verification and review before closing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Corrected directional CASE placeholder recognition in the shared backend converter; preserved JSONB operators before CASE and after END. Ordinary SyncV2Store insertion now seeds receipt repair coverage, with real PostgreSQL/SQLite successive insertion, replay and nondecreasing domain-watermark assertions. Plan: Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md. ADR check: no new decision; existing ADR-002 governs unchanged Personal Context authority. RED: 11 parser failures and real PostgreSQL ordinary insertion failure, SQLite passed. Final focused verification: 109 passed (placeholder helpers, backend utilities, dual-backend ingress repair, bootstrap), TLDW_TEST_POSTGRES_REQUIRED=1. Ruff touched files and test formatting passed; production Bandit no findings; diff check passed. Independent plan and correctness review approved (reviewer additionally ran 18 parser tests). Broader selected store run: 94 passed, one pre-existing fake-backend receipt test failed with personal_context_link_binding_stale; reproduced after loading unchanged HEAD converter in memory, and neither that test nor Sync_DB changed. No full sweep, capability enablement, PR or merge. Added incident-based testing lesson. Backlog MCP search hung; CLI fallback used.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -1678,7 +1678,25 @@ def push_sync_v2_envelopes(
         dataset_id=result.dataset_id,
         accepted=[SyncPushAcceptedEnvelope(**asdict(item)) for item in result.accepted],
         rejected=[SyncPushRejectedEnvelope(**asdict(item)) for item in result.rejected],
-        conflicts=[SyncPushConflictEnvelope(**asdict(item)) for item in result.conflicts],
+        conflicts=[
+            SyncPushConflictEnvelope(
+                **{
+                    **asdict(item),
+                    "authority_candidate": (
+                        SyncV2EnvelopeResponse(
+                            **{
+                                **asdict(item.authority_candidate),
+                                "authority": item.authority_candidate.authority,
+                                "encryption_policy": "server_trusted_v1",
+                            }
+                        )
+                        if item.authority_candidate is not None
+                        else None
+                    ),
+                }
+            )
+            for item in result.conflicts
+        ],
         next_cursor=result.next_cursor,
         personal_context_exchange=result.personal_context_exchange,
     )

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -1124,6 +1124,7 @@ class PersonalContextRepository:
         domain: str,
         object_id: str,
         local_payload: Mapping[str, Any],
+        local_envelope_digest: str,
         purge_generation: int,
     ) -> dict[str, Any]:
         """Commit immutable heads and private narrow freezes before Sync reports conflict."""
@@ -1143,6 +1144,7 @@ class PersonalContextRepository:
                 "object_id": object_id,
                 "purge_generation": purge_generation,
                 "local_digest": self._canonical_digest(local_payload),
+                "local_envelope_digest": local_envelope_digest,
             }
             existing = self._sync_conflict_head(connection, profile_id, conflict_id)
             if existing is not None:
@@ -1205,6 +1207,7 @@ class PersonalContextRepository:
                 "candidate_object_id": str(current["object_id"]),
                 "candidate_version_id": str(current["version_id"]),
                 "candidate_created_at": str(current["created_at"]),
+                "integrity_key_id": f"personal-context-integrity-v{keys.integrity_key_version}",
                 "authority": {
                     "role": "home_authority",
                     "publication_batch_id": str(source["publication_batch_id"]),
@@ -1229,9 +1232,18 @@ class PersonalContextRepository:
         action: str,
         command: Mapping[str, Any] | None,
         purge_generation: int,
+        exchange: PersonalContextExchangeProof,
     ) -> dict[str, Any]:
         """Commit a reviewed choice and its exact replay receipt in one transaction."""
         with self._database.transaction(immediate=True) as connection:
+            self.validate_activation_exchange(
+                profile_id=profile_id,
+                device_id=device_id,
+                dataset_id=dataset_id,
+                activation_epoch=exchange.activation_epoch,
+                continuity_token=exchange.continuity_token,
+                _connection=connection,
+            )
             keys = self._keys.load(profile_id, connection=connection)
             row = self._sync_conflict_head(connection, profile_id, conflict_id)
             if row is None:
@@ -2234,6 +2246,7 @@ class PersonalContextRepository:
         dataset_id: str,
         activation_epoch: str,
         continuity_token: str,
+        _connection: sqlite3.Connection | None = None,
     ) -> PersonalContextExchangeProof:
         """Return the canonical proof only for an acknowledged current device baseline."""
         try:
@@ -2244,7 +2257,8 @@ class PersonalContextRepository:
             )
         except (TypeError, ValueError):
             raise PersonalContextActivationInputError("personal_context_activation_required") from None
-        with self._database.transaction() as connection:
+        transaction = self._database.transaction() if _connection is None else nullcontext(_connection)
+        with transaction as connection:
             row = connection.execute(
                 """SELECT a.* FROM personal_context_activations a
                    JOIN personal_context_activation_devices d ON d.activation_id = a.activation_id

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -38,6 +38,7 @@ from tldw_Server_API.app.core.exceptions import (
     PersonalContextActivationMissingError,
     PersonalContextActivationPendingError,
     PersonalContextActivationStaleError,
+    PersonalContextConflictInputError,
 )
 from tldw_Server_API.app.core.Personalization.personal_context_crypto import (
     EncryptedEnvelope,
@@ -1290,23 +1291,23 @@ class PersonalContextRepository:
                 if (None if head is None else str(head["version_id"])) != version:
                     raise ConcurrentProfileUpdateError("Personal Context conflict head changed")
             if (action == "skip") != (command is None):
-                raise ValueError("Personal Context resolution payload is invalid")
+                raise PersonalContextConflictInputError("Personal Context resolution payload is invalid")
             if command is not None:
                 target = command["object_id"]
                 if action == "overwrite" and target != journal["candidate_object_id"]:
-                    raise ValueError("Reviewed overwrite must name the shared canonical object")
+                    raise PersonalContextConflictInputError("Reviewed overwrite must name the shared canonical object")
                 if action == "duplicate_rename":
                     if journal["domain"] != "personal_context.record" or target in {
                         item[1] for item in journal["heads"]
                     }:
-                        raise ValueError("Personal Context duplicate requires a new record identity")
+                        raise PersonalContextConflictInputError(
+                            "Personal Context duplicate requires a new record identity"
+                        )
                     if self._head_row(connection, profile_id, "record", target) is not None:
                         raise ConcurrentProfileUpdateError("Personal Context duplicate identity already exists")
-                    if (
-                        self._conflict_key_slot(command["payload"]) == journal["key_slot"]
-                        and journal["key_slot"] is not None
-                    ):
-                        raise ValueError("Personal Context duplicate requires a free key")
+                    replacement_slot = self._conflict_key_slot(command["payload"])
+                    if replacement_slot is None or replacement_slot == journal["key_slot"]:
+                        raise PersonalContextConflictInputError("Personal Context duplicate requires a free key")
             # Only this exact journal is released within the same write transaction;
             # any error rolls this back, and other conflicts remain enforced.
             deciding = {**journal, "state": "resolving"}

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -11,7 +11,7 @@ import time
 import uuid
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager, nullcontext
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, TypeVar
 
@@ -74,6 +74,7 @@ _MAX_PROPOSAL_HEADS = 1_000
 _MAX_RECORD_HEADS = 1_000
 _MAX_SCOPE_HEADS = 1_000
 _MAX_LIST_ROWS = 1_000
+_MAX_CONFLICT_HEADS = 1_000
 _SYNC_HISTORY_KEY_LABEL = b"tldw-personal-context-sync-history-v1"
 _DIRECT_CONFIRMED_FULL_PROFILE_PURGE = object()
 _DIRECT_PURGE_CLEANUP_ORIGIN = "direct_confirmed_full_profile_purge"
@@ -416,6 +417,8 @@ class PersonalContextRepository:
         parent_version_id: str | None,
         value: BaseModel | Mapping[str, Any],
     ) -> None:
+        if object_type in {"record", "scope", "proposal"}:
+            self._require_unfrozen_object(connection, keys, object_type, object_id, value)
         plaintext = self._canonical_payload(value)
         aad = self._aad(
             profile_id,
@@ -1001,6 +1004,322 @@ class PersonalContextRepository:
 
         return self._read_model(profile_id, "manifest", profile_id, ProfileManifest)
 
+    def _sync_conflict_rows(self, connection: sqlite3.Connection, profile_id: str) -> list[sqlite3.Row]:
+        rows = connection.execute(
+            """SELECT versions.* FROM personal_context_object_heads AS heads
+               JOIN personal_context_object_versions AS versions
+                 ON versions.profile_id = heads.profile_id AND versions.object_type = heads.object_type
+                AND versions.object_id = heads.object_id AND versions.version_id = heads.current_version_id
+              WHERE heads.profile_id = ? AND heads.object_type = 'sync_conflict' LIMIT ?""",
+            (profile_id, _MAX_CONFLICT_HEADS + 1),
+        ).fetchall()
+        if len(rows) > _MAX_CONFLICT_HEADS:
+            raise ProfileQuotaExceededError("Personal Context conflict capacity exhausted")
+        return rows
+
+    def _require_unfrozen_object(
+        self,
+        connection: sqlite3.Connection,
+        keys: ProfileKeyMaterial,
+        object_type: str,
+        object_id: str,
+        value: BaseModel | Mapping[str, Any],
+    ) -> None:
+        """Check exact object and contested key ownership under the canonical write lock."""
+        payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else dict(value)
+        slot = self._conflict_key_slot(payload) if object_type == "record" else None
+        for row in self._sync_conflict_rows(connection, str(payload["profile_id"])):
+            journal = json.loads(self._decrypt_row(row, keys))
+            if journal["state"] != "unresolved":
+                continue
+            if [object_type, object_id] in [head[:2] for head in journal["heads"]] or (
+                slot is not None and slot == journal["key_slot"]
+            ):
+                raise ConcurrentProfileUpdateError("Personal Context object is frozen for review")
+
+    @staticmethod
+    def _conflict_key_slot(payload: Mapping[str, Any]) -> list[Any] | None:
+        if payload.get("state") != "active" or payload.get("semantic_key") is None:
+            return None
+        return [payload["scope_id"], payload["kind"], payload["semantic_key"]]
+
+    def _write_sync_conflict(
+        self,
+        connection: sqlite3.Connection,
+        keys: ProfileKeyMaterial,
+        journal: Mapping[str, Any],
+        *,
+        previous_version: str | None,
+        object_type: str = "sync_conflict",
+    ) -> None:
+        version = str(uuid.uuid4())
+        self._insert_encrypted(
+            connection,
+            keys,
+            profile_id=journal["profile_id"],
+            object_type=object_type,
+            object_id=journal["conflict_id"],
+            version_id=version,
+            parent_version_id=previous_version,
+            value=journal,
+        )
+        self._set_head(
+            connection,
+            profile_id=journal["profile_id"],
+            object_type=object_type,
+            object_id=journal["conflict_id"],
+            version_id=version,
+            expected_version_id=previous_version,
+        )
+
+    def _sync_conflict_head(
+        self, connection: sqlite3.Connection, profile_id: str, conflict_id: str
+    ) -> sqlite3.Row | None:
+        return self._head_row(connection, profile_id, "sync_conflict", conflict_id) or self._head_row(
+            connection,
+            profile_id,
+            "sync_conflict_receipt",
+            conflict_id,
+        )
+
+    def get_sync_conflict(self, profile_id: str, conflict_id: str) -> dict[str, Any]:
+        """Read the authenticated private conflict journal through canonical custody."""
+        with self._database.transaction() as connection:
+            keys = self._keys.load(profile_id, connection=connection)
+            row = self._sync_conflict_head(connection, profile_id, conflict_id)
+            if row is None:
+                raise ConcurrentProfileUpdateError("Personal Context conflict is unavailable")
+            return json.loads(self._decrypt_row(row, keys))
+
+    @contextmanager
+    def sync_conflict_staging_guard(
+        self,
+        profile_id: str,
+        conflict_id: str,
+        *,
+        dataset_id: str,
+        purge_generation: int,
+    ) -> Iterator[dict[str, Any]]:
+        """Keep canonical authority alive through local protected Sync attachment."""
+        with self._database.transaction(immediate=True) as connection:
+            keys = self._keys.load(profile_id, connection=connection)
+            manifest = self._current_manifest_for_publication(connection, profile_id, keys)
+            self._require_current_writable_manifest_state(connection, profile_id, keys)
+            row = self._sync_conflict_head(connection, profile_id, conflict_id)
+            if row is None or manifest.purge_generation != purge_generation:
+                raise ConcurrentProfileUpdateError("Personal Context conflict authority changed")
+            journal = json.loads(self._decrypt_row(row, keys))
+            if journal["dataset_id"] != dataset_id or journal["purge_generation"] != purge_generation:
+                raise ConcurrentProfileUpdateError("Personal Context conflict authority changed")
+            yield journal
+
+    def capture_sync_conflict(
+        self,
+        *,
+        profile_id: str,
+        conflict_id: str,
+        dataset_id: str,
+        device_id: str,
+        local_envelope_id: str,
+        domain: str,
+        object_id: str,
+        local_payload: Mapping[str, Any],
+        purge_generation: int,
+    ) -> dict[str, Any]:
+        """Commit immutable heads and private narrow freezes before Sync reports conflict."""
+        with self._database.transaction(immediate=True) as connection:
+            keys = self._keys.load(profile_id, connection=connection)
+            manifest = self._current_manifest_for_publication(connection, profile_id, keys)
+            self._require_current_writable_manifest_state(connection, profile_id, keys)
+            if manifest.purge_generation != purge_generation:
+                raise ConcurrentProfileUpdateError("Personal Context conflict generation changed")
+            identity = {
+                "profile_id": profile_id,
+                "conflict_id": conflict_id,
+                "dataset_id": dataset_id,
+                "device_id": device_id,
+                "local_envelope_id": local_envelope_id,
+                "domain": domain,
+                "object_id": object_id,
+                "purge_generation": purge_generation,
+                "local_digest": self._canonical_digest(local_payload),
+            }
+            existing = self._sync_conflict_head(connection, profile_id, conflict_id)
+            if existing is not None:
+                journal = json.loads(self._decrypt_row(existing, keys))
+                if any(journal.get(key) != value for key, value in identity.items()):
+                    raise ConcurrentProfileUpdateError("Personal Context conflict identity changed")
+                return journal
+            if len(self._sync_conflict_rows(connection, profile_id)) >= _MAX_CONFLICT_HEADS:
+                raise ProfileQuotaExceededError("Personal Context conflict capacity exhausted")
+            object_type = domain.removeprefix("personal_context.")
+            current = self._head_row(connection, profile_id, object_type, object_id)
+            heads = [[object_type, object_id, None if current is None else str(current["version_id"])]]
+            contested_slot = None
+            if object_type == "record":
+                slot = self._conflict_key_slot(local_payload)
+                if slot is not None:
+                    record_rows = connection.execute(
+                        """SELECT versions.* FROM personal_context_object_heads AS heads
+                           JOIN personal_context_object_versions AS versions
+                             ON versions.profile_id = heads.profile_id AND versions.object_type = heads.object_type
+                            AND versions.object_id = heads.object_id AND versions.version_id = heads.current_version_id
+                          WHERE heads.profile_id = ? AND heads.object_type = 'record' LIMIT ?""",
+                        (profile_id, _MAX_RECORD_HEADS + 1),
+                    ).fetchall()
+                    if len(record_rows) > _MAX_RECORD_HEADS:
+                        raise ProfileQuotaExceededError("record head quota exceeded")
+                    for record_row in record_rows:
+                        record = ProfileRecord.model_validate_json(self._decrypt_row(record_row, keys))
+                        if (
+                            record.record_id != object_id
+                            and self._conflict_key_slot(record.model_dump(mode="json")) == slot
+                            and (record.expires_at is None or record.expires_at > datetime.now(UTC))
+                        ):
+                            current = self._head_row(connection, profile_id, "record", record.record_id)
+                            heads.append(["record", record.record_id, record.version_id])
+                            contested_slot = slot
+                            break
+            if current is None:
+                raise ConcurrentProfileUpdateError("Personal Context authority candidate is unavailable")
+            payload = json.loads(self._decrypt_row(current, keys))
+            source = connection.execute(
+                """SELECT * FROM personal_context_publication_rows
+                    WHERE profile_id = ? AND opaque_object_id = ? AND opaque_version_id = ?
+                    ORDER BY profile_publication_sequence DESC LIMIT 1""",
+                (profile_id, current["object_id"], current["version_id"]),
+            ).fetchone()
+            if source is None:
+                raise ConcurrentProfileUpdateError("Personal Context candidate publication is unavailable")
+            # A dedicated candidate identity never competes with normal publication lineage.
+            candidate_id = str(
+                uuid.uuid5(uuid.NAMESPACE_URL, f"tldw:personal-context:candidate:{conflict_id}:{current['version_id']}")
+            )
+            journal = {
+                **identity,
+                "state": "unresolved",
+                "heads": heads,
+                "key_slot": contested_slot,
+                "remote_envelope_id": candidate_id,
+                "candidate": payload,
+                "candidate_object_id": str(current["object_id"]),
+                "candidate_version_id": str(current["version_id"]),
+                "candidate_created_at": str(current["created_at"]),
+                "authority": {
+                    "role": "home_authority",
+                    "publication_batch_id": str(source["publication_batch_id"]),
+                    "profile_publication_sequence": int(source["profile_publication_sequence"]),
+                    "batch_ordinal": int(source["batch_ordinal"]),
+                    "batch_size": int(source["batch_size"]),
+                },
+            }
+            self._write_sync_conflict(connection, keys, journal, previous_version=None)
+            return journal
+
+    def resolve_sync_conflict(
+        self,
+        *,
+        profile_id: str,
+        conflict_id: str,
+        dataset_id: str,
+        device_id: str,
+        expected_local_envelope_id: str,
+        expected_remote_envelope_id: str,
+        idempotency_key: str,
+        action: str,
+        command: Mapping[str, Any] | None,
+        purge_generation: int,
+    ) -> dict[str, Any]:
+        """Commit a reviewed choice and its exact replay receipt in one transaction."""
+        with self._database.transaction(immediate=True) as connection:
+            keys = self._keys.load(profile_id, connection=connection)
+            row = self._sync_conflict_head(connection, profile_id, conflict_id)
+            if row is None:
+                raise ConcurrentProfileUpdateError("Personal Context conflict is unavailable")
+            journal = json.loads(self._decrypt_row(row, keys))
+            manifest = self._current_manifest_for_publication(connection, profile_id, keys)
+            if (
+                journal["dataset_id"] != dataset_id
+                or journal["device_id"] != device_id
+                or journal["local_envelope_id"] != expected_local_envelope_id
+                or journal["remote_envelope_id"] != expected_remote_envelope_id
+                or journal["purge_generation"] != purge_generation
+                or manifest.purge_generation != purge_generation
+                or action not in {"skip", "overwrite", "duplicate_rename"}
+                or not idempotency_key
+            ):
+                raise ConcurrentProfileUpdateError("Personal Context conflict review is stale")
+            digest = self._canonical_digest({"action": action, "command": command})
+            if journal["state"] == "resolved":
+                if journal["command_digest"] != digest or journal["idempotency_key"] != idempotency_key:
+                    raise ConcurrentProfileUpdateError("Personal Context resolution command changed")
+                return journal["receipt"]
+            for head_type, head_id, version in journal["heads"]:
+                head = self._head_row(connection, profile_id, head_type, head_id)
+                if (None if head is None else str(head["version_id"])) != version:
+                    raise ConcurrentProfileUpdateError("Personal Context conflict head changed")
+            if (action == "skip") != (command is None):
+                raise ValueError("Personal Context resolution payload is invalid")
+            if command is not None:
+                target = command["object_id"]
+                if action == "overwrite" and target != journal["candidate_object_id"]:
+                    raise ValueError("Reviewed overwrite must name the shared canonical object")
+                if action == "duplicate_rename":
+                    if journal["domain"] != "personal_context.record" or target in {
+                        item[1] for item in journal["heads"]
+                    }:
+                        raise ValueError("Personal Context duplicate requires a new record identity")
+                    if self._head_row(connection, profile_id, "record", target) is not None:
+                        raise ConcurrentProfileUpdateError("Personal Context duplicate identity already exists")
+                    if (
+                        self._conflict_key_slot(command["payload"]) == journal["key_slot"]
+                        and journal["key_slot"] is not None
+                    ):
+                        raise ValueError("Personal Context duplicate requires a free key")
+            # Only this exact journal is released within the same write transaction;
+            # any error rolls this back, and other conflicts remain enforced.
+            deciding = {**journal, "state": "resolving"}
+            self._write_sync_conflict(connection, keys, deciding, previous_version=str(row["version_id"]))
+            receipt: dict[str, Any] = {
+                "action": action,
+                "resulting_object_id": journal["candidate_object_id"],
+                "publication_batch_id": None,
+            }
+            if command is not None:
+                result = self.apply_ingress_and_publish(
+                    identity=IngressIdentity(
+                        dataset_id=dataset_id,
+                        device_id=device_id,
+                        client_envelope_id=command["client_envelope_id"],
+                        canonical_payload_digest=self._canonical_digest(command["payload"]),
+                        purge_generation=purge_generation,
+                        wire_entity_version=str(command["entity_version"]),
+                    ),
+                    domain=journal["domain"],
+                    value=command["payload"],
+                    base_object_hash=command["base_object_hash"],
+                    _resolution_connection=connection,
+                )
+                receipt = {"action": action, **asdict(result)}
+            self._write_sync_conflict(
+                connection,
+                keys,
+                {
+                    **journal,
+                    "state": "resolved",
+                    "idempotency_key": idempotency_key,
+                    "command_digest": digest,
+                    "receipt": receipt,
+                },
+                previous_version=None,
+                object_type="sync_conflict_receipt",
+            )
+            connection.execute(
+                "DELETE FROM personal_context_object_heads WHERE profile_id = ? AND object_type = 'sync_conflict' AND object_id = ?",
+                (profile_id, conflict_id),
+            )
+            return receipt
+
     def apply_ingress_and_publish(
         self,
         *,
@@ -1008,10 +1327,16 @@ class PersonalContextRepository:
         domain: str,
         value: ProfileManifest | ProfileScope | ProfileRecord | ProfileProposal | Mapping[str, Any],
         base_object_hash: str | None,
+        _resolution_connection: sqlite3.Connection | None = None,
     ) -> CanonicalApplyReceipt:
         """Atomically accept one ingress object and its authority publication."""
 
-        with self._database.transaction(immediate=True) as connection:
+        transaction = (
+            self._database.transaction(immediate=True)
+            if _resolution_connection is None
+            else nullcontext(_resolution_connection)
+        )
+        with transaction as connection:
             if domain == "personal_context.record":
                 record = ProfileRecord.model_validate(value)
                 if record.controls.sync_mode is SyncMode.DEVICE_ONLY:
@@ -1069,9 +1394,10 @@ class PersonalContextRepository:
             if identity.wire_entity_version != expected_wire_version:
                 raise ValueError("ingress wire entity version is invalid")
             keys = self._keys.load(profile_id, connection=connection)
-            replay = PersonalContextPublicationJournal(keys).read_ingress_receipt(
-                connection,
-                identity,
+            replay = (
+                PersonalContextPublicationJournal(keys).read_ingress_receipt(connection, identity)
+                if _resolution_connection is None
+                else None
             )
             if replay is not None:
                 return replay
@@ -1092,7 +1418,10 @@ class PersonalContextRepository:
                     connection, keys, manifest, expected_version_id=current.current_version_id
                 )
                 batch = self._append_publication(
-                    connection, keys, manifest=manifest, ingress=identity
+                    connection,
+                    keys,
+                    manifest=manifest,
+                    ingress=identity if _resolution_connection is None else None,
                 )
                 return CanonicalApplyReceipt(
                     resulting_object_id=manifest.profile_id,
@@ -1260,8 +1589,11 @@ class PersonalContextRepository:
                 version_id=version_id, operation=operation,
             )
             batch = self._append_publication(
-                connection, keys, manifest=next_manifest,
-                semantic=(semantic,), ingress=identity,
+                connection,
+                keys,
+                manifest=next_manifest,
+                semantic=(semantic,),
+                ingress=identity if _resolution_connection is None else None,
             )
             return CanonicalApplyReceipt(
                 resulting_object_id=object_id,

--- a/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Personal_Context_Repository.py
@@ -1098,10 +1098,20 @@ class PersonalContextRepository:
         conflict_id: str,
         *,
         dataset_id: str,
+        device_id: str,
         purge_generation: int,
+        exchange: PersonalContextExchangeProof,
     ) -> Iterator[dict[str, Any]]:
         """Keep canonical authority alive through local protected Sync attachment."""
         with self._database.transaction(immediate=True) as connection:
+            self.validate_activation_exchange(
+                profile_id=profile_id,
+                device_id=device_id,
+                dataset_id=dataset_id,
+                activation_epoch=exchange.activation_epoch,
+                continuity_token=exchange.continuity_token,
+                _connection=connection,
+            )
             keys = self._keys.load(profile_id, connection=connection)
             manifest = self._current_manifest_for_publication(connection, profile_id, keys)
             self._require_current_writable_manifest_state(connection, profile_id, keys)
@@ -1109,7 +1119,7 @@ class PersonalContextRepository:
             if row is None or manifest.purge_generation != purge_generation:
                 raise ConcurrentProfileUpdateError("Personal Context conflict authority changed")
             journal = json.loads(self._decrypt_row(row, keys))
-            if journal["dataset_id"] != dataset_id or journal["purge_generation"] != purge_generation:
+            if journal["dataset_id"] != dataset_id or journal["device_id"] != device_id or journal["purge_generation"] != purge_generation:
                 raise ConcurrentProfileUpdateError("Personal Context conflict authority changed")
             yield journal
 
@@ -1126,9 +1136,18 @@ class PersonalContextRepository:
         local_payload: Mapping[str, Any],
         local_envelope_digest: str,
         purge_generation: int,
+        exchange: PersonalContextExchangeProof,
     ) -> dict[str, Any]:
         """Commit immutable heads and private narrow freezes before Sync reports conflict."""
         with self._database.transaction(immediate=True) as connection:
+            self.validate_activation_exchange(
+                profile_id=profile_id,
+                device_id=device_id,
+                dataset_id=dataset_id,
+                activation_epoch=exchange.activation_epoch,
+                continuity_token=exchange.continuity_token,
+                _connection=connection,
+            )
             keys = self._keys.load(profile_id, connection=connection)
             manifest = self._current_manifest_for_publication(connection, profile_id, keys)
             self._require_current_writable_manifest_state(connection, profile_id, keys)

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -2795,6 +2795,15 @@ class SyncDatabase:
                        AND status = 'accepted'
                        AND server_sequence < ?
                        AND apply_status NOT IN ('applied', 'superseded')
+                       AND NOT (
+                           domain IN ('personal_context.record', 'personal_context.scope', 'personal_context.proposal', 'personal_context.manifest', 'personal_context.purge') AND apply_status = 'conflict'
+                           AND EXISTS (
+                               SELECT 1 FROM sync_conflicts AS review
+                                WHERE review.dataset_id = sync_envelopes.dataset_id
+                                  AND review.server_sequence = sync_envelopes.server_sequence
+                                  AND review.status = 'unresolved' AND review.remote_envelope_id IS NOT NULL
+                           )
+                       )
                      ORDER BY server_sequence ASC
                      LIMIT 1
                     """,
@@ -7530,6 +7539,7 @@ class SyncDatabase:
                    AND conflict.status = 'unresolved'
                    AND envelope.status = 'accepted'
                    AND envelope.apply_status = 'conflict'
+                   AND conflict.domain NOT IN ('personal_context.record', 'personal_context.scope', 'personal_context.proposal', 'personal_context.manifest', 'personal_context.purge')
                  ORDER BY envelope.server_sequence ASC
                  LIMIT 1
                 """,
@@ -8913,6 +8923,8 @@ class SyncDatabase:
                 return "applied"
             if row.get("apply_status") != "pending":
                 return "mismatch"
+            if self.envelope_is_conflict_pinned(dataset_id, client_envelope_id, connection=connection):
+                return "mismatch"
             current = _first(
                 self.execute(
                     """SELECT latest_server_cursor FROM sync_current_heads
@@ -10194,6 +10206,44 @@ class SyncDatabase:
             return None
         return _conflict_from_row(row)
 
+    def list_conflict_pinned_envelopes(
+        self,
+        dataset_id: str,
+        *,
+        limit: int = 1000,
+        connection: Any | None = None,
+    ) -> list[SyncEnvelope]:
+        """Return immutable candidates still owned by an unresolved review."""
+        rows = self.execute(
+            """SELECT envelope.* FROM sync_envelopes AS envelope
+                WHERE envelope.dataset_id = ? AND EXISTS (
+                    SELECT 1 FROM sync_conflicts AS review
+                     WHERE review.dataset_id = envelope.dataset_id AND review.status = 'unresolved'
+                       AND (review.local_envelope_id = envelope.client_envelope_id
+                         OR review.remote_envelope_id = envelope.client_envelope_id)
+                ) ORDER BY envelope.server_sequence LIMIT ?""",
+            (dataset_id, limit),
+            connection=connection,
+        ).rows
+        return [_envelope_from_row(row) for row in rows]
+
+    def envelope_is_conflict_pinned(
+        self,
+        dataset_id: str,
+        envelope_id: str,
+        *,
+        connection: Any | None = None,
+    ) -> bool:
+        """Check retention ownership in the caller's guarded storage transaction."""
+        return bool(
+            self.execute(
+                """SELECT 1 FROM sync_conflicts WHERE dataset_id = ? AND status = 'unresolved'
+                 AND (local_envelope_id = ? OR remote_envelope_id = ?) LIMIT 1""",
+                (dataset_id, envelope_id, envelope_id),
+                connection=connection,
+            ).rows
+        )
+
     def get_unresolved_conflict_for_envelope(
         self,
         dataset_id: str,
@@ -10439,11 +10489,11 @@ class SyncDatabase:
                             AND resolution_action = ?
                             AND (
                                 resolved_by_device_id = ?
-                                OR (resolved_by_device_id IS NULL AND ? IS NULL)
+                                OR (resolved_by_device_id IS NULL AND CAST(? AS TEXT) IS NULL)
                             )
                             AND (
                                 resolution_notes = ?
-                                OR (resolution_notes IS NULL AND ? IS NULL)
+                                OR (resolution_notes IS NULL AND CAST(? AS TEXT) IS NULL)
                             )
                         )
                    )
@@ -12455,6 +12505,18 @@ class SyncDatabase:
         now = utcnow_iso()
         with self.backend.transaction(connection) as conn:
             self._require_dataset_domain(dataset_id, domain, connection=conn)
+            pinned = self.execute(
+                """SELECT 1 FROM sync_envelopes AS envelope
+                    WHERE envelope.dataset_id = ? AND envelope.domain = ? AND envelope.server_sequence <= ?
+                      AND EXISTS (SELECT 1 FROM sync_conflicts AS review
+                          WHERE review.dataset_id = envelope.dataset_id AND review.status = 'unresolved'
+                            AND (review.local_envelope_id = envelope.client_envelope_id
+                              OR review.remote_envelope_id = envelope.client_envelope_id)) LIMIT 1""",
+                (dataset_id, domain, through_server_sequence),
+                connection=conn,
+            ).rows
+            if pinned:
+                raise SyncStoreError("retention_conflict_pinned")
             existing = _first(
                 self.execute(
                     """

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -7895,7 +7895,22 @@ class SyncDatabase:
         *,
         connection: Any,
     ) -> SyncEnvelope:
-        now = utcnow_iso()
+        authority = envelope.routing_metadata.get("personal_context_authority")
+        protected_conflict_candidate = (
+            envelope.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
+            and envelope.status == "conflict"
+            and envelope.apply_status == "applied"
+            and envelope.device_id == "server-origin"
+            and bool(envelope.payload_ciphertext)
+            and bool(envelope.routing_metadata.get("personal_context_conflict_candidate"))
+            and isinstance(authority, Mapping)
+            and authority.get("role") == "home_authority"
+        )
+        # Canonical candidate custody fixes these bytes before any Sync allocation.
+        # Ordinary client ingress still receives the server's actual arrival time.
+        now = envelope.received_at_server if protected_conflict_candidate else utcnow_iso()
+        if not now:
+            raise SyncStoreError("Personal Context candidate timestamp is unavailable")
         self.execute(
             """
             INSERT INTO sync_envelopes (

--- a/tldw_Server_API/app/core/DB_Management/backends/query_utils.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/query_utils.py
@@ -91,6 +91,12 @@ def convert_sqlite_placeholders_to_postgres(query: str) -> str:
             return True
         prev_token = _prev_token(idx)
         next_token = _next_token(idx)
+        # CASE introduces expressions on the left; END closes one on the right.
+        # Keep `CASE ... END ? 'key'` and `payload ? CASE ... END` as JSONB.
+        if prev_token in {"CASE", "WHEN", "THEN", "ELSE"} or next_token in {
+            "WHEN", "THEN", "ELSE", "END",
+        }:
+            return False
         if prev_token in {
             "LIMIT",
             "OFFSET",

--- a/tldw_Server_API/app/core/Personalization/personal_context_service.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_service.py
@@ -774,10 +774,14 @@ class PersonalContextService:
         """Hold this user's canonical authority through local candidate attachment."""
         return self._repository.sync_conflict_staging_guard(self._profile_id(), conflict_id, **identity)
 
-    def resolve_sync_conflict(self, **command: Any) -> dict[str, Any]:
+    def resolve_sync_conflict(self, *, defer_relay: bool = False, **command: Any) -> dict[str, Any]:
         """Apply a reviewed exact choice through the canonical mutation authority."""
         try:
-            return self._repository.resolve_sync_conflict(profile_id=self._profile_id(), **command)
+            profile_id = self._profile_id()
+            receipt = self._repository.resolve_sync_conflict(profile_id=profile_id, **command)
+            if not defer_relay and receipt.get("publication_batch_id") is not None:
+                self._relay_after_commit(profile_id)
+            return receipt
         except (ConcurrentProfileUpdateError, ProfileSemanticKeyCollisionError) as exc:
             raise ProfileConflictError("Personal Context conflict review changed") from exc
 

--- a/tldw_Server_API/app/core/Personalization/personal_context_service.py
+++ b/tldw_Server_API/app/core/Personalization/personal_context_service.py
@@ -762,6 +762,25 @@ class PersonalContextService:
         except (ConcurrentProfileUpdateError, ProfileSemanticKeyCollisionError) as exc:
             raise ProfileConflictError("Personal context changed concurrently") from exc
 
+    def capture_sync_conflict(self, **identity: Any) -> dict[str, Any]:
+        """Capture private canonical candidates and freezes for authenticated Sync ingress."""
+        return self._repository.capture_sync_conflict(profile_id=self._profile_id(), **identity)
+
+    def get_sync_conflict(self, conflict_id: str) -> dict[str, Any]:
+        """Load a private conflict journal within this authenticated user's profile."""
+        return self._repository.get_sync_conflict(self._profile_id(), conflict_id)
+
+    def sync_conflict_staging_guard(self, conflict_id: str, **identity: Any) -> Any:
+        """Hold this user's canonical authority through local candidate attachment."""
+        return self._repository.sync_conflict_staging_guard(self._profile_id(), conflict_id, **identity)
+
+    def resolve_sync_conflict(self, **command: Any) -> dict[str, Any]:
+        """Apply a reviewed exact choice through the canonical mutation authority."""
+        try:
+            return self._repository.resolve_sync_conflict(profile_id=self._profile_id(), **command)
+        except (ConcurrentProfileUpdateError, ProfileSemanticKeyCollisionError) as exc:
+            raise ProfileConflictError("Personal Context conflict review changed") from exc
+
     def get_manifest(self) -> ProfileManifest:
         """Return the authenticated user's manifest."""
 

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
@@ -151,6 +151,22 @@ class PersonalContextDomainAdapter:
 
         head = _current_object_head(envelope, context)
         if head is not None and not _references_head(envelope, head, value):
+            if self.domain == "personal_context.purge":
+                # Push verifies the full immutable fingerprint before evaluation
+                # and insertion; an exact stored ingress may retry its failed apply.
+                if (
+                    envelope.routing_metadata.get("personal_context_authority", {}).get("role") == "client_ingress"
+                    and envelope.client_envelope_id == head.client_envelope_id
+                    and envelope.device_id == head.device_id
+                    and envelope.payload_hash == head.payload_hash
+                ):
+                    return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+                return AdapterRejected(
+                    client_envelope_id=envelope.client_envelope_id,
+                    error_code="personal_context_purge_reconfirmation_required",
+                    message="Refresh Personal Context and explicitly reconfirm delete-everywhere.",
+                    retryable=False,
+                )
             return AdapterConflict(
                 client_envelope_id=envelope.client_envelope_id,
                 domain=self.domain,

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
@@ -85,6 +85,11 @@ class PersonalContextDomainAdapter:
 
         if envelope.domain != self.domain:
             return self._reject(envelope, "personal_context_domain_mismatch")
+        if (
+            self.domain == "personal_context.manifest"
+            and envelope.routing_metadata.get("personal_context_authority", {}).get("role") == "client_ingress"
+        ):
+            return self._reject(envelope, "personal_context_manifest_client_forbidden")
         if envelope.adapter_version != 1 or envelope.schema_version != 1:
             return self._reject(envelope, "personal_context_schema_unsupported")
         if dataset.encryption_policy != "server_trusted_v1":

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py
@@ -126,6 +126,11 @@ class PersonalContextDomainAdapter:
 
         try:
             value = _parse_payload(self.domain, payload)
+            if (
+                self.domain == "personal_context.purge"
+                and value["purge_generation"] != dataset_state["purge_generation"] + 1
+            ):
+                return self._reject(envelope, "personal_context_purge_generation_invalid")
             _validate_envelope_identity(
                 envelope,
                 value,
@@ -388,8 +393,6 @@ def _validate_envelope_identity(
             value["profile_id"],
         )
         entity_version = value["purge_generation"]
-        if value["purge_generation"] != purge_generation + 1:
-            raise PersonalContextSyncIdentityConflict
     if (
         object_id != envelope.object_id
         or parent_id != envelope.parent_id

--- a/tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py
@@ -55,6 +55,12 @@ class PersonalContextMaterializer:
         del guarded_mutation
         if envelope.domain != self.domain:
             return MaterializationResult(status="skipped")
+        if (
+            self.domain == "personal_context.manifest"
+            and envelope.authority is not None
+            and envelope.authority.role == "client_ingress"
+        ):
+            return self._fail(envelope, store, "personal_context_manifest_client_forbidden")
         if envelope.server_cursor is None:
             return MaterializationResult(
                 status="failed",

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
@@ -1,0 +1,225 @@
+"""Journaled Personal Context candidate delivery and explicit batched choices."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import uuid
+from dataclasses import asdict
+from typing import Any
+
+from tldw_profile_core.canonical import canonical_json_bytes
+
+from .adapters import AdapterAccepted
+from .errors import SyncStoreError
+from .models import SyncConflictCreate, SyncEnvelopeCreate
+
+
+class PersonalContextConflictService:
+    """Bridge Sync transport decisions to user-bound canonical authority."""
+
+    def __init__(self, sync: Any, store: Any) -> None:
+        self.sync = sync
+        self.store = store
+
+    @staticmethod
+    def conflict_id(dataset_id: str, device_id: str, envelope_id: str) -> str:
+        return str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"tldw:personal-context:conflict:{dataset_id}:{device_id}:{envelope_id}")
+        )
+
+    def ensure_authority_candidate(self, *, dataset: Any, source: Any) -> Any:
+        """Attach an authenticated immutable candidate before a terminal response."""
+        canonical = self.sync._personal_context_service_for_user(dataset.owner_user_id)
+        clear = self.sync._restore_personal_context_from_storage(dataset, source)
+        state = dataset.metadata["personal_context"]
+        if canonical.get_manifest().profile_id != state["profile_id"]:
+            raise SyncStoreError("Personal Context authority binding changed")
+        conflict_id = self.conflict_id(dataset.dataset_id, str(source.device_id), source.client_envelope_id)
+        canonical.capture_sync_conflict(
+            conflict_id=conflict_id,
+            dataset_id=dataset.dataset_id,
+            device_id=source.device_id,
+            local_envelope_id=source.client_envelope_id,
+            domain=source.domain,
+            object_id=source.object_id,
+            local_payload=clear.payload,
+            purge_generation=state["purge_generation"],
+        )
+        with canonical.sync_conflict_staging_guard(
+            conflict_id,
+            dataset_id=dataset.dataset_id,
+            purge_generation=state["purge_generation"],
+        ) as journal:
+            return self._attach_candidate(dataset, source, canonical, journal)
+
+    def _attach_candidate(self, dataset: Any, source: Any, canonical: Any, journal: Any) -> Any:
+        from .service import SyncPushConflict
+
+        state = dataset.metadata["personal_context"]
+        conflict_id = journal["conflict_id"]
+        candidate = self.store.get_envelope_by_client_id(dataset.dataset_id, journal["remote_envelope_id"])
+        if candidate is None:
+            key_id, key = canonical.sync_integrity_key(state["profile_id"])
+            payload = journal["candidate"]
+            encoded = canonical_json_bytes(payload)
+            version = journal["candidate_version_id"]
+            if source.domain == "personal_context.proposal":
+                version = "sync-proposal-sha256:" + hashlib.sha256(encoded).hexdigest()
+            envelope = SyncEnvelopeCreate(
+                dataset_id=dataset.dataset_id,
+                device_id="server-origin",
+                client_envelope_id=journal["remote_envelope_id"],
+                domain=source.domain,
+                object_id=journal["candidate_object_id"],
+                entity_version=version,
+                parent_id=payload.get("profile_id")
+                if source.domain == "personal_context.scope"
+                else payload.get("scope_id"),
+                operation="tombstone" if payload.get("state") == "deleted" else "upsert",
+                payload=payload,
+                payload_size_bytes=len(encoded),
+                payload_hash="hmac-sha256-v1:" + hmac.new(key, encoded, hashlib.sha256).hexdigest(),
+                created_at_client=journal["candidate_created_at"],
+                received_at_server=journal["candidate_created_at"],
+                # Candidates are delivered only by conflict review. They must never
+                # advance current heads or masquerade as a new publication batch.
+                status="conflict",
+                apply_status="applied",
+                routing_metadata={
+                    "profile_id": state["profile_id"],
+                    "purge_generation": state["purge_generation"],
+                    "integrity_key_id": key_id,
+                    "personal_context_conflict_candidate": conflict_id,
+                    "personal_context_authority": journal["authority"],
+                },
+            )
+            candidate = self.store.insert_envelope(self.sync._protect_personal_context_for_storage(dataset, envelope))
+        clear_candidate = self.sync._restore_personal_context_from_storage(dataset, candidate)
+        if (
+            clear_candidate.payload != journal["candidate"]
+            or clear_candidate.object_id != journal["candidate_object_id"]
+            or clear_candidate.device_id != "server-origin"
+            or clear_candidate.authority is None
+            or clear_candidate.authority.model_dump(mode="json") != journal["authority"]
+            or clear_candidate.apply_status != "applied"
+            or clear_candidate.routing_metadata.get("personal_context_conflict_candidate") != conflict_id
+        ):
+            raise SyncStoreError("Personal Context conflict candidate authentication failed")
+        conflict = self.store.insert_conflict(
+            SyncConflictCreate(
+                conflict_id=conflict_id,
+                dataset_id=dataset.dataset_id,
+                domain=source.domain,
+                object_id=source.object_id,
+                conflict_type="personal_context_key_collision"
+                if journal["key_slot"] is not None
+                else "personal_context_base_conflict",
+                local_envelope_id=source.client_envelope_id,
+                remote_envelope_id=candidate.client_envelope_id,
+                server_cursor=source.server_cursor,
+            )
+        )
+        return SyncPushConflict(
+            conflict_id=conflict.conflict_id,
+            client_envelope_id=source.client_envelope_id,
+            domain=source.domain,
+            entity_id=source.object_id,
+            server_sequence=source.server_sequence,
+            message="Personal Context requires review",
+            expected_local_envelope_id=source.client_envelope_id,
+            expected_remote_envelope_id=candidate.client_envelope_id,
+            authority_candidate=clear_candidate,
+        )
+
+    def resolve_batch_item(
+        self,
+        *,
+        user_id: str,
+        dataset: Any,
+        device_id: str,
+        conflict: Any,
+        action: str,
+        resolution_envelope: Any,
+        expected_local_envelope_id: str,
+        expected_remote_envelope_id: str,
+        idempotency_key: str,
+    ) -> Any:
+        """Validate transport identity and finalize only after the canonical receipt."""
+        self.sync._require_registered_device(user_id, device_id, store=self.store)
+        if (
+            conflict.local_envelope_id != expected_local_envelope_id
+            or conflict.remote_envelope_id != expected_remote_envelope_id
+            or not idempotency_key
+            or action not in {"skip", "overwrite", "duplicate_rename"}
+            or (action == "skip") != (resolution_envelope is None)
+        ):
+            raise SyncStoreError("Personal Context conflict review is stale")
+        source = self.store.get_envelope_by_server_cursor(conflict.server_sequence)
+        remote = self.store.get_envelope_by_client_id(dataset.dataset_id, expected_remote_envelope_id)
+        if (
+            source is None
+            or remote is None
+            or source.dataset_id != dataset.dataset_id
+            or source.device_id != device_id
+            or source.client_envelope_id != expected_local_envelope_id
+            or source.object_id != conflict.object_id
+            or source.domain != conflict.domain
+        ):
+            raise SyncStoreError("Personal Context conflict candidate is unavailable")
+        canonical = self.sync._personal_context_service_for_user(user_id)
+        journal = canonical.get_sync_conflict(conflict.conflict_id)
+        restored = self.sync._restore_personal_context_from_storage(dataset, remote)
+        if restored.payload != journal["candidate"] or restored.object_id != journal["candidate_object_id"]:
+            raise SyncStoreError("Personal Context conflict candidate authentication failed")
+        command = None
+        if resolution_envelope is not None:
+            if (
+                resolution_envelope.dataset_id != dataset.dataset_id
+                or resolution_envelope.device_id != device_id
+                or resolution_envelope.domain != conflict.domain
+                or set(resolution_envelope.routing_metadata) - {"profile_id", "purge_generation", "integrity_key_id"}
+                or resolution_envelope.routing_metadata.get("purge_generation") != journal["purge_generation"]
+                or self.sync._payload_exceeds_size_limit(resolution_envelope)
+            ):
+                raise SyncStoreError("Personal Context resolution envelope identity is invalid")
+            adapter = self.sync.adapters.get(conflict.domain)
+            # Canonical storage checks exact current heads inside its write transaction.
+            if not isinstance(adapter.evaluate_envelope(resolution_envelope, dataset=dataset), AdapterAccepted):
+                raise SyncStoreError("Personal Context resolution envelope is invalid")
+            command = asdict(resolution_envelope)
+        receipt = canonical.resolve_sync_conflict(
+            conflict_id=conflict.conflict_id,
+            dataset_id=dataset.dataset_id,
+            device_id=device_id,
+            expected_local_envelope_id=expected_local_envelope_id,
+            expected_remote_envelope_id=expected_remote_envelope_id,
+            idempotency_key=idempotency_key,
+            action=action,
+            command=command,
+            purge_generation=dataset.metadata["personal_context"]["purge_generation"],
+        )
+        if conflict.status == "unresolved":
+            self.store.claim_conflict_resolution(
+                conflict.conflict_id,
+                dataset_id=dataset.dataset_id,
+                resolved_by_device_id=device_id,
+                resolution_action=action,
+                resolution_notes=None,
+            )
+            self.store.terminalize_claimed_conflict_envelope(
+                conflict.conflict_id,
+                dataset_id=dataset.dataset_id,
+                resolved_by_device_id=device_id,
+                resolution_action=action,
+                resolution_notes=None,
+                apply_error_code="personal_context_conflict_resolved",
+            )
+        return self.store.resolve_conflict(
+            conflict.conflict_id,
+            dataset_id=dataset.dataset_id,
+            status="dismissed" if action == "skip" else "resolved",
+            resolved_by_device_id=device_id,
+            resolution_action=action,
+            resolved_by_envelope_id=receipt.get("receipt_id"),
+        )

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
@@ -12,7 +12,7 @@ from tldw_profile_core.canonical import canonical_json_bytes
 
 from .adapters import AdapterAccepted
 from .errors import SyncStoreError
-from .models import SyncConflictCreate, SyncEnvelopeCreate
+from .models import SyncConflictCreate, SyncEnvelopeCreate, normalize_sync_timestamp
 
 
 class PersonalContextConflictService:
@@ -44,6 +44,7 @@ class PersonalContextConflictService:
             domain=source.domain,
             object_id=source.object_id,
             local_payload=clear.payload,
+            local_envelope_digest=self._local_envelope_digest(clear),
             purge_generation=state["purge_generation"],
         )
         with canonical.sync_conflict_staging_guard(
@@ -53,59 +54,88 @@ class PersonalContextConflictService:
         ) as journal:
             return self._attach_candidate(dataset, source, canonical, journal)
 
+    def _candidate_envelope(self, dataset: Any, canonical: Any, journal: Any) -> SyncEnvelopeCreate:
+        """Reconstruct every immutable review field from canonical custody."""
+        state = dataset.metadata["personal_context"]
+        key_id, key = canonical.sync_integrity_key(journal["profile_id"])
+        if (
+            dataset.dataset_id != journal["dataset_id"]
+            or state["profile_id"] != journal["profile_id"]
+            or state["purge_generation"] != journal["purge_generation"]
+            or key_id != journal["integrity_key_id"]
+        ):
+            raise SyncStoreError("Personal Context conflict authority changed")
+        payload = journal["candidate"]
+        encoded = canonical_json_bytes(payload)
+        version = journal["candidate_version_id"]
+        if journal["domain"] == "personal_context.proposal":
+            version = "sync-proposal-sha256:" + hashlib.sha256(encoded).hexdigest()
+        return SyncEnvelopeCreate(
+            dataset_id=journal["dataset_id"],
+            device_id="server-origin",
+            client_envelope_id=journal["remote_envelope_id"],
+            domain=journal["domain"],
+            object_id=journal["candidate_object_id"],
+            entity_version=version,
+            parent_id=payload.get("profile_id")
+            if journal["domain"] == "personal_context.scope"
+            else payload.get("scope_id"),
+            operation="tombstone" if payload.get("state") == "deleted" else "upsert",
+            payload=payload,
+            payload_size_bytes=len(encoded),
+            payload_hash="hmac-sha256-v1:" + hmac.new(key, encoded, hashlib.sha256).hexdigest(),
+            created_at_client=journal["candidate_created_at"],
+            received_at_server=normalize_sync_timestamp(journal["candidate_created_at"]),
+            # Candidates are delivered only by conflict review. They must never
+            # advance current heads or masquerade as a new publication batch.
+            status="conflict",
+            apply_status="applied",
+            routing_metadata={
+                "profile_id": journal["profile_id"],
+                "purge_generation": journal["purge_generation"],
+                "integrity_key_id": key_id,
+                "personal_context_conflict_candidate": journal["conflict_id"],
+                "personal_context_authority": journal["authority"],
+            },
+        )
+
+    def _validate_candidate(self, dataset: Any, candidate: Any, expected: SyncEnvelopeCreate) -> Any:
+        clear_candidate = self.sync._restore_personal_context_from_storage(dataset, candidate)
+        # Cursors and their derived server envelope ID belong to Sync allocation;
+        # every other returned field is fixed by the encrypted canonical journal.
+        immutable = asdict(expected)
+        immutable.pop("server_cursor")
+        immutable.pop("server_sequence")
+        if any(getattr(clear_candidate, field) != value for field, value in immutable.items()):
+            raise SyncStoreError("Personal Context conflict candidate authentication failed")
+        return clear_candidate
+
+    @staticmethod
+    def _local_envelope_digest(source: Any) -> str:
+        immutable = asdict(source)
+        for field in (
+            "server_cursor",
+            "server_sequence",
+            "envelope_id",
+            "received_at_server",
+            "server_timestamp",
+            "apply_status",
+            "apply_error_code",
+            "apply_error_message",
+            "applied_at",
+        ):
+            immutable.pop(field, None)
+        return "sha256:" + hashlib.sha256(canonical_json_bytes(immutable)).hexdigest()
+
     def _attach_candidate(self, dataset: Any, source: Any, canonical: Any, journal: Any) -> Any:
         from .service import SyncPushConflict
 
-        state = dataset.metadata["personal_context"]
         conflict_id = journal["conflict_id"]
+        envelope = self._candidate_envelope(dataset, canonical, journal)
         candidate = self.store.get_envelope_by_client_id(dataset.dataset_id, journal["remote_envelope_id"])
         if candidate is None:
-            key_id, key = canonical.sync_integrity_key(state["profile_id"])
-            payload = journal["candidate"]
-            encoded = canonical_json_bytes(payload)
-            version = journal["candidate_version_id"]
-            if source.domain == "personal_context.proposal":
-                version = "sync-proposal-sha256:" + hashlib.sha256(encoded).hexdigest()
-            envelope = SyncEnvelopeCreate(
-                dataset_id=dataset.dataset_id,
-                device_id="server-origin",
-                client_envelope_id=journal["remote_envelope_id"],
-                domain=source.domain,
-                object_id=journal["candidate_object_id"],
-                entity_version=version,
-                parent_id=payload.get("profile_id")
-                if source.domain == "personal_context.scope"
-                else payload.get("scope_id"),
-                operation="tombstone" if payload.get("state") == "deleted" else "upsert",
-                payload=payload,
-                payload_size_bytes=len(encoded),
-                payload_hash="hmac-sha256-v1:" + hmac.new(key, encoded, hashlib.sha256).hexdigest(),
-                created_at_client=journal["candidate_created_at"],
-                received_at_server=journal["candidate_created_at"],
-                # Candidates are delivered only by conflict review. They must never
-                # advance current heads or masquerade as a new publication batch.
-                status="conflict",
-                apply_status="applied",
-                routing_metadata={
-                    "profile_id": state["profile_id"],
-                    "purge_generation": state["purge_generation"],
-                    "integrity_key_id": key_id,
-                    "personal_context_conflict_candidate": conflict_id,
-                    "personal_context_authority": journal["authority"],
-                },
-            )
             candidate = self.store.insert_envelope(self.sync._protect_personal_context_for_storage(dataset, envelope))
-        clear_candidate = self.sync._restore_personal_context_from_storage(dataset, candidate)
-        if (
-            clear_candidate.payload != journal["candidate"]
-            or clear_candidate.object_id != journal["candidate_object_id"]
-            or clear_candidate.device_id != "server-origin"
-            or clear_candidate.authority is None
-            or clear_candidate.authority.model_dump(mode="json") != journal["authority"]
-            or clear_candidate.apply_status != "applied"
-            or clear_candidate.routing_metadata.get("personal_context_conflict_candidate") != conflict_id
-        ):
-            raise SyncStoreError("Personal Context conflict candidate authentication failed")
+        clear_candidate = self._validate_candidate(dataset, candidate, envelope)
         conflict = self.store.insert_conflict(
             SyncConflictCreate(
                 conflict_id=conflict_id,
@@ -144,6 +174,7 @@ class PersonalContextConflictService:
         expected_local_envelope_id: str,
         expected_remote_envelope_id: str,
         idempotency_key: str,
+        exchange: Any,
     ) -> Any:
         """Validate transport identity and finalize only after the canonical receipt."""
         self.sync._require_registered_device(user_id, device_id, store=self.store)
@@ -169,9 +200,21 @@ class PersonalContextConflictService:
             raise SyncStoreError("Personal Context conflict candidate is unavailable")
         canonical = self.sync._personal_context_service_for_user(user_id)
         journal = canonical.get_sync_conflict(conflict.conflict_id)
-        restored = self.sync._restore_personal_context_from_storage(dataset, remote)
-        if restored.payload != journal["candidate"] or restored.object_id != journal["candidate_object_id"]:
-            raise SyncStoreError("Personal Context conflict candidate authentication failed")
+        self._validate_candidate(dataset, remote, self._candidate_envelope(dataset, canonical, journal))
+        local = self.sync._restore_personal_context_from_storage(dataset, source)
+        local_identity = {
+            "dataset_id": local.dataset_id,
+            "device_id": local.device_id,
+            "local_envelope_id": local.client_envelope_id,
+            "domain": local.domain,
+            "object_id": local.object_id,
+        }
+        if (
+            any(journal[field] != value for field, value in local_identity.items())
+            or journal["local_digest"] != "sha256:" + hashlib.sha256(canonical_json_bytes(local.payload)).hexdigest()
+            or journal["local_envelope_digest"] != self._local_envelope_digest(local)
+        ):
+            raise SyncStoreError("Personal Context local candidate authentication failed")
         command = None
         if resolution_envelope is not None:
             if (
@@ -198,6 +241,7 @@ class PersonalContextConflictService:
             action=action,
             command=command,
             purge_generation=dataset.metadata["personal_context"]["purge_generation"],
+            exchange=exchange,
         )
         if conflict.status == "unresolved":
             self.store.claim_conflict_resolution(

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
@@ -28,7 +28,7 @@ class PersonalContextConflictService:
             uuid.uuid5(uuid.NAMESPACE_URL, f"tldw:personal-context:conflict:{dataset_id}:{device_id}:{envelope_id}")
         )
 
-    def ensure_authority_candidate(self, *, dataset: Any, source: Any) -> Any:
+    def ensure_authority_candidate(self, *, dataset: Any, source: Any, exchange: Any) -> Any:
         """Attach an authenticated immutable candidate before a terminal response."""
         canonical = self.sync._personal_context_service_for_user(dataset.owner_user_id)
         clear = self.sync._restore_personal_context_from_storage(dataset, source)
@@ -46,11 +46,14 @@ class PersonalContextConflictService:
             local_payload=clear.payload,
             local_envelope_digest=self._local_envelope_digest(clear),
             purge_generation=state["purge_generation"],
+            exchange=exchange,
         )
         with canonical.sync_conflict_staging_guard(
             conflict_id,
             dataset_id=dataset.dataset_id,
+            device_id=source.device_id,
             purge_generation=state["purge_generation"],
+            exchange=exchange,
         ) as journal:
             return self._attach_candidate(dataset, source, canonical, journal)
 

--- a/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
+++ b/tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py
@@ -235,6 +235,8 @@ class PersonalContextConflictService:
                 raise SyncStoreError("Personal Context resolution envelope is invalid")
             command = asdict(resolution_envelope)
         receipt = canonical.resolve_sync_conflict(
+            # The batch still owns a Sync savepoint; relay follows its outer commit.
+            defer_relay=True,
             conflict_id=conflict.conflict_id,
             dataset_id=dataset.dataset_id,
             device_id=device_id,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -1119,6 +1119,9 @@ class SyncPushConflict:
     entity_id: str
     server_sequence: int | None = None
     message: str | None = None
+    expected_local_envelope_id: str | None = None
+    expected_remote_envelope_id: str | None = None
+    authority_candidate: SyncEnvelope | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -3340,12 +3343,21 @@ class SyncV2Service:
             domain for domain in dataset.domains if domains is None or domain in domains
         ]
         active_devices = self._retention_active_devices(dataset)
-        envelopes = self.store.list_accepted_envelopes_for_replay(
-            dataset_id,
-            since_cursor=0,
-            limit=scan_limit,
+        pinned_envelopes = self.store.list_conflict_pinned_envelopes(dataset_id, limit=scan_limit)
+        remaining_limit = scan_limit - len(pinned_envelopes)
+        envelopes = (
+            self.store.list_accepted_envelopes_for_replay(
+                dataset_id,
+                since_cursor=0,
+                limit=remaining_limit,
+            )
+            if remaining_limit
+            else []
         )
         latest_by_object = self._retention_latest_envelopes_by_object(envelopes)
+        pinned_cursors = {item.server_cursor for item in pinned_envelopes}
+        seen_cursors = {item.server_cursor for item in envelopes}
+        envelopes.extend(item for item in pinned_envelopes if item.server_cursor not in seen_cursors)
         restore_window_blocked = self._retention_restore_window_active(
             active_devices,
             offline_restore_window_seconds,
@@ -3360,9 +3372,13 @@ class SyncV2Service:
                 envelope,
                 latest_by_object=latest_by_object,
             )
+            if envelope.server_cursor in pinned_cursors:
+                candidate_type = candidate_type or "envelope_compaction"
             if candidate_type is None:
                 continue
             blockers: list[str] = []
+            if envelope.server_cursor in pinned_cursors:
+                blockers.append("retention_conflict_pinned")
             if audit_mode:
                 blockers.append("retention_audit_mode")
             window_seconds = (
@@ -4688,10 +4704,42 @@ class SyncV2Service:
                     continue
             if (
                 existing is not None
+                and existing.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
+                and existing.apply_status == "superseded"
+            ):
+                rejected.append(
+                    SyncPushRejected(
+                        client_envelope_id=envelope.client_envelope_id,
+                        error_code="personal_context_conflict_resolved",
+                        message="Personal Context conflict was already resolved",
+                    )
+                )
+                continue
+            if (
+                existing is not None
                 and existing.status == "accepted"
                 and existing.apply_status in {"applied", "superseded"}
             ):
                 accepted.append(self._push_accepted_from_envelope(existing))
+                continue
+            if (
+                existing is not None
+                and existing.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
+                and (existing.apply_status == "conflict" or existing.status == "conflict")
+            ):
+                try:
+                    conflicts.append(self._ensure_personal_context_conflict_candidate(dataset, existing, self.store))
+                except PersonalContextStorageEncryptionUnavailableError:
+                    rejected.append(
+                        SyncPushRejected(
+                            client_envelope_id=envelope.client_envelope_id,
+                            error_code="personal_context_storage_unavailable",
+                            message="Personal Context conflict recovery is unavailable",
+                            retryable=True,
+                        )
+                    )
+                if stop_on_conflict and conflicts:
+                    stopped_after_conflict = True
                 continue
             try:
                 outcome = self._evaluate_envelope(
@@ -6719,9 +6767,9 @@ class SyncV2Service:
                 conflict_id,
                 action,
                 resolution_envelope,
-                _expected_local_envelope_id,
-                _expected_remote_envelope_id,
-                _idempotency_key,
+                expected_local_envelope_id,
+                expected_remote_envelope_id,
+                idempotency_key,
             ) in enumerate(resolutions):
                 conflict = selected[conflict_id]
                 if conflict is None or index in invalid_personal_context_items:
@@ -6729,19 +6777,34 @@ class SyncV2Service:
                     continue
                 try:
                     with guarded_store.conflict_resolution_savepoint():
-                        outcome = self.resolve_conflict(
-                            user_id=user_id,
-                            dataset_id=dataset_id,
-                            conflict_id=conflict_id,
-                            action=action,
-                            resolution_envelope=resolution_envelope,
-                            resolved_by_device_id=device_id,
-                            notes=None,
-                            personal_context_exchange=personal_context_exchange,
-                            _conflict=conflict,
-                            _store=guarded_store,
-                            _verified_personal_context_exchange=verified_exchange,
-                        )
+                        if conflict.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
+                            from .personal_context_conflicts import PersonalContextConflictService
+
+                            outcome = PersonalContextConflictService(self, guarded_store).resolve_batch_item(
+                                user_id=user_id,
+                                dataset=dataset,
+                                device_id=device_id,
+                                conflict=conflict,
+                                action=action,
+                                resolution_envelope=resolution_envelope,
+                                expected_local_envelope_id=expected_local_envelope_id,
+                                expected_remote_envelope_id=expected_remote_envelope_id,
+                                idempotency_key=idempotency_key,
+                            )
+                        else:
+                            outcome = self.resolve_conflict(
+                                user_id=user_id,
+                                dataset_id=dataset_id,
+                                conflict_id=conflict_id,
+                                action=action,
+                                resolution_envelope=resolution_envelope,
+                                resolved_by_device_id=device_id,
+                                notes=None,
+                                personal_context_exchange=personal_context_exchange,
+                                _conflict=conflict,
+                                _store=guarded_store,
+                                _verified_personal_context_exchange=verified_exchange,
+                            )
                 except Exception:  # noqa: BLE001 - preserve per-item API outcomes.
                     rejected.append(index)
                     continue
@@ -6774,6 +6837,8 @@ class SyncV2Service:
             raise SyncStoreError("Sync conflict was not found or is not accessible")
         if require_personal_context_conflict and not conflict.domain.startswith("personal_context."):
             raise SyncStoreError("Personal Context conflict identity is not valid for this conflict")
+        if conflict.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
+            raise SyncStoreError("Personal Context conflict resolution requires an exact batched review")
         try:
             dataset = self._require_dataset_access(
                 user_id=user_id,
@@ -8398,6 +8463,10 @@ class SyncV2Service:
                         else None
                     )
                     blockers: list[str] = []
+                    if envelope is not None and guarded.envelope_is_conflict_pinned(
+                        dataset.dataset_id, envelope.client_envelope_id
+                    ):
+                        blockers.append("retention_conflict_pinned")
                     if (
                         envelope is None
                         or envelope.dataset_id != dataset.dataset_id
@@ -9539,6 +9608,8 @@ class SyncV2Service:
             replace(envelope, status="conflict"),
         )
         inserted = active_store.insert_envelope(storage_envelope)
+        if envelope.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
+            return self._ensure_personal_context_conflict_candidate(dataset, inserted, active_store)
         existing = active_store.get_unresolved_conflict_for_envelope(
             dataset.dataset_id,
             local_envelope_id=envelope.client_envelope_id,
@@ -9741,6 +9812,9 @@ class SyncV2Service:
     ) -> SyncPushConflict:
         sync_store = store or self.store
         dataset_id = dataset.dataset_id if isinstance(dataset, SyncDataset) else dataset
+        if envelope.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
+            current_dataset = dataset if isinstance(dataset, SyncDataset) else sync_store.get_dataset(dataset_id)
+            return self._ensure_personal_context_conflict_candidate(current_dataset, envelope, sync_store)
         existing = sync_store.get_unresolved_conflict_for_envelope(
             dataset_id,
             local_envelope_id=envelope.client_envelope_id,
@@ -9775,6 +9849,26 @@ class SyncV2Service:
             server_sequence=envelope.server_sequence,
             message=result.message,
         )
+
+    def _ensure_personal_context_conflict_candidate(
+        self,
+        dataset: SyncDataset,
+        source: SyncEnvelope,
+        store: SyncV2Store,
+    ) -> SyncPushConflict:
+        from .personal_context_conflicts import PersonalContextConflictService
+
+        try:
+            if store._connection is None:
+                with store.conflict_resolution_guard(dataset.dataset_id) as guarded:
+                    return self._ensure_personal_context_conflict_candidate(dataset, source, guarded)
+            return PersonalContextConflictService(self, store).ensure_authority_candidate(
+                dataset=dataset, source=source
+            )
+        except Exception as exc:  # noqa: BLE001 - no terminal conflict without durable candidates.
+            raise PersonalContextStorageEncryptionUnavailableError(
+                "Personal Context conflict candidate is not durably available"
+            ) from exc
 
     def _resolve_cursor(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -4731,13 +4731,29 @@ class SyncV2Service:
             ):
                 accepted.append(self._push_accepted_from_envelope(existing))
                 continue
+            recorded_personal_context_conflict = False
+            if existing is not None and existing.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
+                from tldw_Server_API.app.core.exceptions import ConcurrentProfileUpdateError
+
+                from .personal_context_conflicts import PersonalContextConflictService
+
+                try:
+                    self._personal_context_service_for_user(user_id).get_sync_conflict(
+                        PersonalContextConflictService.conflict_id(dataset_id, device_id, existing.client_envelope_id)
+                    )
+                except ConcurrentProfileUpdateError:
+                    pass
+                else:
+                    # Canonical capture can survive rollback of Sync's conflict status.
+                    # Recovery still rechecks activation inside capture and staging.
+                    recorded_personal_context_conflict = True
             if (
                 existing is not None
                 and existing.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
-                and (existing.apply_status == "conflict" or existing.status == "conflict")
+                and (existing.apply_status == "conflict" or existing.status == "conflict" or recorded_personal_context_conflict)
             ):
                 try:
-                    conflicts.append(self._ensure_personal_context_conflict_candidate(dataset, existing, self.store))
+                    conflicts.append(self._ensure_personal_context_conflict_candidate(dataset, existing, self.store, exchange=verified_exchange))
                 except PersonalContextStorageEncryptionUnavailableError:
                     rejected.append(
                         SyncPushRejected(
@@ -4805,7 +4821,7 @@ class SyncV2Service:
             if isinstance(outcome, AdapterConflict):
                 try:
                     conflicts.append(
-                        self._store_preflight_conflict(dataset, envelope, outcome)
+                        self._store_preflight_conflict(dataset, envelope, outcome, exchange=verified_exchange)
                     )
                 except SyncIdempotencyConflictError:
                     rejected.append(
@@ -4885,7 +4901,7 @@ class SyncV2Service:
                 )
                 try:
                     conflicts.append(
-                        self._store_preflight_conflict(dataset, envelope, outcome)
+                        self._store_preflight_conflict(dataset, envelope, outcome, exchange=verified_exchange)
                     )
                 except SyncIdempotencyConflictError:
                     rejected.append(
@@ -4943,7 +4959,7 @@ class SyncV2Service:
                     stopped_after_conflict = True
                 continue
             if inserted.apply_status not in {"applied", "superseded"}:
-                materialization = self._materialize_envelope(inserted)
+                materialization = self._materialize_envelope(inserted, exchange=verified_exchange)
                 inserted = self._envelope_snapshot(inserted)
                 if materialization.status == "conflict":
                     conflicts.append(
@@ -4951,6 +4967,7 @@ class SyncV2Service:
                             dataset,
                             inserted,
                             materialization,
+                            exchange=verified_exchange,
                         )
                     )
                     if stop_on_conflict:
@@ -9611,6 +9628,7 @@ class SyncV2Service:
         outcome: AdapterConflict,
         *,
         store: SyncV2Store | None = None,
+        exchange: PersonalContextExchangeProof | None = None,
     ) -> SyncPushConflict:
         active_store = store or self.store
         storage_envelope = self._protect_personal_context_for_storage(
@@ -9619,7 +9637,7 @@ class SyncV2Service:
         )
         inserted = active_store.insert_envelope(storage_envelope)
         if envelope.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
-            return self._ensure_personal_context_conflict_candidate(dataset, inserted, active_store)
+            return self._ensure_personal_context_conflict_candidate(dataset, inserted, active_store, exchange=exchange)
         existing = active_store.get_unresolved_conflict_for_envelope(
             dataset.dataset_id,
             local_envelope_id=envelope.client_envelope_id,
@@ -9660,6 +9678,8 @@ class SyncV2Service:
         dataset: SyncDataset,
         envelope: SyncEnvelopeCreate,
         outcome: AdapterConflict,
+        *,
+        exchange: PersonalContextExchangeProof | None = None,
     ) -> SyncPushConflict:
         """Atomically prefer an accepted projection blocker over preflight history."""
 
@@ -9687,6 +9707,7 @@ class SyncV2Service:
                 envelope,
                 outcome,
                 store=guarded_store,
+                exchange=exchange,
             )
 
     def _materialize_envelope(
@@ -9695,6 +9716,7 @@ class SyncV2Service:
         *,
         store: SyncV2Store | None = None,
         guarded_mutation: GuardedProductMutation | None = None,
+        exchange: PersonalContextExchangeProof | None = None,
     ) -> MaterializationResult:
         materializer = self.materializers.get(envelope.domain)
         if materializer is None:
@@ -9708,6 +9730,7 @@ class SyncV2Service:
                         envelope,
                         store=guarded_store,
                         guarded_mutation=guarded_mutation,
+                        exchange=exchange,
                     )
             except SyncMaterializationBusyError:
                 return MaterializationResult(
@@ -9722,6 +9745,8 @@ class SyncV2Service:
                     message="An earlier projection must finish first",
                 )
             except Exception as exc:  # noqa: BLE001 - commit/lock failures are retryable.
+                if isinstance(exc, SyncStoreError) and str(exc) == "personal_context_activation_required":
+                    raise
                 return MaterializationResult(
                     status="failed",
                     error_code="sync_projection_failed",
@@ -9752,9 +9777,12 @@ class SyncV2Service:
                     self._envelope_snapshot(envelope, store=store),
                     result,
                     store=store,
+                    exchange=exchange,
                 )
             return result
         except Exception as exc:  # noqa: BLE001 - materializer failures are captured as replayable sync state.
+            if isinstance(exc, SyncStoreError) and str(exc) == "personal_context_activation_required":
+                raise
             error_code = "sync_projection_failed"
             error_message = _safe_projection_error_message(exc)
             if envelope.server_cursor is not None:
@@ -9819,12 +9847,13 @@ class SyncV2Service:
         result: MaterializationResult,
         *,
         store: SyncV2Store | None = None,
+        exchange: PersonalContextExchangeProof | None = None,
     ) -> SyncPushConflict:
         sync_store = store or self.store
         dataset_id = dataset.dataset_id if isinstance(dataset, SyncDataset) else dataset
         if envelope.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
             current_dataset = dataset if isinstance(dataset, SyncDataset) else sync_store.get_dataset(dataset_id)
-            return self._ensure_personal_context_conflict_candidate(current_dataset, envelope, sync_store)
+            return self._ensure_personal_context_conflict_candidate(current_dataset, envelope, sync_store, exchange=exchange)
         existing = sync_store.get_unresolved_conflict_for_envelope(
             dataset_id,
             local_envelope_id=envelope.client_envelope_id,
@@ -9865,16 +9894,30 @@ class SyncV2Service:
         dataset: SyncDataset,
         source: SyncEnvelope,
         store: SyncV2Store,
+        *,
+        exchange: PersonalContextExchangeProof | None = None,
     ) -> SyncPushConflict:
+        from tldw_Server_API.app.core.exceptions import PersonalContextActivationError
+
         from .personal_context_conflicts import PersonalContextConflictService
 
+        if exchange is None:
+            raise SyncStoreError("personal_context_activation_required")
         try:
             if store._connection is None:
                 with store.conflict_resolution_guard(dataset.dataset_id) as guarded:
-                    return self._ensure_personal_context_conflict_candidate(dataset, source, guarded)
+                    return self._ensure_personal_context_conflict_candidate(dataset, source, guarded, exchange=exchange)
             return PersonalContextConflictService(self, store).ensure_authority_candidate(
-                dataset=dataset, source=source
+                dataset=dataset, source=source, exchange=exchange,
             )
+        except PersonalContextActivationError as exc:
+            raise SyncStoreError("personal_context_activation_required") from exc
+        except SyncStoreError as exc:
+            if str(exc) == "personal_context_activation_required":
+                raise
+            raise PersonalContextStorageEncryptionUnavailableError(
+                "Personal Context conflict candidate is not durably available"
+            ) from exc
         except Exception as exc:  # noqa: BLE001 - no terminal conflict without durable candidates.
             raise PersonalContextStorageEncryptionUnavailableError(
                 "Personal Context conflict candidate is not durably available"

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -4895,6 +4895,16 @@ class SyncV2Service:
                 )
                 continue
             except SyncHeadConflictError:
+                if envelope.domain == "personal_context.purge":
+                    rejected.append(
+                        SyncPushRejected(
+                            client_envelope_id=envelope.client_envelope_id,
+                            error_code="personal_context_purge_reconfirmation_required",
+                            message="Refresh Personal Context and explicitly reconfirm delete-everywhere.",
+                            retryable=False,
+                        )
+                    )
+                    continue
                 outcome = AdapterConflict(
                     client_envelope_id=envelope.client_envelope_id,
                     domain=envelope.domain,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -3373,7 +3373,8 @@ class SyncV2Service:
                 latest_by_object=latest_by_object,
             )
             if envelope.server_cursor in pinned_cursors:
-                candidate_type = candidate_type or "envelope_compaction"
+                # Preserve informational pins without inventing eligible compaction work.
+                candidate_type = candidate_type or "conflict_pin"
             if candidate_type is None:
                 continue
             blockers: list[str] = []
@@ -3425,7 +3426,9 @@ class SyncV2Service:
                     required_device_ids=[device.device_id for device in active_devices],
                     unacknowledged_device_ids=unacknowledged,
                     reason=(
-                        "superseded envelope"
+                        "unresolved conflict envelope"
+                        if candidate_type == "conflict_pin"
+                        else "superseded envelope"
                         if candidate_type == "envelope_compaction"
                         else "tombstone retained for deletion window"
                     ),
@@ -6735,6 +6738,7 @@ class SyncV2Service:
     ]:
         """Resolve one ordered batch from a single guarded conflict snapshot."""
 
+        relay_profile_id = None
         with self.store.conflict_resolution_guard(dataset_id) as guarded_store:
             dataset = self._require_dataset_access(
                 user_id=user_id,
@@ -6750,8 +6754,7 @@ class SyncV2Service:
                 )
             verified_exchange = None
             if any(
-                conflict is not None
-                and conflict.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
+                conflict is not None and conflict.domain in PERSONAL_CONTEXT_SYNC_DOMAINS
                 for conflict in selected.values()
             ):
                 verified_exchange = self.require_active_exchange(
@@ -6781,8 +6784,7 @@ class SyncV2Service:
                         or idempotency_key is None
                         or (
                             resolution_envelope is not None
-                            and resolution_envelope.domain
-                            not in PERSONAL_CONTEXT_SYNC_DOMAINS
+                            and resolution_envelope.domain not in PERSONAL_CONTEXT_SYNC_DOMAINS
                         )
                     )
                 )
@@ -6806,6 +6808,8 @@ class SyncV2Service:
                         if conflict.domain in PERSONAL_CONTEXT_SYNC_DOMAINS:
                             from .personal_context_conflicts import PersonalContextConflictService
 
+                            if action in {"overwrite", "duplicate_rename"}:
+                                relay_profile_id = dataset.metadata["personal_context"]["profile_id"]
                             outcome = PersonalContextConflictService(self, guarded_store).resolve_batch_item(
                                 user_id=user_id,
                                 dataset=dataset,
@@ -6837,7 +6841,19 @@ class SyncV2Service:
                     continue
                 selected[conflict_id] = outcome
                 resolved.append((index, outcome))
-            return resolved, rejected, verified_exchange
+        # Canonical receipts may have committed even when Sync finalization failed.
+        # Reentering Sync before this outer fence exits would invalidate its savepoint.
+        if relay_profile_id is not None and self.personal_context_relay is not None:
+            try:
+                self.personal_context_relay.relay_profile(
+                    user_id=user_id,
+                    profile_id=relay_profile_id,
+                    dataset_id=dataset_id,
+                    after_server_cursor=None,
+                )
+            except Exception:  # noqa: BLE001 - committed choices retain durable relay debt.
+                logger.warning("personal_context_conflict_relay_failed: durable recovery pending")
+        return resolved, rejected, verified_exchange
 
     def resolve_conflict(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -4598,6 +4598,15 @@ class SyncV2Service:
                     )
                 )
                 continue
+            if envelope.domain == "personal_context.manifest":
+                rejected.append(
+                    SyncPushRejected(
+                        client_envelope_id=envelope.client_envelope_id,
+                        error_code="personal_context_manifest_client_forbidden",
+                        message="Linked profile manifests are server-authored",
+                    )
+                )
+                continue
             if has_guard_required_routing_key(envelope.routing_metadata):
                 rejected.append(
                     SyncPushRejected(
@@ -6790,6 +6799,7 @@ class SyncV2Service:
                                 expected_local_envelope_id=expected_local_envelope_id,
                                 expected_remote_envelope_id=expected_remote_envelope_id,
                                 idempotency_key=idempotency_key,
+                                exchange=verified_exchange,
                             )
                         else:
                             outcome = self.resolve_conflict(

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -1398,6 +1398,12 @@ class SyncV2Store:
             server_sequence=server_sequence,
         )
 
+    def list_conflict_pinned_envelopes(self, dataset_id: str, *, limit: int = 1000) -> list[SyncEnvelope]:
+        return self.db.list_conflict_pinned_envelopes(dataset_id, limit=limit, connection=self._connection)
+
+    def envelope_is_conflict_pinned(self, dataset_id: str, envelope_id: str) -> bool:
+        return self.db.envelope_is_conflict_pinned(dataset_id, envelope_id, connection=self._connection)
+
     def get_envelope_by_server_cursor(self, server_cursor: int) -> SyncEnvelope | None:
         return self.db.get_envelope_by_server_cursor(
             server_cursor,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -206,6 +206,10 @@ class PersonalContextError(RuntimeError):
     """Base error for canonical Personal Context operations."""
 
 
+class PersonalContextConflictInputError(PersonalContextError, ValueError):
+    """A reviewed conflict command fails canonical choice validation."""
+
+
 class PersonalContextActivationError(PersonalContextError, ValueError):
     """Base activation failure retaining compatibility with ValueError callers."""
 

--- a/tldw_Server_API/tests/DB_Management/unit/test_postgres_placeholder_prepare.py
+++ b/tldw_Server_API/tests/DB_Management/unit/test_postgres_placeholder_prepare.py
@@ -3,9 +3,59 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
 from tldw_Server_API.app.core.DB_Management.backends.query_utils import (
     convert_sqlite_placeholders_to_postgres,
-    prepare_backend_statement,
     prepare_backend_many_statement,
+    prepare_backend_statement,
 )
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT CASE ? WHEN ? THEN ? ELSE ? END",
+        "SELECT CASE WHEN ? THEN ? ELSE ? END",
+        "SELECT CASE WHEN n > ? THEN n ELSE ? END FROM items",
+        "SELECT CASE WHEN ? THEN CASE ? WHEN ? THEN ? ELSE ? END ELSE ? END",
+        "SELECT case when ? then ? else ? end",
+        "UPDATE state SET version = ?, seq = CASE WHEN seq > ? THEN seq ELSE ? END, updated = ? WHERE id = ? AND domain = ?",
+    ],
+)
+def test_case_placeholders_preserve_parameter_order(sql):
+    params = tuple(range(sql.count("?")))
+    converted, prepared = prepare_backend_statement(BackendType.POSTGRESQL, sql, params)
+    assert converted == sql.replace("?", "%s")
+    assert prepared == params
+    assert prepare_backend_statement(BackendType.SQLITE, sql, params) == (sql, params)
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("SELECT CASE WHEN payload ? 'key' THEN ? ELSE ? END", "SELECT CASE WHEN payload ? 'key' THEN %s ELSE %s END"),
+        ("SELECT CASE WHEN payload ? ? THEN ? ELSE ? END", "SELECT CASE WHEN payload ? %s THEN %s ELSE %s END"),
+        (
+            "SELECT CASE WHEN flag THEN payload ELSE payload END ? 'key'",
+            "SELECT CASE WHEN flag THEN payload ELSE payload END ? 'key'",
+        ),
+        (
+            "SELECT payload ? CASE WHEN flag THEN 'a' ELSE 'b' END",
+            "SELECT payload ? CASE WHEN flag THEN 'a' ELSE 'b' END",
+        ),
+        (
+            "SELECT CASE WHEN \"END\" ? 'key' THEN '?' ELSE ? END",
+            "SELECT CASE WHEN \"END\" ? 'key' THEN '?' ELSE %s END",
+        ),
+        (
+            "SELECT CASE WHEN payload ?| array['a'] THEN ? ELSE ? END",
+            "SELECT CASE WHEN payload ?| array['a'] THEN %s ELSE %s END",
+        ),
+        (
+            "SELECT CASE WHEN payload ?& array['a'] THEN ? ELSE ? END",
+            "SELECT CASE WHEN payload ?& array['a'] THEN %s ELSE %s END",
+        ),
+    ],
+)
+def test_case_preserves_jsonb_operators_and_quoted_text(sql, expected):
+    assert convert_sqlite_placeholders_to_postgres(sql) == expected
 
 
 def test_convert_placeholders_ignores_single_quoted_literals():
@@ -54,10 +104,10 @@ def test_prepare_backend_many_statement_batch_params():
     reason="psycopg not available",
 )
 def test_postgres_backend_prepare_query_no_replace_inside_literals():
+    from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
     from tldw_Server_API.app.core.DB_Management.backends.postgresql_backend import (
         PostgreSQLBackend,
     )
-    from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
 
     backend = PostgreSQLBackend(DatabaseConfig(backend_type=BackendType.POSTGRESQL))
     sql = "SELECT '? literal ?' as txt, id FROM table WHERE id = ? AND note = 'x?y'"

--- a/tldw_Server_API/tests/DB_Management/unit/test_postgres_placeholder_prepare.py
+++ b/tldw_Server_API/tests/DB_Management/unit/test_postgres_placeholder_prepare.py
@@ -8,6 +8,7 @@ from tldw_Server_API.app.core.DB_Management.backends.query_utils import (
 )
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "sql",
     [
@@ -19,7 +20,8 @@ from tldw_Server_API.app.core.DB_Management.backends.query_utils import (
         "UPDATE state SET version = ?, seq = CASE WHEN seq > ? THEN seq ELSE ? END, updated = ? WHERE id = ? AND domain = ?",
     ],
 )
-def test_case_placeholders_preserve_parameter_order(sql):
+def test_case_placeholders_preserve_parameter_order(sql: str) -> None:
+    """CASE binds preserve their order on PostgreSQL and remain unchanged on SQLite."""
     params = tuple(range(sql.count("?")))
     converted, prepared = prepare_backend_statement(BackendType.POSTGRESQL, sql, params)
     assert converted == sql.replace("?", "%s")
@@ -27,6 +29,7 @@ def test_case_placeholders_preserve_parameter_order(sql):
     assert prepare_backend_statement(BackendType.SQLITE, sql, params) == (sql, params)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("sql", "expected"),
     [
@@ -54,7 +57,8 @@ def test_case_placeholders_preserve_parameter_order(sql):
         ),
     ],
 )
-def test_case_preserves_jsonb_operators_and_quoted_text(sql, expected):
+def test_case_preserves_jsonb_operators_and_quoted_text(sql: str, expected: str) -> None:
+    """CASE conversion leaves JSONB operators and quoted question marks intact."""
     assert convert_sqlite_placeholders_to_postgres(sql) == expected
 
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_adapter.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_adapter.py
@@ -167,6 +167,52 @@ def test_adapter_accepts_exact_canonical_whole_objects(domain: str) -> None:
     assert isinstance(result, AdapterAccepted)
 
 
+@pytest.mark.parametrize("head_generation", [0, 1])
+def test_stale_purge_lineage_requires_explicit_reconfirmation(head_generation: int) -> None:
+    """A valid next generation with obsolete lineage cannot enter ordinary review."""
+    domain = "personal_context.purge"
+    previous = _envelope(
+        domain, payload={"schema_version": 1, "profile_id": "profile-a", "purge_generation": head_generation}
+    )
+    head = SyncEnvelope(**{**asdict(previous), "server_cursor": 1, "envelope_id": "prior-purge"})
+    outcome = _adapter(domain).evaluate_envelope(
+        _envelope(domain, base_object_hash="hmac-sha256-v1:" + "0" * 64),
+        dataset=_dataset(),
+        context=SyncAdapterContext(prior_envelopes=(head,)),
+    )
+    assert isinstance(outcome, AdapterRejected)
+    assert outcome.error_code == "personal_context_purge_reconfirmation_required"
+    assert outcome.retryable is False
+    assert outcome.message == "Refresh Personal Context and explicitly reconfirm delete-everywhere."
+
+
+def test_purge_accepts_next_generation_with_current_lineage() -> None:
+    """Explicitly confirmed next-generation lineage retains normal adapter acceptance."""
+    domain = "personal_context.purge"
+    previous = _envelope(domain, payload={"schema_version": 1, "profile_id": "profile-a", "purge_generation": 0})
+    head = SyncEnvelope(**{**asdict(previous), "server_cursor": 1, "envelope_id": "prior-purge"})
+    outcome = _adapter(domain).evaluate_envelope(
+        _envelope(domain, base_object_hash=head.payload_hash),
+        dataset=_dataset(),
+        context=SyncAdapterContext(prior_envelopes=(head,)),
+    )
+    assert isinstance(outcome, AdapterAccepted)
+
+
+def test_invalid_purge_generation_precedes_stale_lineage_rejection() -> None:
+    """An invalid generation keeps its existing classification before lineage review."""
+    domain = "personal_context.purge"
+    previous = _envelope(domain)
+    head = SyncEnvelope(**{**asdict(previous), "server_cursor": 1, "envelope_id": "prior-purge"})
+    outcome = _adapter(domain).evaluate_envelope(
+        _envelope(domain, payload={"schema_version": 1, "profile_id": "profile-a", "purge_generation": 2}),
+        dataset=_dataset(),
+        context=SyncAdapterContext(prior_envelopes=(head,)),
+    )
+    assert isinstance(outcome, AdapterRejected)
+    assert outcome.error_code == "personal_context_purge_generation_invalid"
+
+
 @pytest.mark.parametrize("domain", PERSONAL_CONTEXT_SYNC_DOMAINS)
 def test_adapter_rejects_entity_version_outside_canonical_payload(domain: str) -> None:
     result = _adapter(domain).evaluate_envelope(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 from dataclasses import asdict, replace
 
 import pytest
@@ -28,8 +29,16 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture()
-def linked(production_factories):
+def linked(production_factories, monkeypatch):
     canonical, sync = production_factories
+    relay_type = type(sync.personal_context_relay)
+    original_relay = relay_type.relay_profile
+
+    def deterministic_relay(relay, **kwargs):
+        relay.clock_ns = lambda: 0
+        return original_relay(relay, **kwargs)
+
+    monkeypatch.setattr(relay_type, "relay_profile", deterministic_relay)
     return _link(canonical, sync)
 
 
@@ -55,6 +64,182 @@ def _link(canonical, sync):
         personal_context_exchange=exchange,
     )
     return canonical, sync, initial.dataset_id, exchange, record
+
+
+def _reopen(linked):
+    from tldw_Server_API.app.api.v1.API_Deps.personal_context_deps import personal_context_service_for_user
+    from tldw_Server_API.app.core.DB_Management.backends.factory import reset_managed_sqlite_backends
+    from tldw_Server_API.app.core.Sync.v2 import factory
+    from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import _clear_factory_caches
+
+    canonical, sync, dataset_id, exchange, record = linked
+    backend = sync.store.db.backend
+    reset_managed_sqlite_backends(backends=[backend])
+    _clear_factory_caches()
+    reopened = personal_context_service_for_user(_USER_ID)
+    restarted = factory.sync_v2_service_for_user(_USER_ID)
+    assert reopened._repository.database is not canonical._repository.database
+    assert restarted.store.db.backend is not backend
+    return reopened, restarted, dataset_id, exchange, record
+
+
+@pytest.mark.parametrize("boundary", ["capture", "receipt"])
+def test_reopened_owners_resume_exact_conflict_after_interruption(linked, monkeypatch, boundary):
+    from tldw_Server_API.app.core.Sync.v2.personal_context_conflicts import PersonalContextConflictService
+
+    canonical, sync, dataset_id, _exchange, record = linked
+    if boundary == "capture":
+        incoming = _envelope(
+            linked, record.model_copy(update={"version_id": "interrupted-local-version"}), "interrupted-local-envelope"
+        )
+        with monkeypatch.context() as fault:
+
+            def fail_attachment(*args, **kwargs):
+                raise RuntimeError("injected capture-before-attachment interruption")
+
+            fault.setattr(PersonalContextConflictService, "_attach_candidate", fail_attachment)
+            assert _push(linked, incoming).rejected[0].retryable
+        conflict_id = PersonalContextConflictService.conflict_id(dataset_id, _DEVICE_ID, incoming.client_envelope_id)
+        journal = canonical.get_sync_conflict(conflict_id)
+        runtime = _reopen(linked)
+        replay = _push(runtime, incoming)
+        assert len(replay.conflicts) == 1
+        assert replay.conflicts[0].expected_remote_envelope_id == journal["remote_envelope_id"]
+        assert replay.conflicts[0].authority_candidate.payload == journal["candidate"]
+        assert asdict(_push(runtime, incoming).conflicts[0]) == asdict(replay.conflicts[0])
+    else:
+        conflict, _source = _conflict(linked)
+        replacement = record.model_copy(
+            update={"version_id": "reopened-reviewed-version", "parent_version_id": record.version_id}
+        )
+        command = _envelope(linked, replacement, "reopened-reviewed-envelope", base=record)
+        with monkeypatch.context() as fault:
+
+            def fail_finalize(*args, **kwargs):
+                raise RuntimeError("injected receipt-before-finalization interruption")
+
+            fault.setattr(type(sync.store), "resolve_conflict", fail_finalize)
+            assert _resolve(linked, conflict, "overwrite", command)[1] == [0]
+        manifest = canonical.get_manifest()
+        with canonical._repository.database.transaction() as connection:
+            publications = connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+        runtime = _reopen(linked)
+        assert _resolve(runtime, conflict, "overwrite", command)[1] == []
+        assert runtime[0].get_manifest() == manifest
+        assert runtime[0].get_record(record.record_id) == replacement
+        with runtime[0]._repository.database.transaction() as connection:
+            assert (
+                connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+                == publications
+            )
+
+
+def test_old_resolution_rejected_after_purge_and_recreation_attempt(linked):
+    from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+
+    conflict, _source = _conflict(linked)
+    canonical = linked[0]
+    canonical.purge_profile(mode="everywhere", confirmation="DELETE EVERYWHERE", expected_purge_generation=0)
+    runtime = _reopen(linked)
+    with pytest.raises(ProfileConflictError):
+        runtime[0].create_profile()
+    with pytest.raises(SyncStoreError):
+        _resolve(runtime, conflict)
+    assert not runtime[0].list_records()
+    with runtime[0]._repository.database.transaction() as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type IN ('sync_conflict', 'sync_conflict_receipt')"
+            ).fetchone()[0]
+            == 0
+        )
+
+
+@pytest.mark.parametrize("domain", ["personal_context.scope", "personal_context.proposal"])
+def test_non_record_candidate_replay_and_explicit_choice(linked, domain):
+    from datetime import UTC, datetime, timedelta
+
+    from tldw_Server_API.tests.Personalization.test_personal_context_service import _pending_proposal_for_scope
+
+    canonical, sync, dataset_id, exchange, record = linked
+    scope = canonical.list_scopes()[0]
+    if domain == "personal_context.scope":
+        original = scope
+        local = original.model_copy(update={"version_id": "conflicted-scope-version"})
+        replacement = original.model_copy(update={"version_id": "reviewed-scope-version"})
+        object_id, parent = scope.scope_id, scope.profile_id
+        version, replacement_version = local.version_id, replacement.version_id
+    else:
+        proposal = _pending_proposal_for_scope(
+            canonical, profile_id=record.profile_id, scope_id=scope.scope_id, proposal_id="conflicted-proposal-13163"
+        )
+        now = datetime.now(UTC).replace(microsecond=0)
+        original = canonical.create_proposal(
+            type(proposal).model_validate(
+                {**proposal.model_dump(mode="python"), "created_at": now, "expires_at": now + timedelta(days=90)}
+            )
+        )
+        local = type(original).model_validate({**original.model_dump(mode="python"), "confidence": 0.9})
+        replacement = type(original).model_validate(
+            {**original.model_dump(mode="python"), "state": "rejected", "proposed_record": None, "confidence": None}
+        )
+        object_id, parent = original.proposal_id, original.scope_id
+        version = "sync-proposal-sha256:" + hashlib.sha256(canonical_bytes(local)).hexdigest()
+        replacement_version = "sync-proposal-sha256:" + hashlib.sha256(canonical_bytes(replacement)).hexdigest()
+    sync.pull(
+        user_id=_USER_ID,
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        domains=[domain],
+        personal_context_exchange=exchange,
+    )
+    incoming = _whole_object_envelope(linked, local, domain, object_id, version, parent=parent)
+    result = _push(linked, incoming)
+    assert result.conflicts, (
+        [(item.apply_status, item.apply_error_code) for item in result.accepted],
+        [(item.error_code, item.retryable) for item in result.rejected],
+    )
+    conflict = result.conflicts[0]
+    assert conflict.authority_candidate.payload == original.model_dump(mode="json")
+    assert asdict(_push(linked, incoming).conflicts[0]) == asdict(conflict)
+    command = _whole_object_envelope(
+        linked, replacement, domain, object_id, replacement_version, parent=parent, base=original
+    )
+    assert _resolve(linked, conflict, "overwrite", command)[1] == []
+    assert canonical.get_sync_conflict(conflict.conflict_id)["receipt"]["resulting_object_id"] == object_id
+
+
+def test_invalid_purge_envelope_is_rejected_without_review(linked):
+    envelope = replace(
+        _envelope(linked, linked[4], "invalid-purge-envelope"), domain="personal_context.purge", operation="tombstone"
+    )
+    result = _push(linked, envelope)
+    assert (
+        not result.conflicts
+        and not result.accepted
+        and result.rejected[0].error_code == "personal_context_payload_invalid"
+    )
+
+
+def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked):
+    from pathlib import Path
+
+    from loguru import logger
+
+    diagnostics = []
+    sink = logger.add(lambda message: diagnostics.append(str(message)))
+    try:
+        conflict, source = _conflict(linked, collision=True)
+        assert _push(linked, source).conflicts
+        assert _resolve(linked, conflict, expected_remote="stale-remote-canary")[1] == [0]
+    finally:
+        logger.remove(sink)
+    for canary in (b"TASK13163-SHARED-CANARY", b"TASK13163-LOCAL-CANARY"):
+        assert canary.decode() not in "".join(diagnostics)
+        for path in (Path(linked[0]._repository.database.db_path), Path(linked[1].store.db.backend.config.sqlite_path)):
+            for artifact in (path, Path(str(path) + "-wal")):
+                if artifact.exists():
+                    assert canary not in artifact.read_bytes()
 
 
 def _envelope(linked, record, envelope_id, *, base=None):
@@ -87,6 +272,152 @@ def _push(linked, envelope):
         envelopes=[envelope],
         personal_context_exchange=exchange,
     )
+
+
+def _whole_object_envelope(linked, value, domain, object_id, version, *, parent=None, base=None):
+    canonical, _sync, dataset_id, _exchange, _record = linked
+    key_id, key = canonical.sync_integrity_key(value.profile_id)
+    payload = canonical_bytes(value)
+    return SyncEnvelopeCreate(
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        client_envelope_id=f"review-{domain}-{version}",
+        domain=domain,
+        operation="upsert",
+        object_id=object_id,
+        parent_id=parent,
+        payload=value.model_dump(mode="json"),
+        entity_version=version,
+        payload_hash="hmac-sha256-v1:" + hmac.new(key, payload, hashlib.sha256).hexdigest(),
+        payload_size_bytes=len(payload),
+        base_object_hash=None if base is None else "sha256:" + hashlib.sha256(canonical_bytes(base)).hexdigest(),
+        routing_metadata={"integrity_key_id": key_id, "profile_id": value.profile_id, "purge_generation": 0},
+    )
+
+
+@pytest.mark.parametrize("stale", [False, True])
+def test_linked_client_manifest_rejected_without_conflict_or_publication(linked, stale):
+    canonical, _sync, _dataset, _exchange, _record = linked
+    before = canonical.get_manifest()
+    envelope = _whole_object_envelope(
+        linked,
+        before,
+        "personal_context.manifest",
+        before.profile_id,
+        before.current_version_id,
+        base=None if stale else before,
+    )
+    with canonical._repository.database.transaction() as connection:
+        publications = connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+    result = _push(linked, envelope)
+    assert not result.accepted and not result.conflicts and len(result.rejected) == 1
+    assert result.rejected[0].error_code == "personal_context_manifest_client_forbidden"
+    assert canonical.get_manifest() == before
+    with canonical._repository.database.transaction() as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type = 'sync_conflict'"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+            == publications
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("entity_version", json.dumps("tampered-version-13163")),
+        ("operation", "tombstone"),
+        ("parent_id", "tampered-parent-13163"),
+        ("created_at_client", "2026-01-01T00:00:00+00:00"),
+        ("received_at_server", "2026-01-01T00:00:00+00:00"),
+        ("payload_hash", "hmac-sha256-v1:" + "0" * 64),
+        ("payload_size_bytes", 1),
+        ("routing_metadata_json", None),
+    ],
+)
+def test_tampered_remote_candidate_replay_and_resolution_fail_closed(linked, field, value):
+    conflict, incoming = _conflict(linked)
+    canonical, sync, _dataset, _exchange, _record = linked
+    if field == "routing_metadata_json":
+        metadata = dict(conflict.authority_candidate.routing_metadata)
+        metadata["personal_context_authority"] = {"role": "client_ingress"}
+        value = json.dumps(metadata)
+    # Field names are a closed test parameter list; production never receives them.
+    sync.store.db.execute(
+        f"UPDATE sync_envelopes SET {field} = ? WHERE client_envelope_id = ?",
+        (value, conflict.expected_remote_envelope_id),
+    )
+    before = canonical.get_manifest()
+    replay = _push(linked, incoming)
+    assert not replay.conflicts and replay.rejected[0].retryable
+    assert _resolve(linked, conflict)[1] == [0]
+    assert canonical.get_manifest() == before
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
+    assert canonical.get_sync_conflict(conflict.conflict_id)["state"] == "unresolved"
+
+
+@pytest.mark.parametrize("authenticated_body", [False, True])
+def test_tampered_local_ciphertext_cannot_release_review(linked, authenticated_body):
+    conflict, _incoming = _conflict(linked)
+    canonical, sync, _dataset, _exchange, _record = linked
+    if authenticated_body:
+        dataset = sync.store.get_dataset(linked[2])
+        source = sync.store.get_envelope_by_client_id(linked[2], conflict.expected_local_envelope_id)
+        clear = sync._restore_personal_context_from_storage(dataset, source)
+        altered = {**clear.payload, "payload": {**clear.payload["payload"], "value": "tampered-local-body"}}
+        protected = sync._protect_personal_context_for_storage(
+            dataset, replace(clear, payload=altered, payload_clear=altered)
+        )
+        sync.store.db.execute(
+            "UPDATE sync_envelopes SET payload_ciphertext = ?, encryption_metadata_json = ? WHERE client_envelope_id = ?",
+            (
+                protected.payload_ciphertext,
+                json.dumps(protected.encryption_metadata),
+                conflict.expected_local_envelope_id,
+            ),
+        )
+    else:
+        sync.store.db.execute(
+            "UPDATE sync_envelopes SET payload_ciphertext = ? WHERE client_envelope_id = ?",
+            ("invalid-ciphertext", conflict.expected_local_envelope_id),
+        )
+    before = canonical.get_manifest()
+    assert _resolve(linked, conflict)[1] == [0]
+    assert canonical.get_manifest() == before
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
+
+
+@pytest.mark.parametrize("committed", [False, True])
+def test_new_activation_between_batch_check_and_canonical_decision_rejects(linked, monkeypatch, committed):
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+
+    conflict, _incoming = _conflict(linked)
+    canonical, sync, _dataset, _exchange, record = linked
+    if committed:
+        with monkeypatch.context() as fault:
+
+            def fail_finalize(*args, **kwargs):
+                raise RuntimeError("injected Sync finalization failure")
+
+            fault.setattr(type(sync.store), "resolve_conflict", fail_finalize)
+            assert _resolve(linked, conflict)[1] == [0]
+    before = canonical.get_manifest()
+    journal = canonical.get_sync_conflict(conflict.conflict_id)
+    original = type(canonical).resolve_sync_conflict
+
+    def transition_then_resolve(owner, **command):
+        PersonalContextActivationService(owner._repository).prepare(record.profile_id, device_id=_DEVICE_ID, fresh=True)
+        return original(owner, **command)
+
+    monkeypatch.setattr(type(canonical), "resolve_sync_conflict", transition_then_resolve)
+    assert _resolve(linked, conflict)[1] == [0]
+    assert canonical.get_manifest() == before
+    assert canonical.get_sync_conflict(conflict.conflict_id) == journal
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
 
 
 def _conflict(linked, *, collision=False):
@@ -299,6 +630,9 @@ def test_exact_journal_survives_reopen_rotation_and_contains_no_plaintext(linked
     from pathlib import Path
 
     assert b"TASK13163-" not in Path(path).read_bytes()
+    if not resolved:
+        assert asdict(_push(linked, _source).conflicts[0]) == asdict(conflict)
+    assert _resolve(linked, conflict)[1] == []
 
 
 def test_batch_partial_failure_preserves_stale_item_and_commits_valid_skip(linked):

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -1,0 +1,588 @@
+"""Real canonical/Sync conflict choices, immutable candidates and crash recovery."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import asdict, replace
+
+import pytest
+from tldw_profile_core import ProfileRecord, canonical_bytes
+
+from tldw_Server_API.app.core.Personalization.personal_context_service import ProfileConflictError, RecordMutation
+from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelopeCreate
+from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import PersonalContextExchangeProof
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_activation import activation_store as activation_store
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import (
+    _DEVICE_ID,
+    _USER_ID,
+    _record_body,
+    _register_device,
+    _seed_exchange,
+)
+from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import (
+    production_factories as production_factories,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def linked(production_factories):
+    canonical, sync = production_factories
+    return _link(canonical, sync)
+
+
+def _link(canonical, sync):
+    canonical.create_profile()
+    _register_device(sync)
+    initial = sync.bootstrap_personal_context(user_id=_USER_ID, device_id=_DEVICE_ID)
+    sync.complete_personal_context_link(
+        user_id=_USER_ID,
+        device_id=_DEVICE_ID,
+        dataset_id=initial.dataset_id,
+        bootstrap_cursor=initial.cursor,
+    )
+    exchange = PersonalContextExchangeProof.model_validate(_seed_exchange(sync, initial.dataset_id))
+    record = canonical.create_manual_record(
+        **_record_body(canonical.list_scopes()[0].scope_id, "TASK13163-SHARED-CANARY")
+    )
+    sync.pull(
+        user_id=_USER_ID,
+        dataset_id=initial.dataset_id,
+        device_id=_DEVICE_ID,
+        domains=["personal_context.record"],
+        personal_context_exchange=exchange,
+    )
+    return canonical, sync, initial.dataset_id, exchange, record
+
+
+def _envelope(linked, record, envelope_id, *, base=None):
+    canonical, sync, dataset_id, _exchange, _record = linked
+    key_id, key = canonical.sync_integrity_key(record.profile_id)
+    payload = canonical_bytes(record)
+    return SyncEnvelopeCreate(
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        client_envelope_id=envelope_id,
+        domain="personal_context.record",
+        operation="upsert",
+        object_id=record.record_id,
+        parent_id=record.scope_id,
+        payload=record.model_dump(mode="json"),
+        payload_hash="hmac-sha256-v1:" + hmac.new(key, payload, hashlib.sha256).hexdigest(),
+        payload_size_bytes=len(payload),
+        entity_version=record.version_id,
+        base_object_hash=(None if base is None else "sha256:" + hashlib.sha256(canonical_bytes(base)).hexdigest()),
+        routing_metadata={"integrity_key_id": key_id, "profile_id": record.profile_id, "purge_generation": 0},
+    )
+
+
+def _push(linked, envelope):
+    _canonical, sync, dataset_id, exchange, _record = linked
+    return sync.push(
+        user_id=_USER_ID,
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        envelopes=[envelope],
+        personal_context_exchange=exchange,
+    )
+
+
+def _conflict(linked, *, collision=False):
+    canonical, sync, dataset_id, exchange, original = linked
+    local = ProfileRecord.model_validate(
+        {
+            **original.model_dump(mode="python"),
+            "record_id": "incoming-collision-record" if collision else original.record_id,
+            "version_id": "local-candidate-version-13163",
+            "parent_version_id": None,
+            "payload": {**original.payload.model_dump(), "value": "TASK13163-LOCAL-CANARY"},
+        }
+    )
+    envelope = _envelope(linked, local, "incoming-conflict-envelope-13163")
+    result = _push(linked, envelope)
+    assert len(result.conflicts) == 1, [(item.apply_status, item.apply_error_code) for item in result.accepted]
+    return result.conflicts[0], envelope
+
+
+def _resolve(linked, conflict, action="skip", envelope=None, **overrides):
+    _canonical, sync, dataset_id, exchange, _record = linked
+    values = {
+        "expected_local": conflict.expected_local_envelope_id,
+        "expected_remote": conflict.expected_remote_envelope_id,
+        "idempotency_key": "resolution-command-key-13163",
+        **overrides,
+    }
+    return sync.resolve_conflicts_batch(
+        user_id=_USER_ID,
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        personal_context_exchange=exchange,
+        resolutions=[
+            (
+                conflict.conflict_id,
+                action,
+                envelope,
+                values["expected_local"],
+                values["expected_remote"],
+                values["idempotency_key"],
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize("collision", [False, True])
+def test_push_candidate_is_durable_and_exact_on_replay(linked, collision):
+    conflict, envelope = _conflict(linked, collision=collision)
+    assert conflict.expected_local_envelope_id == envelope.client_envelope_id
+    assert conflict.expected_remote_envelope_id
+    assert conflict.authority_candidate.authority.role == "home_authority"
+    assert conflict.authority_candidate.apply_status == "applied"
+    replay = _push(linked, envelope).conflicts[0]
+    assert asdict(replay) == asdict(conflict)
+    stored = linked[1].store.get_envelope_by_server_cursor(conflict.authority_candidate.server_cursor)
+    assert stored.payload == {} and stored.payload_ciphertext
+
+
+def test_stale_review_does_not_release_freeze_or_resolve(linked):
+    conflict, _envelope = _conflict(linked)
+    canonical, sync, _dataset, _exchange, record = linked
+    before = canonical.get_manifest()
+    resolved, rejected, _proof = _resolve(linked, conflict, expected_remote="stale-candidate-envelope-13163")
+    assert not resolved and rejected == [0]
+    assert canonical.get_manifest() == before
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
+    with pytest.raises(ProfileConflictError):
+        canonical.update_record(
+            record.record_id,
+            RecordMutation(payload={**record.payload.model_dump(), "value": "blocked"}),
+            expected_version_id=record.version_id,
+        )
+
+
+@pytest.mark.parametrize("collision", [False, True])
+def test_explicit_overwrite_replays_after_sync_finalization_failure(linked, monkeypatch, collision):
+    conflict, _source = _conflict(linked, collision=collision)
+    canonical, sync, _dataset, _exchange, record = linked
+    replacement = ProfileRecord.model_validate(
+        {
+            **record.model_dump(mode="python"),
+            "parent_version_id": record.version_id,
+            "version_id": "reviewed-replacement-version-13163",
+            "payload": {**record.payload.model_dump(), "value": "reviewed local values"},
+        }
+    )
+    command = _envelope(linked, replacement, "reviewed-replacement-envelope-13163", base=record)
+    original = type(sync.store).resolve_conflict
+
+    def fail_finalize(*args, **kwargs):
+        raise RuntimeError("injected Sync finalization failure")
+
+    monkeypatch.setattr(type(sync.store), "resolve_conflict", fail_finalize)
+    assert _resolve(linked, conflict, "overwrite", command)[1] == [0]
+    assert canonical.get_record(record.record_id) == replacement
+    manifest = canonical.get_manifest()
+    monkeypatch.setattr(type(sync.store), "resolve_conflict", original)
+    assert _resolve(linked, conflict, "overwrite", command)[1] == []
+    assert canonical.get_manifest() == manifest
+    assert len(canonical.list_records()) == 1
+    changed = replace(command, client_envelope_id="changed-resolution-envelope-13163")
+    assert _resolve(linked, conflict, "overwrite", changed)[1] == [0]
+
+
+def test_both_candidates_appear_pinned_in_retention_preview_and_apply(linked):
+    conflict, _source = _conflict(linked, collision=True)
+    _canonical, sync, dataset_id, _exchange, _record = linked
+    preview = sync.retention_dry_run(user_id=_USER_ID, dataset_id=dataset_id, audit_mode=False)
+    pinned = {item.server_sequence for item in preview.candidates if "retention_conflict_pinned" in item.blockers}
+    assert {conflict.server_sequence, conflict.authority_candidate.server_cursor} <= pinned
+    sync.retention_compact(user_id=_USER_ID, dataset_id=dataset_id, confirm=True)
+    assert sync.store.get_envelope_by_server_cursor(conflict.server_sequence).payload_ciphertext
+    assert sync.store.get_envelope_by_server_cursor(conflict.authority_candidate.server_cursor).payload_ciphertext
+
+
+def test_candidate_attachment_failure_is_retryable_and_reuses_canonical_snapshot(linked, monkeypatch):
+    canonical, sync, _dataset, _exchange, record = linked
+    local = ProfileRecord.model_validate(
+        {**record.model_dump(mode="python"), "version_id": "retry-local-version-13163"}
+    )
+    incoming = _envelope(linked, local, "retry-local-envelope-13163")
+    original = type(sync.store).insert_conflict
+
+    def fail_attachment(*args, **kwargs):
+        raise RuntimeError("injected candidate attachment failure")
+
+    monkeypatch.setattr(type(sync.store), "insert_conflict", fail_attachment)
+    first = _push(linked, incoming)
+    assert first.rejected[0].retryable and not first.conflicts
+    from tldw_Server_API.app.core.Sync.v2.personal_context_conflicts import PersonalContextConflictService
+
+    conflict_id = PersonalContextConflictService.conflict_id(linked[2], _DEVICE_ID, incoming.client_envelope_id)
+    before = canonical.get_sync_conflict(conflict_id)
+    monkeypatch.setattr(type(sync.store), "insert_conflict", original)
+    replay = _push(linked, incoming).conflicts[0]
+    assert replay.expected_remote_envelope_id == before["remote_envelope_id"]
+    assert replay.authority_candidate.payload == before["candidate"]
+
+
+@pytest.mark.parametrize("action", ["skip", "duplicate_rename"])
+def test_collision_is_resolved_only_by_explicit_reviewed_choice(linked, action):
+    conflict, incoming = _conflict(linked, collision=True)
+    canonical, sync, _dataset, _exchange, record = linked
+    assert canonical.get_record(record.record_id) == record
+    assert len(canonical.list_records()) == 1
+    command = None
+    if action == "duplicate_rename":
+        distinct = ProfileRecord.model_validate(
+            {
+                **incoming.payload,
+                "record_id": "reviewed-distinct-record-13163",
+                "version_id": "reviewed-distinct-version-13163",
+                "semantic_key": {"namespace": "preference", "subject": "reviewed.distinct"},
+            }
+        )
+        command = _envelope(linked, distinct, "reviewed-distinct-envelope-13163")
+    manifest = canonical.get_manifest()
+    assert _resolve(linked, conflict, action, command)[1] == []
+    assert canonical.get_record(record.record_id) == record
+    assert len(canonical.list_records()) == (2 if command else 1)
+    assert canonical.get_manifest().revision == manifest.revision + (1 if command else 0)
+    assert _push(linked, incoming).rejected[0].error_code == "personal_context_conflict_resolved"
+
+
+def test_collision_wrong_target_cannot_silently_replace_identity(linked):
+    conflict, incoming = _conflict(linked, collision=True)
+    assert _resolve(linked, conflict, "overwrite", incoming)[1] == [0]
+    assert linked[0].get_record(linked[4].record_id) == linked[4]
+    assert linked[1].store.get_conflict(conflict.conflict_id).status == "unresolved"
+
+
+def test_collision_freezes_both_ids_but_unrelated_ingress_continues(linked):
+    conflict, incoming = _conflict(linked, collision=True)
+    canonical, sync, _dataset, _exchange, record = linked
+    escaped = ProfileRecord.model_validate(
+        {**incoming.payload, "semantic_key": {"namespace": "preference", "subject": "uncontested"}}
+    )
+    with pytest.raises(ProfileConflictError):
+        canonical.create_record(escaped)
+    with pytest.raises(ProfileConflictError):
+        canonical.archive_record(record.record_id, expected_version_id=record.version_id)
+    unrelated = ProfileRecord.model_validate(
+        {**escaped.model_dump(mode="python"), "record_id": "unrelated-record-13163"}
+    )
+    result = _push(linked, _envelope(linked, unrelated, "unrelated-envelope-13163"))
+    assert len(result.accepted) == 1 and result.accepted[0].apply_status == "applied"
+    assert canonical.get_record(unrelated.record_id) == unrelated
+
+
+@pytest.mark.parametrize("resolved", [False, True])
+def test_exact_journal_survives_reopen_rotation_and_contains_no_plaintext(linked, resolved):
+    conflict, _source = _conflict(linked, collision=True)
+    if resolved:
+        assert _resolve(linked, conflict)[1] == []
+    canonical, sync, _dataset, _exchange, record = linked
+    from tldw_Server_API.app.core.DB_Management.Personal_Context_Repository import PersonalContextRepository
+    from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
+
+    path = canonical._repository.database.db_path
+    reopened = PersonalContextRepository(PersonalizationDB.for_path(path))
+    before = reopened.get_sync_conflict(record.profile_id, conflict.conflict_id)
+    reopened.rotate_encryption_key(record.profile_id)
+    assert reopened.get_sync_conflict(record.profile_id, conflict.conflict_id) == before
+    with reopened.database.transaction() as connection:
+        rows = connection.execute(
+            "SELECT * FROM personal_context_object_versions WHERE object_type IN ('sync_conflict', 'sync_conflict_receipt')"
+        ).fetchall()
+        assert rows and all(row["key_version"] == 2 for row in rows)
+        assert any(row["object_type"] == "sync_conflict_receipt" for row in rows) == resolved
+    from pathlib import Path
+
+    assert b"TASK13163-" not in Path(path).read_bytes()
+
+
+def test_batch_partial_failure_preserves_stale_item_and_commits_valid_skip(linked):
+    conflict, _source = _conflict(linked)
+    _canonical, sync, dataset_id, exchange, _record = linked
+    valid = (
+        conflict.conflict_id,
+        "skip",
+        None,
+        conflict.expected_local_envelope_id,
+        conflict.expected_remote_envelope_id,
+        "valid-skip-command-13163",
+    )
+    stale = (*valid[:4], "stale-remote-candidate-13163", valid[5])
+    resolved, rejected, _proof = sync.resolve_conflicts_batch(
+        user_id=_USER_ID,
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        resolutions=[stale, valid],
+        personal_context_exchange=exchange,
+    )
+    assert rejected == [0] and [index for index, _ in resolved] == [1]
+
+
+@pytest.mark.parametrize("defect", ["owner", "device", "proof"])
+def test_wrong_authority_cannot_resolve_or_release(linked, defect):
+    conflict, _source = _conflict(linked)
+    _canonical, sync, dataset_id, exchange, _record = linked
+    from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+
+    with pytest.raises(SyncStoreError):
+        sync.resolve_conflicts_batch(
+            user_id="wrong-owner" if defect == "owner" else _USER_ID,
+            dataset_id=dataset_id,
+            device_id="wrong-device" if defect == "device" else _DEVICE_ID,
+            resolutions=[
+                (
+                    conflict.conflict_id,
+                    "skip",
+                    None,
+                    conflict.expected_local_envelope_id,
+                    conflict.expected_remote_envelope_id,
+                    "unauthorized-command-13163",
+                )
+            ],
+            personal_context_exchange=None if defect == "proof" else exchange,
+        )
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
+
+
+def test_capacity_exhaustion_preserves_existing_candidate_and_retries_new_push(linked, monkeypatch):
+    from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
+
+    conflict, _source = _conflict(linked)
+    monkeypatch.setattr(repository_module, "_MAX_CONFLICT_HEADS", 1)
+    record = linked[4]
+    local = ProfileRecord.model_validate(
+        {**record.model_dump(mode="python"), "version_id": "second-conflicted-version-13163"}
+    )
+    result = _push(linked, _envelope(linked, local, "second-conflicted-envelope-13163"))
+    assert not result.conflicts and result.rejected[0].retryable
+    assert linked[1].store.get_envelope_by_server_cursor(conflict.authority_candidate.server_cursor).payload_ciphertext
+
+
+def test_resolved_receipt_retains_exact_replay_without_occupying_active_capacity(linked, monkeypatch):
+    from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
+
+    conflict, _source = _conflict(linked)
+    monkeypatch.setattr(repository_module, "_MAX_CONFLICT_HEADS", 1)
+    assert _resolve(linked, conflict)[1] == []
+    record = linked[4]
+    local = ProfileRecord.model_validate({**record.model_dump(mode="python"), "version_id": "new-review-version-13163"})
+    result = _push(linked, _envelope(linked, local, "new-review-envelope-13163"))
+    assert len(result.conflicts) == 1
+    assert _resolve(linked, conflict)[1] == []
+    with linked[0]._repository.database.transaction() as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type = 'sync_conflict'"
+            ).fetchone()[0]
+            == 1
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type = 'sync_conflict_receipt'"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+@pytest.mark.parametrize("resolved", [False, True])
+def test_purge_removes_encrypted_conflict_owner_and_cannot_recreate_receipt(linked, resolved):
+    conflict, _source = _conflict(linked, collision=True)
+    if resolved:
+        assert _resolve(linked, conflict)[1] == []
+    canonical, sync, _dataset, _exchange, record = linked
+    canonical.purge_profile(mode="everywhere", confirmation="DELETE EVERYWHERE", expected_purge_generation=0)
+    with canonical._repository.database.transaction() as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_versions WHERE object_type IN ('sync_conflict', 'sync_conflict_receipt')"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type IN ('sync_conflict', 'sync_conflict_receipt')"
+            ).fetchone()[0]
+            == 0
+        )
+    from tldw_Server_API.app.core.Personalization.personal_context_repository_models import ConcurrentProfileUpdateError
+
+    with pytest.raises(ConcurrentProfileUpdateError):
+        canonical.get_sync_conflict(conflict.conflict_id)
+    assert len(canonical.list_records()) == 0
+
+
+def test_http_push_serializes_protected_candidate(linked):
+    from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import _production_client
+
+    canonical, sync, dataset_id, exchange, record = linked
+    local = ProfileRecord.model_validate({**record.model_dump(mode="python"), "version_id": "http-local-version-13163"})
+    envelope = _envelope(linked, local, "http-local-envelope-13163")
+    with _production_client(sync._certification_production_app) as client:
+        response = client.post(
+            "/api/v1/sync/push",
+            json={
+                "dataset_id": dataset_id,
+                "device_id": _DEVICE_ID,
+                "personal_context_exchange": exchange.model_dump(mode="json"),
+                "envelopes": [asdict(envelope)],
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()["conflicts"][0]
+    assert body["authority_candidate"]["authority"]["role"] == "home_authority"
+    assert body["expected_remote_envelope_id"] == body["authority_candidate"]["client_envelope_id"]
+
+
+def test_postgres_candidate_attachment_replay_and_retention(production_factories, pg_database_config, monkeypatch):
+    from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+    from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+    from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+    canonical, sync = production_factories
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    sync.store = SyncV2Store(SyncDatabase(backend=backend))
+    relay_type = type(sync.personal_context_relay)
+    original_relay = relay_type.relay_profile
+
+    def deterministic_relay(relay, **kwargs):
+        relay.clock_ns = lambda: 0
+        return original_relay(relay, **kwargs)
+
+    monkeypatch.setattr(relay_type, "relay_profile", deterministic_relay)
+    try:
+        runtime = _link(canonical, sync)
+        conflict, incoming = _conflict(runtime, collision=True)
+        replay = _push(runtime, incoming)
+        assert replay.conflicts, [(item.error_code, item.retryable) for item in replay.rejected]
+        assert replay.conflicts[0].expected_remote_envelope_id == conflict.expected_remote_envelope_id
+        assert sync.store.envelope_is_conflict_pinned(runtime[2], conflict.expected_remote_envelope_id)
+        from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+
+        with pytest.raises(SyncStoreError, match="retention_conflict_pinned"):
+            with sync.store.retention_domain_guard(
+                runtime[2], "personal_context.record", [runtime[4].record_id]
+            ) as guarded:
+                guarded.record_domain_compaction(
+                    runtime[2],
+                    "personal_context.record",
+                    through_server_sequence=conflict.authority_candidate.server_cursor,
+                    state={},
+                )
+        assert _resolve(runtime, conflict)[1] == []
+        assert not sync.store.envelope_is_conflict_pinned(runtime[2], conflict.expected_remote_envelope_id)
+    finally:
+        backend.get_pool().close_all()
+
+
+def test_guarded_authority_delete_respects_unresolved_references(activation_store):
+    """Exercise the actual destructive query on SQLite and PostgreSQL."""
+    from tldw_Server_API.app.core.Sync.v2.models import SyncConflictCreate
+
+    metadata = {
+        "role": "home_authority",
+        "publication_batch_id": "protected-publication-13163",
+        "profile_publication_sequence": 1,
+        "batch_ordinal": 0,
+        "batch_size": 1,
+    }
+    candidate = activation_store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="activation-dataset",
+            device_id="server-origin",
+            client_envelope_id="protected-candidate-13163",
+            domain="personal_context.record",
+            operation="upsert",
+            object_id="protected-object-13163",
+            payload_ciphertext="opaque-encrypted-storage-fixture",
+            payload_hash="sha256:" + "a" * 64,
+            routing_metadata={
+                "profile_id": "profile-0123456789",
+                "purge_generation": 0,
+                "personal_context_authority": metadata,
+            },
+        )
+    )
+    activation_store.insert_conflict(
+        SyncConflictCreate(
+            conflict_id="protected-conflict-13163",
+            dataset_id=candidate.dataset_id,
+            domain=candidate.domain,
+            object_id=candidate.object_id,
+            conflict_type="fixture_conflict",
+            local_envelope_id=candidate.client_envelope_id,
+            remote_envelope_id=candidate.client_envelope_id,
+            server_cursor=candidate.server_cursor,
+        )
+    )
+    values = dict(
+        server_cursor=candidate.server_cursor,
+        dataset_id=candidate.dataset_id,
+        client_envelope_id=candidate.client_envelope_id,
+        profile_id="profile-0123456789",
+        purge_generation=0,
+        **{key: value for key, value in metadata.items() if key != "role"},
+    )
+    assert activation_store.db.discard_pending_personal_context_authority(**values) == "mismatch"
+    assert activation_store.get_envelope_by_server_cursor(candidate.server_cursor) is not None
+    activation_store.resolve_conflict("protected-conflict-13163")
+    assert activation_store.db.discard_pending_personal_context_authority(**values) == "removed"
+
+
+def test_candidate_staging_requires_surviving_canonical_authority(linked, monkeypatch):
+    canonical, sync, _dataset, _exchange, record = linked
+    original = type(canonical).capture_sync_conflict
+
+    def revoke_after_capture(owner, **identity):
+        journal = original(owner, **identity)
+        with owner._repository.database.transaction(immediate=True) as connection:
+            connection.execute(
+                "DELETE FROM personal_context_object_heads WHERE object_type = 'sync_conflict' AND object_id = ?",
+                (journal["conflict_id"],),
+            )
+        return journal
+
+    monkeypatch.setattr(type(canonical), "capture_sync_conflict", revoke_after_capture)
+    incoming = _envelope(
+        linked,
+        ProfileRecord.model_validate(
+            {**record.model_dump(mode="python"), "version_id": "revoked-candidate-version-13163"}
+        ),
+        "revoked-candidate-envelope-13163",
+    )
+    result = _push(linked, incoming)
+    assert not result.conflicts and result.rejected[0].retryable
+
+
+def test_candidate_replay_acquires_sync_fence_before_canonical_lock(linked, monkeypatch):
+    from contextlib import contextmanager
+
+    conflict, incoming = _conflict(linked)
+    canonical, sync, dataset_id, _exchange, _record = linked
+    original_guard = sync.store.conflict_resolution_guard
+    original_capture = type(canonical).capture_sync_conflict
+    locked = False
+
+    @contextmanager
+    def tracked_guard(*args, **kwargs):
+        nonlocal locked
+        with original_guard(*args, **kwargs) as guarded:
+            locked = True
+            try:
+                yield guarded
+            finally:
+                locked = False
+
+    def capture_under_sync_fence(owner, **identity):
+        assert locked, "canonical capture must follow the Sync fence"
+        return original_capture(owner, **identity)
+
+    monkeypatch.setattr(sync.store, "conflict_resolution_guard", tracked_guard)
+    monkeypatch.setattr(type(canonical), "capture_sync_conflict", capture_under_sync_fence)
+    source = sync.store.get_envelope_by_client_id(dataset_id, incoming.client_envelope_id)
+    replay = sync._ensure_personal_context_conflict_candidate(sync.store.get_dataset(dataset_id), source, sync.store)
+    assert replay.expected_remote_envelope_id == conflict.expected_remote_envelope_id

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -305,6 +305,114 @@ def test_signed_invalid_purge_generation_rejected_without_candidate_or_mutation(
         )
 
 
+@pytest.mark.parametrize("boundary", ["preflight", "insertion"])
+@pytest.mark.parametrize("storage_backend", ["sqlite", "postgres"])
+def test_stale_purge_after_failed_ingress_requires_refresh_and_reconfirmation(
+    production_factories: tuple[PersonalContextService, SyncV2Service],
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    storage_backend: str,
+) -> None:
+    """A stalled deletion intent remains retryable without reviewing a second stale intent."""
+    from tldw_profile_core.canonical import canonical_json_bytes
+
+    from tldw_Server_API.app.core.Sync.v2.materializers.personal_context import PersonalContextMaterializer
+    from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelope
+
+    canonical, sync = production_factories
+    if storage_backend == "postgres":
+        from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+        from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+
+        backend = DatabaseBackendFactory.create_backend(request.getfixturevalue("pg_database_config"))
+        request.addfinalizer(backend.get_pool().close_all)
+        sync.store = SyncV2Store(SyncDatabase(backend=backend))
+    relay_type = type(sync.personal_context_relay)
+    original_relay = relay_type.relay_profile
+
+    def deterministic_relay(relay: Any, **kwargs: Any) -> Any:
+        """Drain bootstrap publications without spending the live relay time budget."""
+        relay.clock_ns = lambda: 0
+        return original_relay(relay, **kwargs)
+
+    monkeypatch.setattr(relay_type, "relay_profile", deterministic_relay)
+    linked = _link(canonical, sync)
+    _canonical, _sync, dataset_id, _exchange, record = linked
+    before = canonical.get_manifest()
+    key_id, key = canonical.sync_integrity_key(record.profile_id)
+    payload = {"schema_version": 1, "profile_id": record.profile_id, "purge_generation": 1}
+    encoded = canonical_json_bytes(payload)
+    envelope = SyncEnvelopeCreate(
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        client_envelope_id="first-purge-request",
+        domain="personal_context.purge",
+        operation="tombstone",
+        object_id=record.profile_id,
+        parent_id=None,
+        entity_version=1,
+        payload=payload,
+        payload_size_bytes=len(encoded),
+        payload_hash="hmac-sha256-v1:" + hmac.new(key, encoded, hashlib.sha256).hexdigest(),
+        routing_metadata={"integrity_key_id": key_id, "profile_id": record.profile_id, "purge_generation": 0},
+    )
+
+    attempts: list[str] = []
+    apply = PersonalContextMaterializer.apply
+
+    def record_attempt(materializer: PersonalContextMaterializer, stored: SyncEnvelope, **kwargs: Any) -> Any:
+        """Observe real purge materializer entry without replacing its gated behavior."""
+        if stored.domain == "personal_context.purge":
+            attempts.append(stored.client_envelope_id)
+        return apply(materializer, stored, **kwargs)
+
+    monkeypatch.setattr(PersonalContextMaterializer, "apply", record_attempt)
+
+    first_results: list[Any] = []
+
+    def store_first() -> None:
+        """Persist a competing signed request through real ingress with a failed apply."""
+        first_results.append(_push(linked, envelope))
+
+    if boundary == "preflight":
+        store_first()
+    evaluate = sync._evaluate_envelope
+
+    def evaluate_then_compete(*args: Any, **kwargs: Any) -> Any:
+        """Move the real Sync head after validation but before insertion CAS."""
+        outcome = evaluate(*args, **kwargs)
+        if args[1].client_envelope_id == "second-purge-request":
+            store_first()
+        return outcome
+
+    with monkeypatch.context() as race:
+        if boundary == "insertion":
+            race.setattr(sync, "_evaluate_envelope", evaluate_then_compete)
+        result = _push(linked, replace(envelope, client_envelope_id="second-purge-request"))
+    first = first_results[0]
+    first_stored = sync.store.get_envelope_by_client_id(dataset_id, envelope.client_envelope_id)
+    assert first.accepted[0].apply_status == "failed"
+    assert not first.conflicts and not first.rejected
+    assert not result.accepted and not result.conflicts and len(result.rejected) == 1
+    rejection = result.rejected[0]
+    assert rejection.error_code == "personal_context_purge_reconfirmation_required"
+    assert rejection.retryable is False
+    assert rejection.message == "Refresh Personal Context and explicitly reconfirm delete-everywhere."
+    assert canonical.get_manifest() == before
+    assert canonical.get_record(record.record_id) == record
+    assert sync.store.get_envelope_by_client_id(dataset_id, envelope.client_envelope_id) == first_stored
+    assert sync.store.get_envelope_by_client_id(dataset_id, "second-purge-request") is None
+    assert sync.store.list_conflicts(dataset_id) == []
+    changed = _push(linked, replace(envelope, entity_version=2))
+    assert changed.rejected[0].error_code == "idempotency_conflict"
+    assert not changed.accepted and not changed.conflicts
+    exact_retry = _push(linked, envelope)
+    assert not exact_retry.conflicts and not exact_retry.rejected
+    assert exact_retry.accepted[0].server_sequence == first.accepted[0].server_sequence
+    assert attempts == [envelope.client_envelope_id, envelope.client_envelope_id]
+
+
 def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked: LinkedRuntime) -> None:
     """Verify conflict canaries absent from sync storage and diagnostics."""
     from pathlib import Path

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -6,13 +6,22 @@ import hashlib
 import hmac
 import json
 from dataclasses import asdict, replace
+from datetime import datetime, tzinfo
+from typing import Any
 
 import pytest
 from tldw_profile_core import ProfileRecord, canonical_bytes
 
-from tldw_Server_API.app.core.Personalization.personal_context_service import ProfileConflictError, RecordMutation
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
+from tldw_Server_API.app.core.Personalization.personal_context_service import (
+    PersonalContextService,
+    ProfileConflictError,
+    RecordMutation,
+)
 from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelopeCreate
 from tldw_Server_API.app.core.Sync.v2.personal_context_ongoing_contract import PersonalContextExchangeProof
+from tldw_Server_API.app.core.Sync.v2.service import SyncPushConflict, SyncV2Service
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
 from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_activation import activation_store as activation_store
 from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import (
     _DEVICE_ID,
@@ -27,14 +36,20 @@ from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification impo
 
 pytestmark = pytest.mark.unit
 
+LinkedRuntime = tuple[PersonalContextService, SyncV2Service, str, PersonalContextExchangeProof, ProfileRecord]
+
 
 @pytest.fixture()
-def linked(production_factories, monkeypatch):
+def linked(
+    production_factories: tuple[PersonalContextService, SyncV2Service], monkeypatch: pytest.MonkeyPatch
+) -> LinkedRuntime:
+    """Exercise linked."""
     canonical, sync = production_factories
     relay_type = type(sync.personal_context_relay)
     original_relay = relay_type.relay_profile
 
-    def deterministic_relay(relay, **kwargs):
+    def deterministic_relay(relay: Any, **kwargs: Any) -> Any:
+        """Exercise deterministic relay."""
         relay.clock_ns = lambda: 0
         return original_relay(relay, **kwargs)
 
@@ -42,7 +57,8 @@ def linked(production_factories, monkeypatch):
     return _link(canonical, sync)
 
 
-def _link(canonical, sync):
+def _link(canonical: PersonalContextService, sync: SyncV2Service) -> LinkedRuntime:
+    """Exercise link."""
     canonical.create_profile()
     _register_device(sync)
     initial = sync.bootstrap_personal_context(user_id=_USER_ID, device_id=_DEVICE_ID)
@@ -66,7 +82,8 @@ def _link(canonical, sync):
     return canonical, sync, initial.dataset_id, exchange, record
 
 
-def _reopen(linked):
+def _reopen(linked: LinkedRuntime) -> LinkedRuntime:
+    """Exercise reopen."""
     from tldw_Server_API.app.api.v1.API_Deps.personal_context_deps import personal_context_service_for_user
     from tldw_Server_API.app.core.DB_Management.backends.factory import reset_managed_sqlite_backends
     from tldw_Server_API.app.core.Sync.v2 import factory
@@ -84,7 +101,10 @@ def _reopen(linked):
 
 
 @pytest.mark.parametrize("boundary", ["capture", "receipt"])
-def test_reopened_owners_resume_exact_conflict_after_interruption(linked, monkeypatch, boundary):
+def test_reopened_owners_resume_exact_conflict_after_interruption(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch, boundary: str
+) -> None:
+    """Verify reopened owners resume exact conflict after interruption."""
     from tldw_Server_API.app.core.Sync.v2.personal_context_conflicts import PersonalContextConflictService
 
     canonical, sync, dataset_id, _exchange, record = linked
@@ -94,7 +114,8 @@ def test_reopened_owners_resume_exact_conflict_after_interruption(linked, monkey
         )
         with monkeypatch.context() as fault:
 
-            def fail_attachment(*args, **kwargs):
+            def fail_attachment(*args: Any, **kwargs: Any) -> None:
+                """Exercise fail attachment."""
                 raise RuntimeError("injected capture-before-attachment interruption")
 
             fault.setattr(PersonalContextConflictService, "_attach_candidate", fail_attachment)
@@ -115,7 +136,8 @@ def test_reopened_owners_resume_exact_conflict_after_interruption(linked, monkey
         command = _envelope(linked, replacement, "reopened-reviewed-envelope", base=record)
         with monkeypatch.context() as fault:
 
-            def fail_finalize(*args, **kwargs):
+            def fail_finalize(*args: Any, **kwargs: Any) -> None:
+                """Exercise fail finalize."""
                 raise RuntimeError("injected receipt-before-finalization interruption")
 
             fault.setattr(type(sync.store), "resolve_conflict", fail_finalize)
@@ -134,7 +156,8 @@ def test_reopened_owners_resume_exact_conflict_after_interruption(linked, monkey
             )
 
 
-def test_old_resolution_rejected_after_purge_and_recreation_attempt(linked):
+def test_old_resolution_rejected_after_purge_and_recreation_attempt(linked: LinkedRuntime) -> None:
+    """Verify old resolution rejected after purge and recreation attempt."""
     from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
 
     conflict, _source = _conflict(linked)
@@ -156,12 +179,27 @@ def test_old_resolution_rejected_after_purge_and_recreation_attempt(linked):
 
 
 @pytest.mark.parametrize("domain", ["personal_context.scope", "personal_context.proposal"])
-def test_non_record_candidate_replay_and_explicit_choice(linked, domain):
+def test_non_record_candidate_replay_and_explicit_choice(
+    linked: LinkedRuntime, domain: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify non record candidate replay and explicit choice."""
     from datetime import UTC, datetime, timedelta
+
+    from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
+
+    class FixedDateTime(datetime):
+        """Hold expiry-sensitive canonical proposal checks at one instant."""
+
+        @classmethod
+        def now(cls: type[datetime], tz: tzinfo | None = None) -> datetime:
+            """Exercise now."""
+            return datetime(2090, 9, 5, tzinfo=UTC).astimezone(tz)
 
     from tldw_Server_API.tests.Personalization.test_personal_context_service import _pending_proposal_for_scope
 
     canonical, sync, dataset_id, exchange, record = linked
+    monkeypatch.setattr(repository_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(canonical, "_clock", lambda: FixedDateTime.now(UTC))
     scope = canonical.list_scopes()[0]
     if domain == "personal_context.scope":
         original = scope
@@ -173,7 +211,7 @@ def test_non_record_candidate_replay_and_explicit_choice(linked, domain):
         proposal = _pending_proposal_for_scope(
             canonical, profile_id=record.profile_id, scope_id=scope.scope_id, proposal_id="conflicted-proposal-13163"
         )
-        now = datetime.now(UTC).replace(microsecond=0)
+        now = FixedDateTime.now(UTC)
         original = canonical.create_proposal(
             type(proposal).model_validate(
                 {**proposal.model_dump(mode="python"), "created_at": now, "expires_at": now + timedelta(days=90)}
@@ -209,7 +247,8 @@ def test_non_record_candidate_replay_and_explicit_choice(linked, domain):
     assert canonical.get_sync_conflict(conflict.conflict_id)["receipt"]["resulting_object_id"] == object_id
 
 
-def test_invalid_purge_envelope_is_rejected_without_review(linked):
+def test_invalid_purge_envelope_is_rejected_without_review(linked: LinkedRuntime) -> None:
+    """Verify invalid purge envelope is rejected without review."""
     envelope = replace(
         _envelope(linked, linked[4], "invalid-purge-envelope"), domain="personal_context.purge", operation="tombstone"
     )
@@ -221,7 +260,8 @@ def test_invalid_purge_envelope_is_rejected_without_review(linked):
     )
 
 
-def test_signed_invalid_purge_generation_rejected_without_candidate_or_mutation(linked):
+def test_signed_invalid_purge_generation_rejected_without_candidate_or_mutation(linked: LinkedRuntime) -> None:
+    """Verify signed invalid purge generation rejected without candidate or mutation."""
     from tldw_profile_core.canonical import canonical_json_bytes
 
     canonical, _sync, dataset_id, _exchange, record = linked
@@ -265,7 +305,8 @@ def test_signed_invalid_purge_generation_rejected_without_candidate_or_mutation(
         )
 
 
-def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked):
+def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked: LinkedRuntime) -> None:
+    """Verify conflict canaries absent from sync storage and diagnostics."""
     from pathlib import Path
 
     from loguru import logger
@@ -286,7 +327,10 @@ def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked):
                     assert canary not in artifact.read_bytes()
 
 
-def _envelope(linked, record, envelope_id, *, base=None):
+def _envelope(
+    linked: LinkedRuntime, record: ProfileRecord, envelope_id: str, *, base: Any = None
+) -> SyncEnvelopeCreate:
+    """Exercise envelope."""
     canonical, sync, dataset_id, _exchange, _record = linked
     key_id, key = canonical.sync_integrity_key(record.profile_id)
     payload = canonical_bytes(record)
@@ -307,7 +351,8 @@ def _envelope(linked, record, envelope_id, *, base=None):
     )
 
 
-def _push(linked, envelope):
+def _push(linked: LinkedRuntime, envelope: SyncEnvelopeCreate | None) -> Any:
+    """Exercise push."""
     _canonical, sync, dataset_id, exchange, _record = linked
     return sync.push(
         user_id=_USER_ID,
@@ -318,7 +363,17 @@ def _push(linked, envelope):
     )
 
 
-def _whole_object_envelope(linked, value, domain, object_id, version, *, parent=None, base=None):
+def _whole_object_envelope(
+    linked: LinkedRuntime,
+    value: Any,
+    domain: str,
+    object_id: str,
+    version: str,
+    *,
+    parent: str | None = None,
+    base: Any = None,
+) -> SyncEnvelopeCreate:
+    """Exercise whole object envelope."""
     canonical, _sync, dataset_id, _exchange, _record = linked
     key_id, key = canonical.sync_integrity_key(value.profile_id)
     payload = canonical_bytes(value)
@@ -340,7 +395,8 @@ def _whole_object_envelope(linked, value, domain, object_id, version, *, parent=
 
 
 @pytest.mark.parametrize("stale", [False, True])
-def test_linked_client_manifest_rejected_without_conflict_or_publication(linked, stale):
+def test_linked_client_manifest_rejected_without_conflict_or_publication(linked: LinkedRuntime, stale: bool) -> None:
+    """Verify linked client manifest rejected without conflict or publication."""
     canonical, _sync, _dataset, _exchange, _record = linked
     before = canonical.get_manifest()
     envelope = _whole_object_envelope(
@@ -383,7 +439,10 @@ def test_linked_client_manifest_rejected_without_conflict_or_publication(linked,
         ("routing_metadata_json", None),
     ],
 )
-def test_tampered_remote_candidate_replay_and_resolution_fail_closed(linked, field, value):
+def test_tampered_remote_candidate_replay_and_resolution_fail_closed(
+    linked: LinkedRuntime, field: str, value: Any
+) -> None:
+    """Verify tampered remote candidate replay and resolution fail closed."""
     conflict, incoming = _conflict(linked)
     canonical, sync, _dataset, _exchange, _record = linked
     if field == "routing_metadata_json":
@@ -405,7 +464,8 @@ def test_tampered_remote_candidate_replay_and_resolution_fail_closed(linked, fie
 
 
 @pytest.mark.parametrize("authenticated_body", [False, True])
-def test_tampered_local_ciphertext_cannot_release_review(linked, authenticated_body):
+def test_tampered_local_ciphertext_cannot_release_review(linked: LinkedRuntime, authenticated_body: bool) -> None:
+    """Verify tampered local ciphertext cannot release review."""
     conflict, _incoming = _conflict(linked)
     canonical, sync, _dataset, _exchange, _record = linked
     if authenticated_body:
@@ -436,7 +496,10 @@ def test_tampered_local_ciphertext_cannot_release_review(linked, authenticated_b
 
 
 @pytest.mark.parametrize("committed", [False, True])
-def test_new_activation_between_batch_check_and_canonical_decision_rejects(linked, monkeypatch, committed):
+def test_new_activation_between_batch_check_and_canonical_decision_rejects(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch, committed: bool
+) -> None:
+    """Verify new activation between batch check and canonical decision rejects."""
     from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
 
     conflict, _incoming = _conflict(linked)
@@ -444,7 +507,8 @@ def test_new_activation_between_batch_check_and_canonical_decision_rejects(linke
     if committed:
         with monkeypatch.context() as fault:
 
-            def fail_finalize(*args, **kwargs):
+            def fail_finalize(*args: Any, **kwargs: Any) -> None:
+                """Exercise fail finalize."""
                 raise RuntimeError("injected Sync finalization failure")
 
             fault.setattr(type(sync.store), "resolve_conflict", fail_finalize)
@@ -453,7 +517,8 @@ def test_new_activation_between_batch_check_and_canonical_decision_rejects(linke
     journal = canonical.get_sync_conflict(conflict.conflict_id)
     original = type(canonical).resolve_sync_conflict
 
-    def transition_then_resolve(owner, **command):
+    def transition_then_resolve(owner: Any, **command: Any) -> Any:
+        """Exercise transition then resolve."""
         PersonalContextActivationService(owner._repository).prepare(record.profile_id, device_id=_DEVICE_ID, fresh=True)
         return original(owner, **command)
 
@@ -474,8 +539,9 @@ def test_new_activation_between_batch_check_and_canonical_decision_rejects(linke
     ],
 )
 def test_candidate_activation_transition_rejects_and_new_activation_recovers(
-    linked, monkeypatch, boundary, replay, collision
-):
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch, boundary: str, replay: bool, collision: bool
+) -> None:
+    """Verify candidate activation transition rejects and new activation recovers."""
     from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
     from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
     from tldw_Server_API.app.core.Sync.v2.personal_context_conflicts import PersonalContextConflictService
@@ -502,14 +568,16 @@ def test_candidate_activation_transition_rejects_and_new_activation_recovers(
     original_journal = canonical.get_sync_conflict(conflict_id) if replay else None
     prepared = []
 
-    def transition(owner):
+    def transition(owner: Any) -> Any:
+        """Exercise transition."""
         prepared.append(
             PersonalContextActivationService(owner._repository).prepare(
                 record.profile_id, device_id=_DEVICE_ID, fresh=True
             )
         )
 
-    def capture_across_transition(owner, **identity):
+    def capture_across_transition(owner: Any, **identity: Any) -> Any:
+        """Exercise capture across transition."""
         if boundary == "capture":
             transition(owner)
         journal = original_capture(owner, **identity)
@@ -561,7 +629,8 @@ def test_candidate_activation_transition_rejects_and_new_activation_recovers(
     assert resumed.personal_context_exchange == newer
 
 
-def _conflict(linked, *, collision=False):
+def _conflict(linked: LinkedRuntime, *, collision: bool = False) -> tuple[SyncPushConflict, SyncEnvelopeCreate]:
+    """Exercise conflict."""
     canonical, sync, dataset_id, exchange, original = linked
     local = ProfileRecord.model_validate(
         {
@@ -578,7 +647,14 @@ def _conflict(linked, *, collision=False):
     return result.conflicts[0], envelope
 
 
-def _resolve(linked, conflict, action="skip", envelope=None, **overrides):
+def _resolve(
+    linked: LinkedRuntime,
+    conflict: SyncPushConflict,
+    action: str = "skip",
+    envelope: SyncEnvelopeCreate | None = None,
+    **overrides: Any,
+) -> Any:
+    """Exercise resolve."""
     _canonical, sync, dataset_id, exchange, _record = linked
     values = {
         "expected_local": conflict.expected_local_envelope_id,
@@ -605,7 +681,8 @@ def _resolve(linked, conflict, action="skip", envelope=None, **overrides):
 
 
 @pytest.mark.parametrize("collision", [False, True])
-def test_push_candidate_is_durable_and_exact_on_replay(linked, collision):
+def test_push_candidate_is_durable_and_exact_on_replay(linked: LinkedRuntime, collision: bool) -> None:
+    """Verify push candidate is durable and exact on replay."""
     conflict, envelope = _conflict(linked, collision=collision)
     assert conflict.expected_local_envelope_id == envelope.client_envelope_id
     assert conflict.expected_remote_envelope_id
@@ -617,7 +694,8 @@ def test_push_candidate_is_durable_and_exact_on_replay(linked, collision):
     assert stored.payload == {} and stored.payload_ciphertext
 
 
-def test_stale_review_does_not_release_freeze_or_resolve(linked):
+def test_stale_review_does_not_release_freeze_or_resolve(linked: LinkedRuntime) -> None:
+    """Verify stale review does not release freeze or resolve."""
     conflict, _envelope = _conflict(linked)
     canonical, sync, _dataset, _exchange, record = linked
     before = canonical.get_manifest()
@@ -634,7 +712,10 @@ def test_stale_review_does_not_release_freeze_or_resolve(linked):
 
 
 @pytest.mark.parametrize("collision", [False, True])
-def test_explicit_overwrite_replays_after_sync_finalization_failure(linked, monkeypatch, collision):
+def test_explicit_overwrite_replays_after_sync_finalization_failure(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch, collision: bool
+) -> None:
+    """Verify explicit overwrite replays after sync finalization failure."""
     conflict, _source = _conflict(linked, collision=collision)
     canonical, sync, _dataset, _exchange, record = linked
     replacement = ProfileRecord.model_validate(
@@ -648,7 +729,8 @@ def test_explicit_overwrite_replays_after_sync_finalization_failure(linked, monk
     command = _envelope(linked, replacement, "reviewed-replacement-envelope-13163", base=record)
     original = type(sync.store).resolve_conflict
 
-    def fail_finalize(*args, **kwargs):
+    def fail_finalize(*args: Any, **kwargs: Any) -> None:
+        """Exercise fail finalize."""
         raise RuntimeError("injected Sync finalization failure")
 
     monkeypatch.setattr(type(sync.store), "resolve_conflict", fail_finalize)
@@ -663,7 +745,8 @@ def test_explicit_overwrite_replays_after_sync_finalization_failure(linked, monk
     assert _resolve(linked, conflict, "overwrite", changed)[1] == [0]
 
 
-def test_both_candidates_appear_pinned_in_retention_preview_and_apply(linked):
+def test_both_candidates_appear_pinned_in_retention_preview_and_apply(linked: LinkedRuntime) -> None:
+    """Verify both candidates appear pinned in retention preview and apply."""
     conflict, _source = _conflict(linked, collision=True)
     _canonical, sync, dataset_id, _exchange, _record = linked
     preview = sync.retention_dry_run(user_id=_USER_ID, dataset_id=dataset_id, audit_mode=False)
@@ -674,7 +757,10 @@ def test_both_candidates_appear_pinned_in_retention_preview_and_apply(linked):
     assert sync.store.get_envelope_by_server_cursor(conflict.authority_candidate.server_cursor).payload_ciphertext
 
 
-def test_candidate_attachment_failure_is_retryable_and_reuses_canonical_snapshot(linked, monkeypatch):
+def test_candidate_attachment_failure_is_retryable_and_reuses_canonical_snapshot(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify candidate attachment failure is retryable and reuses canonical snapshot."""
     canonical, sync, _dataset, _exchange, record = linked
     local = ProfileRecord.model_validate(
         {**record.model_dump(mode="python"), "version_id": "retry-local-version-13163"}
@@ -682,7 +768,8 @@ def test_candidate_attachment_failure_is_retryable_and_reuses_canonical_snapshot
     incoming = _envelope(linked, local, "retry-local-envelope-13163")
     original = type(sync.store).insert_conflict
 
-    def fail_attachment(*args, **kwargs):
+    def fail_attachment(*args: Any, **kwargs: Any) -> None:
+        """Exercise fail attachment."""
         raise RuntimeError("injected candidate attachment failure")
 
     monkeypatch.setattr(type(sync.store), "insert_conflict", fail_attachment)
@@ -699,7 +786,8 @@ def test_candidate_attachment_failure_is_retryable_and_reuses_canonical_snapshot
 
 
 @pytest.mark.parametrize("action", ["skip", "duplicate_rename"])
-def test_collision_is_resolved_only_by_explicit_reviewed_choice(linked, action):
+def test_collision_is_resolved_only_by_explicit_reviewed_choice(linked: LinkedRuntime, action: str) -> None:
+    """Verify collision is resolved only by explicit reviewed choice."""
     conflict, incoming = _conflict(linked, collision=True)
     canonical, sync, _dataset, _exchange, record = linked
     assert canonical.get_record(record.record_id) == record
@@ -723,14 +811,141 @@ def test_collision_is_resolved_only_by_explicit_reviewed_choice(linked, action):
     assert _push(linked, incoming).rejected[0].error_code == "personal_context_conflict_resolved"
 
 
-def test_collision_wrong_target_cannot_silently_replace_identity(linked):
+def test_collision_wrong_target_cannot_silently_replace_identity(linked: LinkedRuntime) -> None:
+    """Verify collision wrong target cannot silently replace identity."""
     conflict, incoming = _conflict(linked, collision=True)
     assert _resolve(linked, conflict, "overwrite", incoming)[1] == [0]
     assert linked[0].get_record(linked[4].record_id) == linked[4]
     assert linked[1].store.get_conflict(conflict.conflict_id).status == "unresolved"
 
 
-def test_collision_freezes_both_ids_but_unrelated_ingress_continues(linked):
+@pytest.mark.parametrize("collision", [False, True])
+def test_duplicate_requires_concrete_active_semantic_key(linked: LinkedRuntime, collision: bool) -> None:
+    """Keep-both cannot consume a candidate without creating a distinct keyed fact."""
+    from tldw_Server_API.app.core.exceptions import PersonalContextConflictInputError
+
+    conflict, incoming = _conflict(linked, collision=collision)
+    canonical, sync, _dataset, _exchange, _record = linked
+    before = canonical.get_manifest()
+    distinct = ProfileRecord.model_validate(
+        {**incoming.payload, "record_id": "missing-key-duplicate", "semantic_key": None}
+    )
+    command = _envelope(linked, distinct, "missing-key-resolution")
+    with pytest.raises(PersonalContextConflictInputError):
+        canonical.resolve_sync_conflict(
+            conflict_id=conflict.conflict_id,
+            dataset_id=linked[2],
+            device_id=_DEVICE_ID,
+            expected_local_envelope_id=conflict.expected_local_envelope_id,
+            expected_remote_envelope_id=conflict.expected_remote_envelope_id,
+            idempotency_key="invalid-direct-choice",
+            action="duplicate_rename",
+            command=asdict(command),
+            purge_generation=0,
+            exchange=linked[3],
+        )
+    assert _resolve(linked, conflict, "duplicate_rename", command)[1] == [0]
+    assert canonical.get_manifest() == before
+    assert len(canonical.list_records()) == 1
+    assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
+    assert canonical.get_sync_conflict(conflict.conflict_id)["state"] == "unresolved"
+
+
+@pytest.mark.parametrize("action", ["overwrite", "duplicate_rename"])
+@pytest.mark.parametrize("relay_fails", [False, True])
+def test_resolution_relays_after_canonical_commit(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch, action: str, relay_fails: bool
+) -> None:
+    """A reviewed mutation relays after both commits and tolerates egress failure."""
+    from contextlib import contextmanager
+
+    conflict, incoming = _conflict(linked, collision=True)
+    canonical, sync, dataset_id, _exchange, record = linked
+    original_guard = sync.store.conflict_resolution_guard
+    locked = False
+
+    @contextmanager
+    def tracked_guard(*args: Any, **kwargs: Any) -> Any:
+        """Exercise tracked guard."""
+        nonlocal locked
+        with original_guard(*args, **kwargs) as guarded:
+            locked = True
+            try:
+                yield guarded
+            finally:
+                locked = False
+
+    monkeypatch.setattr(sync.store, "conflict_resolution_guard", tracked_guard)
+    payload = {**incoming.payload, "version_id": "immediate-resolution-version"}
+    if action == "overwrite":
+        payload.update(record_id=record.record_id, parent_version_id=record.version_id)
+    else:
+        payload.update(
+            record_id="immediate-distinct-record", semantic_key={"namespace": "preference", "subject": "distinct"}
+        )
+    replacement = ProfileRecord.model_validate(payload)
+    command = _envelope(
+        linked, replacement, "immediate-resolution-envelope", base=record if action == "overwrite" else None
+    )
+    relay_type = type(sync.personal_context_relay)
+    original = relay_type.relay_profile
+    relayed = []
+
+    def relay_after_receipt(owner: Any, **kwargs: Any) -> Any:
+        """Observe the committed receipt only after releasing the outer Sync fence."""
+        assert not locked
+        assert canonical.get_sync_conflict(conflict.conflict_id)["state"] == "resolved"
+        relayed.append(kwargs["profile_id"])
+        if relay_fails:
+            raise RuntimeError("injected relay failure")
+        return original(owner, **kwargs)
+
+    monkeypatch.setattr(relay_type, "relay_profile", relay_after_receipt)
+    assert _resolve(linked, conflict, action, command)[1] == []
+    assert relayed == [record.profile_id]
+    if not relay_fails:
+        head = sync.store.get_current_head(dataset_id, "personal_context.record", replacement.record_id)
+        assert head.entity_version == replacement.version_id
+    assert canonical.get_record(replacement.record_id) == replacement
+
+
+def test_direct_resolution_replay_schedules_committed_publication(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Direct service callers schedule replayed publication debt after receipt commit."""
+    conflict, _incoming = _conflict(linked)
+    canonical, _sync, dataset_id, exchange, record = linked
+    replacement = record.model_copy(
+        update={"version_id": "direct-reviewed-version", "parent_version_id": record.version_id}
+    )
+    command = _envelope(linked, replacement, "direct-reviewed-envelope", base=record)
+    relayed = []
+
+    def committed(profile_id: str) -> None:
+        """Observe the durable receipt when direct service relay is requested."""
+        assert canonical.get_sync_conflict(conflict.conflict_id)["state"] == "resolved"
+        relayed.append(profile_id)
+
+    canonical.set_after_commit_relay(committed)
+    values = {
+        "conflict_id": conflict.conflict_id,
+        "dataset_id": dataset_id,
+        "device_id": _DEVICE_ID,
+        "expected_local_envelope_id": conflict.expected_local_envelope_id,
+        "expected_remote_envelope_id": conflict.expected_remote_envelope_id,
+        "idempotency_key": "direct-reviewed-choice",
+        "action": "overwrite",
+        "command": asdict(command),
+        "purge_generation": 0,
+        "exchange": exchange,
+    }
+    first = canonical.resolve_sync_conflict(**values)
+    assert canonical.resolve_sync_conflict(**values) == first
+    assert relayed == [record.profile_id, record.profile_id]
+
+
+def test_collision_freezes_both_ids_but_unrelated_ingress_continues(linked: LinkedRuntime) -> None:
+    """Verify collision freezes both ids but unrelated ingress continues."""
     conflict, incoming = _conflict(linked, collision=True)
     canonical, sync, _dataset, _exchange, record = linked
     escaped = ProfileRecord.model_validate(
@@ -749,7 +964,10 @@ def test_collision_freezes_both_ids_but_unrelated_ingress_continues(linked):
 
 
 @pytest.mark.parametrize("resolved", [False, True])
-def test_exact_journal_survives_reopen_rotation_and_contains_no_plaintext(linked, resolved):
+def test_exact_journal_survives_reopen_rotation_and_contains_no_plaintext(
+    linked: LinkedRuntime, resolved: bool
+) -> None:
+    """Verify exact journal survives reopen rotation and contains no plaintext."""
     conflict, _source = _conflict(linked, collision=True)
     if resolved:
         assert _resolve(linked, conflict)[1] == []
@@ -776,7 +994,8 @@ def test_exact_journal_survives_reopen_rotation_and_contains_no_plaintext(linked
     assert _resolve(linked, conflict)[1] == []
 
 
-def test_batch_partial_failure_preserves_stale_item_and_commits_valid_skip(linked):
+def test_batch_partial_failure_preserves_stale_item_and_commits_valid_skip(linked: LinkedRuntime) -> None:
+    """Verify batch partial failure preserves stale item and commits valid skip."""
     conflict, _source = _conflict(linked)
     _canonical, sync, dataset_id, exchange, _record = linked
     valid = (
@@ -799,7 +1018,8 @@ def test_batch_partial_failure_preserves_stale_item_and_commits_valid_skip(linke
 
 
 @pytest.mark.parametrize("defect", ["owner", "device", "proof"])
-def test_wrong_authority_cannot_resolve_or_release(linked, defect):
+def test_wrong_authority_cannot_resolve_or_release(linked: LinkedRuntime, defect: str) -> None:
+    """Verify wrong authority cannot resolve or release."""
     conflict, _source = _conflict(linked)
     _canonical, sync, dataset_id, exchange, _record = linked
     from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
@@ -824,7 +1044,10 @@ def test_wrong_authority_cannot_resolve_or_release(linked, defect):
     assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
 
 
-def test_capacity_exhaustion_preserves_existing_candidate_and_retries_new_push(linked, monkeypatch):
+def test_capacity_exhaustion_preserves_existing_candidate_and_retries_new_push(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify capacity exhaustion preserves existing candidate and retries new push."""
     from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
 
     conflict, _source = _conflict(linked)
@@ -838,7 +1061,10 @@ def test_capacity_exhaustion_preserves_existing_candidate_and_retries_new_push(l
     assert linked[1].store.get_envelope_by_server_cursor(conflict.authority_candidate.server_cursor).payload_ciphertext
 
 
-def test_resolved_receipt_retains_exact_replay_without_occupying_active_capacity(linked, monkeypatch):
+def test_resolved_receipt_retains_exact_replay_without_occupying_active_capacity(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify resolved receipt retains exact replay without occupying active capacity."""
     from tldw_Server_API.app.core.DB_Management import Personal_Context_Repository as repository_module
 
     conflict, _source = _conflict(linked)
@@ -865,7 +1091,10 @@ def test_resolved_receipt_retains_exact_replay_without_occupying_active_capacity
 
 
 @pytest.mark.parametrize("resolved", [False, True])
-def test_purge_removes_encrypted_conflict_owner_and_cannot_recreate_receipt(linked, resolved):
+def test_purge_removes_encrypted_conflict_owner_and_cannot_recreate_receipt(
+    linked: LinkedRuntime, resolved: bool
+) -> None:
+    """Verify purge removes encrypted conflict owner and cannot recreate receipt."""
     conflict, _source = _conflict(linked, collision=True)
     if resolved:
         assert _resolve(linked, conflict)[1] == []
@@ -891,7 +1120,8 @@ def test_purge_removes_encrypted_conflict_owner_and_cannot_recreate_receipt(link
     assert len(canonical.list_records()) == 0
 
 
-def test_http_push_serializes_protected_candidate(linked):
+def test_http_push_serializes_protected_candidate(linked: LinkedRuntime) -> None:
+    """Verify http push serializes protected candidate."""
     from tldw_Server_API.tests.Sync.test_sync_v2_personal_context_certification import _production_client
 
     canonical, sync, dataset_id, exchange, record = linked
@@ -913,7 +1143,14 @@ def test_http_push_serializes_protected_candidate(linked):
     assert body["expected_remote_envelope_id"] == body["authority_candidate"]["client_envelope_id"]
 
 
-def test_postgres_candidate_attachment_replay_and_retention(production_factories, pg_database_config, monkeypatch):
+@pytest.mark.parametrize("action", ["skip", "overwrite", "duplicate_rename"])
+def test_postgres_candidate_attachment_replay_and_retention(
+    production_factories: tuple[PersonalContextService, SyncV2Service],
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+) -> None:
+    """Verify postgres candidate attachment replay and retention."""
     from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
     from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
     from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
@@ -924,7 +1161,8 @@ def test_postgres_candidate_attachment_replay_and_retention(production_factories
     relay_type = type(sync.personal_context_relay)
     original_relay = relay_type.relay_profile
 
-    def deterministic_relay(relay, **kwargs):
+    def deterministic_relay(relay: Any, **kwargs: Any) -> Any:
+        """Exercise deterministic relay."""
         relay.clock_ns = lambda: 0
         return original_relay(relay, **kwargs)
 
@@ -948,13 +1186,35 @@ def test_postgres_candidate_attachment_replay_and_retention(production_factories
                     through_server_sequence=conflict.authority_candidate.server_cursor,
                     state={},
                 )
-        assert _resolve(runtime, conflict)[1] == []
+        record = runtime[4]
+        command = None
+        if action != "skip":
+            replacement = ProfileRecord.model_validate(
+                {
+                    **record.model_dump(mode="python"),
+                    "version_id": "postgres-reviewed-version",
+                    "record_id": record.record_id if action == "overwrite" else "postgres-distinct-record",
+                    "parent_version_id": record.version_id if action == "overwrite" else None,
+                    "semantic_key": record.semantic_key
+                    if action == "overwrite"
+                    else {"namespace": "preference", "subject": "postgres.distinct"},
+                }
+            )
+            command = _envelope(
+                runtime, replacement, "postgres-reviewed-envelope", base=record if action == "overwrite" else None
+            )
+        assert _resolve(runtime, conflict, action, command)[1] == []
         assert not sync.store.envelope_is_conflict_pinned(runtime[2], conflict.expected_remote_envelope_id)
+        if command is not None:
+            assert (
+                sync.store.get_current_head(runtime[2], "personal_context.record", command.object_id).entity_version
+                == replacement.version_id
+            )
     finally:
         backend.get_pool().close_all()
 
 
-def test_guarded_authority_delete_respects_unresolved_references(activation_store):
+def test_guarded_authority_delete_respects_unresolved_references(activation_store: SyncV2Store) -> None:
     """Exercise the actual destructive query on SQLite and PostgreSQL."""
     from tldw_Server_API.app.core.Sync.v2.models import SyncConflictCreate
 
@@ -1008,11 +1268,91 @@ def test_guarded_authority_delete_respects_unresolved_references(activation_stor
     assert activation_store.db.discard_pending_personal_context_authority(**values) == "removed"
 
 
-def test_candidate_staging_requires_surviving_canonical_authority(linked, monkeypatch):
+def test_informational_conflict_pins_allow_unrelated_domain_compaction(activation_store: SyncV2Store) -> None:
+    """Synthetic review rows retain ciphertext without blocking another domain."""
+    from tldw_Server_API.app.core.Sync.v2.adapters import SyncAdapterRegistry
+    from tldw_Server_API.app.core.Sync.v2.models import SyncConflictCreate
+    from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service
+
+    store = activation_store
+    first = store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="activation-dataset",
+            device_id="server-origin",
+            client_envelope_id="scope-v1",
+            domain="personal_context.scope",
+            operation="upsert",
+            object_id="unrelated-scope",
+            entity_version="scope-version-1",
+            payload_ciphertext="opaque-scope-1",
+            payload_hash="sha256:scope-1",
+            apply_status="applied",
+            object_revision=1,
+        )
+    )
+    store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="activation-dataset",
+            device_id="server-origin",
+            client_envelope_id="scope-v2",
+            domain="personal_context.scope",
+            operation="upsert",
+            object_id="unrelated-scope",
+            entity_version="scope-version-2",
+            payload_ciphertext="opaque-scope-2",
+            payload_hash="sha256:scope-2",
+            apply_status="applied",
+            object_revision=2,
+            base_server_cursor=first.server_cursor,
+            base_object_revision=first.object_revision,
+            base_object_hash=first.payload_hash,
+        )
+    )
+    candidates = [
+        store.insert_envelope(
+            SyncEnvelopeCreate(
+                dataset_id="activation-dataset",
+                device_id="server-origin",
+                client_envelope_id=identity,
+                domain="personal_context.record",
+                operation="upsert",
+                object_id="contested-record",
+                status="conflict",
+                payload_ciphertext="opaque-review-candidate",
+                payload_hash="sha256:review",
+                apply_status="applied",
+            )
+        )
+        for identity in ("local-candidate", "remote-candidate")
+    ]
+    store.insert_conflict(
+        SyncConflictCreate(
+            conflict_id="unresolved-review",
+            dataset_id="activation-dataset",
+            domain="personal_context.record",
+            object_id="contested-record",
+            conflict_type="personal_context_base_conflict",
+            local_envelope_id=candidates[0].client_envelope_id,
+            remote_envelope_id=candidates[1].client_envelope_id,
+            server_cursor=candidates[0].server_cursor,
+        )
+    )
+    service = SyncV2Service(store=store, adapters=SyncAdapterRegistry([]))
+    result = service.retention_compact(user_id="activation-user", dataset_id="activation-dataset", confirm=True)
+    assert result.mutation_performed
+    assert store.get_domain_compaction_sequence("activation-dataset", "personal_context.scope") == first.server_cursor
+    assert all(store.get_envelope_by_server_cursor(row.server_cursor).payload_ciphertext for row in candidates)
+
+
+def test_candidate_staging_requires_surviving_canonical_authority(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify candidate staging requires surviving canonical authority."""
     canonical, sync, _dataset, _exchange, record = linked
     original = type(canonical).capture_sync_conflict
 
-    def revoke_after_capture(owner, **identity):
+    def revoke_after_capture(owner: Any, **identity: Any) -> Any:
+        """Exercise revoke after capture."""
         journal = original(owner, **identity)
         with owner._repository.database.transaction(immediate=True) as connection:
             connection.execute(
@@ -1033,7 +1373,10 @@ def test_candidate_staging_requires_surviving_canonical_authority(linked, monkey
     assert not result.conflicts and result.rejected[0].retryable
 
 
-def test_candidate_replay_acquires_sync_fence_before_canonical_lock(linked, monkeypatch):
+def test_candidate_replay_acquires_sync_fence_before_canonical_lock(
+    linked: LinkedRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify candidate replay acquires sync fence before canonical lock."""
     from contextlib import contextmanager
 
     conflict, incoming = _conflict(linked)
@@ -1043,7 +1386,8 @@ def test_candidate_replay_acquires_sync_fence_before_canonical_lock(linked, monk
     locked = False
 
     @contextmanager
-    def tracked_guard(*args, **kwargs):
+    def tracked_guard(*args: Any, **kwargs: Any) -> Any:
+        """Exercise tracked guard."""
         nonlocal locked
         with original_guard(*args, **kwargs) as guarded:
             locked = True
@@ -1052,7 +1396,8 @@ def test_candidate_replay_acquires_sync_fence_before_canonical_lock(linked, monk
             finally:
                 locked = False
 
-    def capture_under_sync_fence(owner, **identity):
+    def capture_under_sync_fence(owner: Any, **identity: Any) -> Any:
+        """Exercise capture under sync fence."""
         assert locked, "canonical capture must follow the Sync fence"
         return original_capture(owner, **identity)
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -464,6 +464,103 @@ def test_new_activation_between_batch_check_and_canonical_decision_rejects(linke
     assert sync.store.get_conflict(conflict.conflict_id).status == "unresolved"
 
 
+@pytest.mark.parametrize(
+    "boundary,replay,collision",
+    [
+        ("capture", False, False),
+        ("staging", False, True),
+        ("capture", True, False),
+        ("staging", True, True),
+    ],
+)
+def test_candidate_activation_transition_rejects_and_new_activation_recovers(
+    linked, monkeypatch, boundary, replay, collision
+):
+    from tldw_Server_API.app.core.Personalization.personal_context_activation import PersonalContextActivationService
+    from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+    from tldw_Server_API.app.core.Sync.v2.personal_context_conflicts import PersonalContextConflictService
+
+    canonical, sync, dataset_id, old_exchange, record = linked
+    if replay:
+        previous, incoming = _conflict(linked, collision=collision)
+    else:
+        previous = None
+        incoming = _envelope(
+            linked,
+            record.model_copy(
+                update={
+                    "record_id": "activation-collision-record" if collision else record.record_id,
+                    "version_id": "activation-conflict-version",
+                    "parent_version_id": None,
+                }
+            ),
+            "activation-conflict-envelope",
+        )
+    conflict_id = PersonalContextConflictService.conflict_id(dataset_id, _DEVICE_ID, incoming.client_envelope_id)
+    before = canonical.get_manifest()
+    original_capture = type(canonical).capture_sync_conflict
+    original_journal = canonical.get_sync_conflict(conflict_id) if replay else None
+    prepared = []
+
+    def transition(owner):
+        prepared.append(
+            PersonalContextActivationService(owner._repository).prepare(
+                record.profile_id, device_id=_DEVICE_ID, fresh=True
+            )
+        )
+
+    def capture_across_transition(owner, **identity):
+        if boundary == "capture":
+            transition(owner)
+        journal = original_capture(owner, **identity)
+        if boundary == "staging":
+            transition(owner)
+        return journal
+
+    with monkeypatch.context() as fault:
+        fault.setattr(type(canonical), "capture_sync_conflict", capture_across_transition)
+        with pytest.raises(SyncStoreError, match="personal_context_activation_required"):
+            _push(linked, incoming)
+    assert canonical.get_manifest() == before
+    if replay or boundary == "staging":
+        journal = canonical.get_sync_conflict(conflict_id)
+        if replay:
+            assert journal == original_journal
+        else:
+            assert sync.store.get_conflict(conflict_id) is None
+    else:
+        with canonical._repository.database.transaction() as connection:
+            assert (
+                connection.execute(
+                    "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type = 'sync_conflict'"
+                ).fetchone()[0]
+                == 0
+            )
+    with pytest.raises(SyncStoreError, match="personal_context_activation_required"):
+        sync.require_active_exchange(
+            dataset=sync.store.get_dataset(dataset_id), user_id=_USER_ID, device_id=_DEVICE_ID, exchange=old_exchange
+        )
+    newer = PersonalContextExchangeProof.model_validate(_seed_exchange(sync, dataset_id))
+    assert canonical._repository.load_activation(prepared[0].activation_id).state == "active"
+    if boundary == "staging" and not replay:
+        changed = _envelope(
+            linked,
+            ProfileRecord.model_validate({**incoming.payload, "version_id": "changed-activation-retry"}),
+            incoming.client_envelope_id,
+        )
+        denied = _push((canonical, sync, dataset_id, newer, record), changed)
+        assert not denied.conflicts and not denied.accepted
+        assert denied.rejected[0].error_code == "idempotency_conflict"
+        assert canonical.get_sync_conflict(conflict_id) == journal
+    resumed = _push((canonical, sync, dataset_id, newer, record), incoming)
+    assert len(resumed.conflicts) == 1, [(item.error_code, item.retryable) for item in resumed.rejected]
+    if previous is not None:
+        assert asdict(resumed.conflicts[0]) == asdict(previous)
+    elif boundary == "staging":
+        assert resumed.conflicts[0].expected_remote_envelope_id == journal["remote_envelope_id"]
+    assert resumed.personal_context_exchange == newer
+
+
 def _conflict(linked, *, collision=False):
     canonical, sync, dataset_id, exchange, original = linked
     local = ProfileRecord.model_validate(
@@ -962,5 +1059,7 @@ def test_candidate_replay_acquires_sync_fence_before_canonical_lock(linked, monk
     monkeypatch.setattr(sync.store, "conflict_resolution_guard", tracked_guard)
     monkeypatch.setattr(type(canonical), "capture_sync_conflict", capture_under_sync_fence)
     source = sync.store.get_envelope_by_client_id(dataset_id, incoming.client_envelope_id)
-    replay = sync._ensure_personal_context_conflict_candidate(sync.store.get_dataset(dataset_id), source, sync.store)
+    replay = sync._ensure_personal_context_conflict_candidate(
+        sync.store.get_dataset(dataset_id), source, sync.store, exchange=_exchange
+    )
     assert replay.expected_remote_envelope_id == conflict.expected_remote_envelope_id

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py
@@ -221,6 +221,50 @@ def test_invalid_purge_envelope_is_rejected_without_review(linked):
     )
 
 
+def test_signed_invalid_purge_generation_rejected_without_candidate_or_mutation(linked):
+    from tldw_profile_core.canonical import canonical_json_bytes
+
+    canonical, _sync, dataset_id, _exchange, record = linked
+    before = canonical.get_manifest()
+    key_id, key = canonical.sync_integrity_key(record.profile_id)
+    payload = {"schema_version": 1, "profile_id": record.profile_id, "purge_generation": 2}
+    encoded = canonical_json_bytes(payload)
+    envelope = SyncEnvelopeCreate(
+        dataset_id=dataset_id,
+        device_id=_DEVICE_ID,
+        client_envelope_id="invalid-generation-purge",
+        domain="personal_context.purge",
+        operation="tombstone",
+        object_id=record.profile_id,
+        parent_id=None,
+        entity_version=2,
+        payload=payload,
+        payload_size_bytes=len(encoded),
+        payload_hash="hmac-sha256-v1:" + hmac.new(key, encoded, hashlib.sha256).hexdigest(),
+        routing_metadata={"integrity_key_id": key_id, "profile_id": record.profile_id, "purge_generation": 0},
+    )
+    with canonical._repository.database.transaction() as connection:
+        publications = connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+    result = _push(linked, envelope)
+    assert not result.accepted and not result.conflicts and len(result.rejected) == 1
+    rejection = result.rejected[0]
+    assert rejection.error_code == "personal_context_purge_generation_invalid"
+    assert not rejection.retryable
+    assert record.profile_id not in rejection.message
+    assert canonical.get_manifest() == before
+    with canonical._repository.database.transaction() as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM personal_context_object_heads WHERE object_type = 'sync_conflict'"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            connection.execute("SELECT COUNT(*) FROM personal_context_publication_batches").fetchone()[0]
+            == publications
+        )
+
+
 def test_conflict_canaries_absent_from_sync_storage_and_diagnostics(linked):
     from pathlib import Path
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
@@ -74,6 +74,7 @@ def ingress_store(
 
 
 def _ingress_envelope(**overrides: object) -> SyncEnvelopeCreate:
+    """Build an ordinary client-ingress envelope with explicit scenario overrides."""
     values = {
         "dataset_id": "repair-dataset",
         "domain": "personal_context.record",
@@ -94,6 +95,7 @@ def _ingress_envelope(**overrides: object) -> SyncEnvelopeCreate:
 def test_ordinary_ingress_advances_domain_watermark_without_regression(
     ingress_store: tuple[SyncV2Store, int, CanonicalApplyReceipt],
 ) -> None:
+    """Ordinary insertion, replay and re-enrollment never regress domain progress."""
     store, first_cursor, _receipt = ingress_store
     second = store.insert_envelope(
         _ingress_envelope(
@@ -103,15 +105,17 @@ def test_ordinary_ingress_advances_domain_watermark_without_regression(
     )
     assert second.server_cursor > first_cursor
     assert store.insert_envelope(_ingress_envelope()).server_cursor == first_cursor
-    with store.db.backend.transaction() as connection:
-        # Replay may revisit an older sequence; never lower the watermark.
-        store.db._ensure_domain_state(
+    # Re-enrollment revisits the initial sequence through the public store API.
+    store.enroll_dataset(
+        SyncDatasetCreate(
             dataset_id="repair-dataset",
-            domain="personal_context.record",
-            adapter_version=1,
-            server_sequence=first_cursor,
-            connection=connection,
+            owner_user_id="repair-user",
+            encryption_policy="server_trusted_v1",
+            domains=sorted(PERSONAL_CONTEXT_SYNC_DOMAINS),
         )
+    )
+    with store.db.backend.transaction() as connection:
+        # Inspect persisted progress independently of envelope cursor allocation.
         row = store.db.execute(
             "SELECT server_sequence FROM sync_domain_state WHERE dataset_id = ? AND domain = ?",
             ("repair-dataset", "personal_context.record"),

--- a/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_personal_context_ingress_repair.py
@@ -11,7 +11,12 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
 from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
 from tldw_Server_API.app.core.Personalization.personal_context_publication import CanonicalApplyReceipt
-from tldw_Server_API.app.core.Sync.v2.models import PERSONAL_CONTEXT_SYNC_DOMAINS, SyncDatasetCreate, SyncDeviceUpsert
+from tldw_Server_API.app.core.Sync.v2.models import (
+    PERSONAL_CONTEXT_SYNC_DOMAINS,
+    SyncDatasetCreate,
+    SyncDeviceUpsert,
+    SyncEnvelopeCreate,
+)
 from tldw_Server_API.app.core.Sync.v2.store import SyncStoreError, SyncV2Store
 
 pytestmark = pytest.mark.unit
@@ -45,36 +50,7 @@ def ingress_store(
             domains=sorted(PERSONAL_CONTEXT_SYNC_DOMAINS),
         )
     )
-    # Seed this narrow storage fixture directly: ordinary PostgreSQL insertion
-    # currently hits an unrelated _ensure_domain_state placeholder mismatch.
-    # The bootstrap regression covers the complete SQLite push/repair workflow.
-    with database.backend.transaction() as connection:
-        database.execute(
-            """INSERT INTO sync_envelopes (
-               server_sequence, dataset_id, domain, entity_id, operation,
-               client_envelope_id, device_id, server_timestamp, entity_version,
-               routing_metadata_json, payload_ciphertext, payload_hash,
-               payload_size_bytes, adapter_version, status)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                1,
-                "repair-dataset",
-                "personal_context.record",
-                "repair-record",
-                "upsert",
-                "repair-client-envelope",
-                "repair-device",
-                "2026-09-04T00:00:00Z",
-                '"record-v1"',
-                '{"personal_context_authority":{"role":"client_ingress"}}',
-                "opaque-fixture-ciphertext",
-                "hmac-sha256-v1:" + "a" * 64,
-                24,
-                1,
-                "accepted",
-            ),
-            connection=connection,
-        )
+    envelope = store.insert_envelope(_ingress_envelope())
     receipt = CanonicalApplyReceipt(
         resulting_object_id="repair-record",
         resulting_version_id="record-v1",
@@ -91,10 +67,57 @@ def ingress_store(
         wire_entity_version="record-v1",
     )
     try:
-        yield store, 1, receipt
+        yield store, envelope.server_cursor, receipt
     finally:
         if backend is not None:
             backend.get_pool().close_all()
+
+
+def _ingress_envelope(**overrides: object) -> SyncEnvelopeCreate:
+    values = {
+        "dataset_id": "repair-dataset",
+        "domain": "personal_context.record",
+        "object_id": "repair-record",
+        "operation": "upsert",
+        "client_envelope_id": "repair-client-envelope",
+        "device_id": "repair-device",
+        "entity_version": "record-v1",
+        "routing_metadata": {"personal_context_authority": {"role": "client_ingress"}},
+        "payload_ciphertext": "opaque-fixture-ciphertext",
+        "payload_hash": "hmac-sha256-v1:" + "a" * 64,
+        "payload_size_bytes": 24,
+    }
+    values.update(overrides)
+    return SyncEnvelopeCreate(**values)
+
+
+def test_ordinary_ingress_advances_domain_watermark_without_regression(
+    ingress_store: tuple[SyncV2Store, int, CanonicalApplyReceipt],
+) -> None:
+    store, first_cursor, _receipt = ingress_store
+    second = store.insert_envelope(
+        _ingress_envelope(
+            object_id="second-record",
+            client_envelope_id="second-envelope",
+        )
+    )
+    assert second.server_cursor > first_cursor
+    assert store.insert_envelope(_ingress_envelope()).server_cursor == first_cursor
+    with store.db.backend.transaction() as connection:
+        # Replay may revisit an older sequence; never lower the watermark.
+        store.db._ensure_domain_state(
+            dataset_id="repair-dataset",
+            domain="personal_context.record",
+            adapter_version=1,
+            server_sequence=first_cursor,
+            connection=connection,
+        )
+        row = store.db.execute(
+            "SELECT server_sequence FROM sync_domain_state WHERE dataset_id = ? AND domain = ?",
+            ("repair-dataset", "personal_context.record"),
+            connection=connection,
+        )[0]
+        assert row["server_sequence"] == second.server_cursor
 
 
 def _set_apply_state(store: SyncV2Store, cursor: int, state: str) -> None:


### PR DESCRIPTION
## Summary

- Fix TASK-13192: translate parameter placeholders in SQL CASE expressions without misclassifying them as PostgreSQL JSONB operators. Preserve quoted text, operator handling, and parameter order.
- Replace the raw-SQL test seeding workaround with ordinary Sync envelope insertion, so the ingress-repair tests exercise the production path on SQLite and PostgreSQL.
- No schema, dependency, authority, or capability change.

## Validation

- Latest review-fix round: rebased onto dev 946e591ee9; head 27e29bdfdb. Parser and ordinary-ingress selection: 42 passed with PostgreSQL required. Ruff, test formatting, production Bandit and diff checks passed. Independent scoped spec/quality review approved. Added test annotations/docstrings/markers and exercised lower-sequence re-enrollment through the public API; all six existing Qodo findings received fixes or evidence-backed replies.

- Fresh pre-publication run on commit 6363466d07: 18 placeholder tests passed (6 existing warnings); diff check passed.
- Earlier implementation verification on the same commit: 109 targeted tests passed with PostgreSQL required, covering backend helpers, dual-backend ingress repair and bootstrap. Ruff, formatting, and production Bandit passed; independent review approved.
- A broader earlier store selection had one pre-existing fake-backend receipt failure (`personal_context_link_binding_stale`), reproduced with the unchanged converter; it is not fixed here.
- No full repository sweep. WebUI, extension, Flashcards and Watchlists audit checklists are not applicable: no UI changes.

## Review and integration

- Base: dev, rebased onto the fetched 946e591ee9 snapshot. Recheck dev and CI before merge.
- TASK-13192 and `Docs/superpowers/plans/2026-09-05-postgres-case-ingress.md` contain the detailed evidence. Existing ADR-002 applies.
- AI-assisted implementation. The policy-required human-written Change summary remains pending before merge; this description does not impersonate it.

## Risk & Rollback

- Risk: shared SQL translation can affect PostgreSQL callers outside Sync; targeted CASE/JSONB regression coverage bounds this change.
- Rollback: revert this PR if needed, coordinating with the dependent Personal Context conflict-resolution PR.
