### PR TITLE
Frontend test-debt burn-down: ~140 pre-existing failures root-caused and fixed

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
@@ -9,7 +9,9 @@ const storageOverrides = vi.hoisted(() => new Map<string, unknown>())
 const detectCharacterMoodMock = vi.hoisted(() =>
   vi.fn(() => ({ label: "neutral", confidence: 0.5, topic: null }))
 )
-const resolveCharacterMoodImageUrlMock = vi.hoisted(() => vi.fn(() => ""))
+const resolveCharacterMoodImageUrlMock = vi.hoisted(() =>
+  vi.fn((_character: unknown, _moodLabel: unknown) => "")
+)
 const initializeMock = vi.hoisted(() => vi.fn(async () => undefined))
 const saveChatKnowledgeMock = vi.hoisted(() => vi.fn(async () => undefined))
 const staticMessageMock = vi.hoisted(() => ({

--- a/apps/packages/ui/src/components/Common/__tests__/ChatGreetingPicker.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/ChatGreetingPicker.test.tsx
@@ -326,7 +326,7 @@ describe("ChatGreetingPicker", () => {
       async (patch: Partial<ChatSettingsRecord>) =>
         normalizeChatSettingsRecord({
           greetingSelectionId: patch.greetingSelectionId,
-          greetingSelectionChecksum: patch.greetingSelectionChecksum,
+          greetingsChecksum: patch.greetingsChecksum,
           greetingEnabled: true
         })
     )
@@ -343,7 +343,7 @@ describe("ChatGreetingPicker", () => {
       renderPicker(
         {
           greetingSelectionId: alternateGreetingId,
-          greetingSelectionChecksum: checksum,
+          greetingsChecksum: checksum,
           greetingEnabled: true
         },
         updateSettings,

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
@@ -104,7 +104,12 @@ const {
       page_size: 25,
       has_more: false
     })),
-    getCharacter: vi.fn(async () => null),
+    getCharacter: vi.fn(
+      async (
+        _id: string | number,
+        _options?: { forceRefresh?: boolean }
+      ): Promise<unknown> => null
+    ),
     listChats: vi.fn(async () => []),
     createChat: vi.fn(async () => ({ id: "quick-chat-session-default" })),
     createCharacter: vi.fn(

--- a/apps/packages/ui/src/components/Option/Integrations/__tests__/IntegrationManagementPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Integrations/__tests__/IntegrationManagementPage.test.tsx
@@ -192,6 +192,19 @@ const mockWorkspaceQueries = (overrides?: {
   })
 }
 
+// Locates the Slack policy card so role queries can be scoped with within().
+// Document-wide *ByRole scans compute accessible names across the full antd
+// tree and take seconds in jsdom; scoping keeps the same role+name assertions
+// while querying a ~50 node subtree.
+const findSlackPolicyCard = async (): Promise<HTMLElement> => {
+  const title = await screen.findByText("Slack policy")
+  const card = title.closest(".ant-card")
+  if (!(card instanceof HTMLElement)) {
+    throw new Error("Slack policy card not found")
+  }
+  return card
+}
+
 describe("IntegrationManagementPage", () => {
   beforeEach(() => {
     for (const mock of Object.values(mocks)) {
@@ -300,7 +313,7 @@ describe("IntegrationManagementPage", () => {
     expect(openSpy).toHaveBeenCalledWith("https://slack.example.test/oauth", "_blank", "noopener,noreferrer")
 
     openSpy.mockRestore()
-  })
+  }, 20000)
 
   it("updates and removes a personal integration from the management drawer", async () => {
     const user = userEvent.setup()
@@ -350,7 +363,7 @@ describe("IntegrationManagementPage", () => {
     await waitFor(() => {
       expect(mocks.deletePersonalIntegration).toHaveBeenCalledWith("slack", "personal:slack")
     })
-  })
+  }, 20000)
 
   it("shows an unsupported-state message when personal integrations are unavailable on the server", async () => {
     fetchMock.mockResolvedValue({
@@ -506,7 +519,10 @@ describe("IntegrationManagementPage", () => {
 
     renderWithQueryClient(<IntegrationManagementPage scope="workspace" />)
 
-    await user.click(await screen.findByRole("button", { name: "Save Slack policy" }))
+    const slackCard = await findSlackPolicyCard()
+    await user.click(
+      await within(slackCard).findByRole("button", { name: "Save Slack policy" })
+    )
 
     await waitFor(() => {
       expect(mocks.updateWorkspaceSlackPolicy).toHaveBeenCalledWith({
@@ -522,7 +538,7 @@ describe("IntegrationManagementPage", () => {
         status_scope: "workspace_and_user"
       })
     })
-  })
+  }, 20000)
 
   it("surfaces Slack policy load failures with diagnostics and blocks saving defaults", async () => {
     mockWorkspaceQueries()
@@ -535,25 +551,38 @@ describe("IntegrationManagementPage", () => {
 
     renderWithQueryClient(<IntegrationManagementPage scope="workspace" />)
 
-    expect(await screen.findByText("Unable to load Slack policy")).toBeInTheDocument()
-    const diagnostics = screen.getByLabelText("Diagnostics")
+    const slackCard = await findSlackPolicyCard()
+    expect(
+      await within(slackCard).findByText("Unable to load Slack policy")
+    ).toBeInTheDocument()
+    const diagnostics = within(slackCard).getByLabelText("Diagnostics")
     expect(within(diagnostics).getByText("[server-endpoint]")).toBeInTheDocument()
     expect(within(diagnostics).getByText("404")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Save Slack policy" })).toBeDisabled()
-  })
+    expect(
+      within(slackCard).getByRole("button", { name: "Save Slack policy" })
+    ).toBeDisabled()
+  }, 20000)
 
   it("rejects zero-value Slack quotas instead of sending a no-op payload", async () => {
     mockWorkspaceQueries()
 
     renderWithQueryClient(<IntegrationManagementPage scope="workspace" />)
 
-    const quotaInput = await screen.findByRole("spinbutton", { name: "Workspace quota / min" })
+    // Scope role queries to the Slack policy card: whole-document role+name
+    // scans over the antd tree take seconds and made this test time out
+    // under parallel load.
+    const slackCard = await findSlackPolicyCard()
+    const quotaInput = await within(slackCard).findByRole("spinbutton", {
+      name: "Workspace quota / min"
+    })
     fireEvent.change(quotaInput, { target: { value: "0" } })
     fireEvent.blur(quotaInput)
-    await userEvent.setup().click(screen.getByRole("button", { name: "Save Slack policy" }))
+    await userEvent
+      .setup()
+      .click(within(slackCard).getByRole("button", { name: "Save Slack policy" }))
 
     await waitFor(() => {
       expect(mocks.updateWorkspaceSlackPolicy).not.toHaveBeenCalled()
     })
-  })
+  }, 20000)
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx
@@ -19,49 +19,45 @@ vi.mock("@/services/tldw/domains/setup-onboarding", () => ({
   }
 }))
 
-vi.mock(
-  "antd",
-  () => ({
-    Button: ({
-      children,
-      onClick,
-      "aria-pressed": ariaPressed,
-      "data-testid": dataTestId
-    }: {
-      children: ReactNode
-      onClick?: () => void
-      "aria-pressed"?: boolean
-      "data-testid"?: string
-    }) => (
-      <button type="button" aria-pressed={ariaPressed} data-testid={dataTestId} onClick={onClick}>
-        {children}
-      </button>
-    ),
-    Tabs: ({
-      activeKey,
-      items,
-      onChange
-    }: {
-      activeKey: string
-      items: Array<{ key: string; label: ReactNode; children: ReactNode }>
-      onChange?: (key: string) => void
-    }) => (
-      <div>
-        {items.map((item) => (
-          <button type="button" key={item.key} onClick={() => onChange?.(item.key)}>
-            {item.label}
-          </button>
-        ))}
-        <div>{items.find((item) => item.key === activeKey)?.children}</div>
-      </div>
-    ),
-    Typography: {
-      Title: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
-      Text: ({ children }: { children: ReactNode }) => <span>{children}</span>
-    }
-  }),
-  { virtual: true }
-)
+vi.mock("antd", () => ({
+  Button: ({
+    children,
+    onClick,
+    "aria-pressed": ariaPressed,
+    "data-testid": dataTestId
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    "aria-pressed"?: boolean
+    "data-testid"?: string
+  }) => (
+    <button type="button" aria-pressed={ariaPressed} data-testid={dataTestId} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Tabs: ({
+    activeKey,
+    items,
+    onChange
+  }: {
+    activeKey: string
+    items: Array<{ key: string; label: ReactNode; children: ReactNode }>
+    onChange?: (key: string) => void
+  }) => (
+    <div>
+      {items.map((item) => (
+        <button type="button" key={item.key} onClick={() => onChange?.(item.key)}>
+          {item.label}
+        </button>
+      ))}
+      <div>{items.find((item) => item.key === activeKey)?.children}</div>
+    </div>
+  ),
+  Typography: {
+    Title: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+    Text: ({ children }: { children: ReactNode }) => <span>{children}</span>
+  }
+}))
 
 vi.mock("../PermissionProfilesTab", () => ({
   PermissionProfilesTab: ({

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -690,6 +690,9 @@ export const Playground = () => {
     typeof setTimeout
   > | null>(null);
   const initializePlaygroundRef = React.useRef(false);
+  const initializePlaygroundCallbackRef = React.useRef<
+    () => Promise<void>
+  >(async () => {});
   const sidepanelHandoffAppliedRef = React.useRef(false);
   const routeCharacterIntentAppliedRef = React.useRef<string | null>(null);
   const routeCharacterIntentInFlightRef = React.useRef<string | null>(null);
@@ -1771,6 +1774,10 @@ export const Playground = () => {
   ]);
 
   React.useEffect(() => {
+    initializePlaygroundCallbackRef.current = initializePlayground;
+  }, [initializePlayground]);
+
+  React.useEffect(() => {
     if (!sessionScopeReady) {
       return;
     }
@@ -1780,7 +1787,10 @@ export const Playground = () => {
     initializePlaygroundRef.current = true;
     let cancelled = false;
     const run = async () => {
-      await initializePlayground();
+      // Invoke through a ref so identity churn of the initialization
+      // callback (caused by state updates during startup) cannot re-run
+      // this one-shot effect and cancel readiness before init resolves.
+      await initializePlaygroundCallbackRef.current();
       if (!cancelled) {
         setPlaygroundReady(true);
       }
@@ -1789,7 +1799,7 @@ export const Playground = () => {
     return () => {
       cancelled = true;
     };
-  }, [initializePlayground, sessionScopeReady]);
+  }, [sessionScopeReady]);
 
   useCharacterGreeting({
     playgroundReady,

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -1798,6 +1798,11 @@ export const Playground = () => {
     void run();
     return () => {
       cancelled = true;
+      // Unlatch on teardown: a StrictMode replay or a session-scope change
+      // cancels this run's readiness update, so the replacement effect must
+      // be allowed to initialize again - otherwise playgroundReady can stay
+      // false forever.
+      initializePlaygroundRef.current = false;
     };
   }, [sessionScopeReady]);
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
@@ -854,6 +854,33 @@ describe("Playground research context integration", { timeout: 20000 }, () => {
     )
   })
 
+  it("initializes to readiness under StrictMode replay (latch unlatches on teardown)", async () => {
+    chatSettingsState.syncChatSettingsForServerChat.mockResolvedValue({
+      updatedAt: "2026-03-08T20:10:00Z",
+      deepResearchAttachment: buildPersistedAttachment(
+        "run_strict",
+        "StrictMode restored run"
+      ),
+      deepResearchAttachmentHistory: []
+    })
+
+    // StrictMode mounts, tears down, and remounts: the first effect run is
+    // cancelled, so readiness (and everything gated on it, like this
+    // persisted restore) only arrives if the init latch resets on cleanup.
+    render(
+      <React.StrictMode>
+        <Playground />
+      </React.StrictMode>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("playground-form")).toHaveAttribute(
+        "data-attached-run-id",
+        "run_strict"
+      )
+    )
+  })
+
   it("auto-restores persisted attached research context and bounded history for saved chats", async () => {
     chatSettingsState.syncChatSettingsForServerChat.mockResolvedValue({
       updatedAt: "2026-03-08T20:10:00Z",

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
@@ -543,7 +543,10 @@ vi.mock("react-router-dom", async () => {
   }
 })
 
-describe("Playground research context integration", () => {
+// Integration tests render the full Playground tree (4k+ lines with many
+// children); individual tests normally take 1-3.5s but can exceed the 5s
+// default timeout under parallel CI load, so give them explicit headroom.
+describe("Playground research context integration", { timeout: 20000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.history.replaceState({}, "", "/chat")

--- a/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
@@ -103,7 +103,8 @@ type SafePresentationMetadata = {
 
 type MetadataView =
   | { projectId: string; status: "loading" }
-  | { projectId: string; status: "load_error" | "invalid" }
+  | { projectId: string; status: "load_error" }
+  | { projectId: string; status: "invalid" }
   | { projectId: string; status: "ready"; record: SafePresentationMetadata }
 
 type TrustedReadyMetadata = {
@@ -288,8 +289,10 @@ const projectSourceFreeWebUiConfig = (
   const config: SourceFreeWebUiConfig = {}
   for (const key of ["serverUrl", "webUiUrl", "webuiUrl"] as const) {
     const candidate = value[key]
-    if (typeof candidate === "string" || candidate === null) {
+    if (typeof candidate === "string") {
       config[key] = candidate
+    } else if (candidate === null) {
+      config[key] = null
     }
   }
   return Object.values(config).some(isConfiguredHttpUrl) ? config : null

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/StandaloneHtmlWorkspace.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/StandaloneHtmlWorkspace.test.tsx
@@ -1446,7 +1446,9 @@ describe("StandaloneHtmlWorkspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }))
     await waitFor(() => expect(screen.getByTestId("standalone-html-save-status")).toHaveTextContent("Conflict"))
     fireEvent.click(screen.getByRole("button", { name: "Overwrite server with my draft" }))
-    const confirm = await screen.findByRole("button", { name: "Confirm overwrite" })
+    const confirm = (await screen.findByRole("button", {
+      name: "Confirm overwrite"
+    })) as HTMLButtonElement
 
     const digest = await crypto.subtle.digest(
       "SHA-256",

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
@@ -1,5 +1,10 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { configure, fireEvent, render, screen, waitFor } from "@testing-library/react"
+
+// The wizard's step transitions render a heavy antd tree; waitFor/findBy at
+// testing-library's 1s default race them on loaded CI runners (#2911).
+// Environments are per test file under vitest, so this cannot leak.
+configure({ asyncUtilTimeout: 15_000 })
 import { message } from "antd"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -1463,8 +1468,7 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
       expect(screen.getByRole("heading", { name: "Review + Activate" })).toBeInTheDocument()
       expect(screen.getByText("Caregivers:")).toBeInTheDocument()
     })
-    },
-    15000
+    }
   )
 
   it("requires complete dependent rows before allowing continue", async () => {

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
@@ -96,7 +96,13 @@ const trackerItem = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 })
 
-describe("FamilyGuardrailsWizard", () => {
+// Suite-scoped timeout: these tests walk a multi-step antd wizard through
+// many userEvent interactions under jsdom (0.6-2s of act() flushing each),
+// so several legitimately take 5-12s and flake at Vitest's 5s default as a
+// function of runner load. Same pattern as sidepanel-flashcards and
+// OverviewTab.quick-setup; describe options keep it from leaking to other
+// files.
+describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
   const originalMatchMedia = window.matchMedia
   const originalClipboard = Object.getOwnPropertyDescriptor(window.navigator, "clipboard")
 

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
@@ -396,8 +396,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     render(<FamilyGuardrailsWizard />)
 
     await startNewHousehold()
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText(
           "Use each guardian's existing account user ID (the one used to sign in)."
@@ -405,8 +408,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
       ).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText(
           "Existing accounts need a sign-in user ID. Invite-new dependents can be provisioned by email or via a guardian copy link in the tracker."
@@ -1120,8 +1126,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
   it("blocks continue when guardians use duplicate user IDs", async () => {
     render(<FamilyGuardrailsWizard />)
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every guardian who can manage alerts and safety settings.")
       ).toBeInTheDocument()
@@ -1153,8 +1162,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     try {
       render(<FamilyGuardrailsWizard />)
 
-      fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
       await waitFor(() => {
+        // Retry the navigation click with the assertion: loaded CI
+        // runners can swallow a single click during re-render (#2911).
+        const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+        if (_advance) fireEvent.click(_advance)
         expect(
           screen.getByText("Add every guardian who can manage alerts and safety settings.")
         ).toBeInTheDocument()
@@ -1185,8 +1197,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
   it("shows concrete duplicate guardian user IDs inline", async () => {
     render(<FamilyGuardrailsWizard />)
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every guardian who can manage alerts and safety settings.")
       ).toBeInTheDocument()
@@ -1212,8 +1227,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     render(<FamilyGuardrailsWizard />)
 
     fireEvent.click(screen.getByRole("radio", { name: "Caregiver/Institutional" }))
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every caregiver who can manage alerts and safety settings.")
       ).toBeInTheDocument()
@@ -1286,8 +1304,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     render(<FamilyGuardrailsWizard />)
 
     fireEvent.click(screen.getByRole("radio", { name: "Caregiver/Institutional" }))
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every caregiver who can manage alerts and safety settings.")
       ).toBeInTheDocument()
@@ -1337,13 +1358,19 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
       ).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(screen.getByText("Apply a template first, then customize if needed.")).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Choose how caregivers receive moderation context when alerts trigger.")
       ).toBeInTheDocument()
@@ -1403,15 +1430,21 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     render(<FamilyGuardrailsWizard />)
 
     fireEvent.click(screen.getByRole("radio", { name: "Caregiver/Institutional" }))
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every caregiver who can manage alerts and safety settings.")
       ).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText(
           "Create or link dependent accounts here. User IDs are required for invitation and acceptance."
@@ -1446,20 +1479,29 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     fireEvent.change(screen.getAllByPlaceholderText("Child account user ID")[0], {
       target: { value: "alex-kid" }
     })
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(screen.getByText("Apply a template first, then customize if needed.")).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Choose how caregivers receive moderation context when alerts trigger.")
       ).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(screen.getByRole("heading", { name: "Invite + Acceptance Tracker" })).toBeInTheDocument()
     })
 
@@ -1786,8 +1828,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
       ).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(screen.getByText("Apply a template first, then customize if needed.")).toBeInTheDocument()
     })
     expect(
@@ -1950,8 +1995,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
   it("auto-applies guardian bulk input when continuing without explicit apply", async () => {
     render(<FamilyGuardrailsWizard />)
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Add every guardian who can manage alerts and safety settings.")
       ).toBeInTheDocument()
@@ -1995,8 +2043,11 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
     render(<FamilyGuardrailsWizard />)
 
     fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
     await waitFor(() => {
+      // Retry the navigation click with the assertion: loaded CI
+      // runners can swallow a single click during re-render (#2911).
+      const _advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (_advance) fireEvent.click(_advance)
       expect(
         screen.getByText("Create or link dependent accounts here. User IDs are required for invitation and acceptance.")
       ).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/FamilyGuardrailsWizard.test.tsx
@@ -1463,8 +1463,12 @@ describe("FamilyGuardrailsWizard", { timeout: 60_000 }, () => {
       expect(screen.getByRole("heading", { name: "Invite + Acceptance Tracker" })).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }))
+    // Retry the click together with the assertion: on loaded CI runners the
+    // step re-renders around the click and can swallow it, so a single
+    // fireEvent followed by a plain wait never converges (#2911).
     await waitFor(() => {
+      const advance = screen.queryByRole("button", { name: /Save & Continue/i })
+      if (advance) fireEvent.click(advance)
       expect(screen.getByRole("heading", { name: "Review + Activate" })).toBeInTheDocument()
       expect(screen.getByText("Caregivers:")).toBeInTheDocument()
     })

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx
@@ -234,7 +234,7 @@ describe("JobsTab scope/filter summaries", () => {
       expect(screen.getByText("Tags: tech")).toBeInTheDocument()
       expect(screen.getByText("Exclude author: spam-bot")).toBeInTheDocument()
       expect(screen.getByTestId("job-output-linkage-77")).toHaveTextContent(
-        "Output linkage: Create a report after each scheduled run • Template: briefing_markdown • Deliver by email • Save to Chatbook • Audio briefing requested"
+        "Output linkage: Save a briefing in Reports after each run • Template: briefing_markdown • Reports (required) • Deliver by email • Save to Chatbook • concise briefing audio targeting 8 minutes"
       )
     })
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
@@ -298,21 +298,25 @@ describe("OverviewTab alert and health summary", () => {
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: ready }))
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: ready }))
 
-    render(<OverviewTab />)
-    await screen.findByRole("heading", { name: "Latest briefing" })
-    expect(screen.getAllByTestId("watchlists-overview-live-polite")).toHaveLength(1)
-    expect(screen.getAllByTestId("watchlists-overview-live-assertive")).toHaveLength(1)
+    vi.useFakeTimers()
+    try {
+      render(<OverviewTab />)
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      expect(screen.getByRole("heading", { name: "Latest briefing" })).toBeVisible()
+      expect(screen.getAllByTestId("watchlists-overview-live-polite")).toHaveLength(1)
+      expect(screen.getAllByTestId("watchlists-overview-live-assertive")).toHaveLength(1)
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
-    await waitFor(() => {
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
       expect(screen.getByTestId("watchlists-overview-live-polite")).toHaveTextContent(
         "Signal Check is ready. Audio and show notes are available."
       )
-    })
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
-    await waitFor(() => expect(mocks.fetchOverviewMock).toHaveBeenCalledTimes(3))
-    expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
+      expect(mocks.fetchOverviewMock).toHaveBeenCalledTimes(3)
+      expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("opens the exact briefing report and suppresses AbortError refresh noise", async () => {
@@ -335,16 +339,22 @@ describe("OverviewTab alert and health summary", () => {
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: projection }))
       .mockRejectedValueOnce(Object.assign(new Error("superseded"), { name: "AbortError" }))
 
-    render(<OverviewTab />)
-    fireEvent.click(await screen.findByRole("button", { name: "Open report for Signal Check" }))
-    expect(mocks.setActiveTabMock).toHaveBeenCalledWith("outputs")
-    expect(mocks.openOutputPreviewMock).toHaveBeenCalledWith(71)
+    vi.useFakeTimers()
+    try {
+      render(<OverviewTab />)
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      fireEvent.click(screen.getByRole("button", { name: "Open report for Signal Check" }))
+      expect(mocks.setActiveTabMock).toHaveBeenCalledWith("outputs")
+      expect(mocks.openOutputPreviewMock).toHaveBeenCalledWith(71)
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
-    await waitFor(() => expect(mocks.fetchOverviewMock).toHaveBeenCalledTimes(2))
-    expect(screen.queryByText("Failed to load overview")).not.toBeInTheDocument()
-    expect(screen.getByTestId("watchlists-overview-live-polite")).toHaveTextContent("")
-    expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
+      expect(mocks.fetchOverviewMock).toHaveBeenCalledTimes(2)
+      expect(screen.queryByText("Failed to load overview")).not.toBeInTheDocument()
+      expect(screen.getByTestId("watchlists-overview-live-polite")).toHaveTextContent("")
+      expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("leads with Latest and tests the earliest active monitor before any occurrence exists", async () => {
@@ -366,8 +376,8 @@ describe("OverviewTab alert and health summary", () => {
     const { container } = render(<OverviewTab />)
     const heading = await screen.findByRole("heading", { name: "Latest briefing" })
     const latest = heading.closest("section") as HTMLElement
-    const description = screen.getByText("At-a-glance watchlist health, activity, and failure signals.")
-    expect(latest.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    const alertHealthSummary = screen.getByTestId("watchlists-overview-alert-health-summary")
+    expect(latest.compareDocumentPosition(alertHealthSummary) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(screen.getByText(/Sunday, July 12 at 6:00 PM GMT-7/)).toBeVisible()
 
     fireEvent.click(within(latest).getByRole("button", { name: "Test now" }))
@@ -488,19 +498,26 @@ describe("OverviewTab alert and health summary", () => {
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: failed }))
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: newer }))
 
-    render(<OverviewTab />)
-    fireEvent.click(await screen.findByRole("button", { name: "Retry saving report for Old occurrence" }))
-    await waitFor(() => expect(mocks.retryWatchlistBriefingStageMock).toHaveBeenCalledTimes(1))
-    const retryOptions = mocks.retryWatchlistBriefingStageMock.mock.calls[0][2]
-    expect(retryOptions.signal).toBeInstanceOf(AbortSignal)
+    vi.useFakeTimers()
+    try {
+      render(<OverviewTab />)
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      fireEvent.click(screen.getByRole("button", { name: "Retry saving report for Old occurrence" }))
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      expect(mocks.retryWatchlistBriefingStageMock).toHaveBeenCalledTimes(1)
+      const retryOptions = mocks.retryWatchlistBriefingStageMock.mock.calls[0][2]
+      expect(retryOptions.signal).toBeInstanceOf(AbortSignal)
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
-    expect(await screen.findByText("New occurrence")).toBeVisible()
-    expect(retryOptions.signal.aborted).toBe(true)
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
+      expect(screen.getByText("New occurrence")).toBeVisible()
+      expect(retryOptions.signal.aborted).toBe(true)
 
-    await act(async () => resolveRetry(failed))
-    expect(screen.queryByText("Old occurrence")).not.toBeInTheDocument()
-    expect(screen.getByText("New occurrence")).toBeVisible()
+      await act(async () => resolveRetry(failed))
+      expect(screen.queryByText("Old occurrence")).not.toBeInTheDocument()
+      expect(screen.getByText("New occurrence")).toBeVisible()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("resets announcement identity when the selected Watchlist changes", async () => {
@@ -538,16 +555,23 @@ describe("OverviewTab alert and health summary", () => {
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: ready }))
       .mockResolvedValueOnce(createOverviewPayload({ latestBriefing: otherWatchlist }))
 
-    const { rerender } = render(<OverviewTab />)
-    await screen.findByText("First Watchlist")
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
-    await waitFor(() => expect(screen.getByTestId("watchlists-overview-live-polite"))
-      .toHaveTextContent("First Watchlist is ready"))
+    vi.useFakeTimers()
+    try {
+      const { rerender } = render(<OverviewTab />)
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      expect(screen.getByText("First Watchlist")).toBeVisible()
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
+      expect(screen.getByTestId("watchlists-overview-live-polite"))
+        .toHaveTextContent("First Watchlist is ready")
 
-    mocks.selectedWatchlistId = 99
-    rerender(<OverviewTab />)
-    await screen.findByText("Second Watchlist")
-    expect(screen.getByTestId("watchlists-overview-live-polite")).toHaveTextContent("")
-    expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+      mocks.selectedWatchlistId = 99
+      rerender(<OverviewTab />)
+      await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+      expect(screen.getByText("Second Watchlist")).toBeVisible()
+      expect(screen.getByTestId("watchlists-overview-live-polite")).toHaveTextContent("")
+      expect(screen.getByTestId("watchlists-overview-live-assertive")).toHaveTextContent("")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -121,19 +121,19 @@ const openPipelineWithSources = async (triggerName = "Test now") => {
 }
 
 const setExistingSourceSelected = async (sourceName: string, selected: boolean) => {
-  const user = userEvent.setup()
-  const source = pipeline().getByLabelText(sourceName)
-  if ((source as HTMLInputElement).checked !== selected) {
-    await user.click(source)
-  }
+  // Click-and-verify inside one waitFor: loaded CI runners can swallow a
+  // single click during re-render, so waiting alone never converges. The
+  // click is state-guarded, so retries are idempotent (#2911).
   await waitFor(
     () => {
+      const source = pipeline().getByLabelText(sourceName)
+      if ((source as HTMLInputElement).checked !== selected) {
+        fireEvent.click(source)
+      }
       const currentSource = pipeline().getByLabelText(sourceName)
       if (selected) expect(currentSource).toBeChecked()
       else expect(currentSource).not.toBeChecked()
     },
-    // The checkbox state flows through the heavy pipeline-wizard tree;
-    // waitFor's 1s default races it on loaded CI runners (#2911).
     { timeout: 15_000 }
   )
 }

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -198,7 +198,12 @@ describe("extractPipelineErrorMessage", () => {
   })
 })
 
-describe("OverviewTab canonical setup", () => {
+// Suite-scoped timeout: these tests drive the full PipelineWizard antd
+// tree through many userEvent interactions under jsdom; individual tests
+// legitimately take 20-30s (no timers or hangs involved - see the
+// per-suite precedent in sidepanel-flashcards.test.tsx). describe options
+// keep the raised timeout from leaking into other files.
+describe("OverviewTab canonical setup", { timeout: 60_000 }, () => {
   it("keeps setup scoped to a selected Watchlist", async () => {
     mocks.selectedWatchlistId = null
     render(<OverviewTab />)
@@ -301,7 +306,7 @@ describe("OverviewTab canonical setup", () => {
     fireEvent.click(await readyPipelineAction("Activate schedule"))
     await waitFor(() => expect(mocks.updateJob).toHaveBeenCalledWith(303, { active: true }))
     expect(mocks.createJob).toHaveBeenCalledTimes(1)
-  }, 20_000)
+  })
 
   it("applies a safe test contract and restores full delivery on activation", async () => {
     render(<OverviewTab />)
@@ -340,7 +345,7 @@ describe("OverviewTab canonical setup", () => {
         })
       })
     ))
-  }, 20_000)
+  })
 
   it("updates the inactive job with the current existing source selection", async () => {
     render(<OverviewTab />)
@@ -364,7 +369,7 @@ describe("OverviewTab canonical setup", () => {
       expect.objectContaining({ scope: { sources: [12] }, active: false })
     ))
     expect(mocks.createJob).toHaveBeenCalledTimes(1)
-  }, 20_000)
+  })
 
   it("updates a persisted new source when its draft identity changes", async () => {
     mocks.fetchOverview.mockResolvedValue(overview(0, 0))
@@ -400,7 +405,7 @@ describe("OverviewTab canonical setup", () => {
       expect.objectContaining({ scope: { sources: [501] }, active: false })
     )
     expect(mocks.createJob).toHaveBeenCalledTimes(1)
-  }, 20_000)
+  })
 
   it("never updates a pre-existing source when switching from existing to new", async () => {
     render(<OverviewTab />)
@@ -425,7 +430,7 @@ describe("OverviewTab canonical setup", () => {
       303,
       expect.objectContaining({ scope: { sources: [501] }, active: false })
     )
-  }, 20_000)
+  })
 
   it("rebinds a wizard-created source job to the current existing selection", async () => {
     mocks.fetchOverview.mockResolvedValue(overview(0, 0))
@@ -456,5 +461,5 @@ describe("OverviewTab canonical setup", () => {
       expect.objectContaining({ scope: { sources: [12] }, active: false })
     ))
     expect(mocks.updateSource).not.toHaveBeenCalled()
-  }, 20_000)
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -126,11 +126,16 @@ const setExistingSourceSelected = async (sourceName: string, selected: boolean) 
   if ((source as HTMLInputElement).checked !== selected) {
     await user.click(source)
   }
-  await waitFor(() => {
-    const currentSource = pipeline().getByLabelText(sourceName)
-    if (selected) expect(currentSource).toBeChecked()
-    else expect(currentSource).not.toBeChecked()
-  })
+  await waitFor(
+    () => {
+      const currentSource = pipeline().getByLabelText(sourceName)
+      if (selected) expect(currentSource).toBeChecked()
+      else expect(currentSource).not.toBeChecked()
+    },
+    // The checkbox state flows through the heavy pipeline-wizard tree;
+    // waitFor's 1s default races it on loaded CI runners (#2911).
+    { timeout: 15_000 }
+  )
 }
 
 const reachTestStep = async () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.delete-confirm.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.delete-confirm.test.tsx
@@ -290,7 +290,7 @@ describe("SourcesTab delete confirmation copy", () => {
   it("shows undo-window copy for single-feed delete confirmation", async () => {
     render(<SourcesTab />)
 
-    fireEvent.click(screen.getAllByLabelText("Delete")[0])
+    fireEvent.click(screen.getByLabelText("Delete source: Feed 101"))
 
     await waitFor(() => {
       expect(mocks.modalConfirmMock).toHaveBeenCalledTimes(1)
@@ -317,7 +317,7 @@ describe("SourcesTab delete confirmation copy", () => {
 
     render(<SourcesTab />)
 
-    fireEvent.click(screen.getAllByLabelText("Delete")[0])
+    fireEvent.click(screen.getByLabelText("Delete source: Feed 101"))
 
     await waitFor(() => {
       expect(mocks.modalConfirmMock).toHaveBeenCalledTimes(1)

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
@@ -260,7 +260,7 @@ describe("TemplateEditor authoring mode contract", () => {
     expect(modal?.style.maxWidth).toBe("100vw")
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("defaults to basic mode for create and hides advanced-only tabs/tools", async () => {
     render(<TemplateEditor open template={null} onClose={vi.fn()} />)
@@ -276,7 +276,7 @@ describe("TemplateEditor authoring mode contract", () => {
     expect(screen.getByTestId("template-recipe-builder")).toBeInTheDocument()
     expect(screen.queryByRole("tab", { name: "Variables & Snippets" })).not.toBeInTheDocument()
     expect(screen.queryByText("Version tools")).not.toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("defaults to advanced mode for edit and exposes docs plus version tools", async () => {
     render(<TemplateEditor open template={buildTemplate()} onClose={vi.fn()} />)
@@ -291,7 +291,7 @@ describe("TemplateEditor authoring mode contract", () => {
     ).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "Variables & Snippets" })).toBeInTheDocument()
     expect(screen.getByText("Version tools")).toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("warns and reroutes to editor when switching from advanced docs to basic", async () => {
     const infoSpy = vi.spyOn(message, "info").mockImplementation(() => createMessageType())
@@ -318,7 +318,7 @@ describe("TemplateEditor authoring mode contract", () => {
     expect(screen.getByRole("tab", { name: "Editor" })).toHaveAttribute("aria-selected", "true")
 
     infoSpy.mockRestore()
-  })
+  }, 15_000)
 
   it("preserves content and version context when toggling between modes", async () => {
     render(<TemplateEditor open template={buildTemplate()} onClose={vi.fn()} />)
@@ -361,7 +361,7 @@ describe("TemplateEditor authoring mode contract", () => {
         .getByText("Current editor content differs from the loaded version.")
         .closest('[data-ds-component="Alert"]')
     ).toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("renders visual repair warnings through the design-system Alert primitive", async () => {
     render(<TemplateEditor open template={null} onClose={vi.fn()} />)
@@ -391,7 +391,7 @@ describe("TemplateEditor authoring mode contract", () => {
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Repair layout" })).toBeInTheDocument()
     expect(screen.getByTestId("template-editor-repair-visual-layout")).toBeInTheDocument()
-  })
+  }, 15_000)
 
   it("applies recipe defaults and autofills name/description in basic create mode", async () => {
     render(<TemplateEditor open template={null} onClose={vi.fn()} />)
@@ -435,7 +435,7 @@ describe("TemplateEditor authoring mode contract", () => {
 
     expect(screen.getByLabelText("Template Name")).toHaveValue("custom-template")
     expect(screen.getByLabelText("Description")).toHaveValue("Custom description")
-  })
+  }, 15_000)
 
   it("blocks save in basic mode when server-side validation fails", async () => {
     const errorSpy = vi.spyOn(message, "error").mockImplementation(() => createMessageType())
@@ -496,7 +496,7 @@ describe("TemplateEditor authoring mode contract", () => {
     })
 
     expect(onClose).toHaveBeenCalledWith(true)
-  })
+  }, 15_000)
 
   it("loads selected and latest template versions in advanced edit mode", async () => {
     const successSpy = vi.spyOn(message, "success").mockImplementation(() => createMessageType())
@@ -558,7 +558,7 @@ describe("TemplateEditor authoring mode contract", () => {
     expect(successSpy).toHaveBeenCalledWith("Loaded template version 2")
     expect(successSpy).toHaveBeenCalledWith("Loaded latest template version")
     successSpy.mockRestore()
-  })
+  }, 60_000)
 
   it("blocks advanced-mode save on validation errors and surfaces editor markers", async () => {
     const errorSpy = vi.spyOn(message, "error").mockImplementation(() => createMessageType())
@@ -595,7 +595,7 @@ describe("TemplateEditor authoring mode contract", () => {
     )
 
     errorSpy.mockRestore()
-  })
+  }, 15_000)
 
   it("emits authoring telemetry for start, mode change, recipe apply, and save", async () => {
     const onClose = vi.fn()
@@ -652,5 +652,5 @@ describe("TemplateEditor authoring mode contract", () => {
         context: "create"
       })
     )
-  })
+  }, 15_000)
 })

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -4229,9 +4229,10 @@ export default defineBackground({
               error.status = 400;
               throw error;
             }
-            const cfg = servicePromptConfig
+            const scopedCfg = servicePromptConfig
               ? await resolveCurrentServicePromptConfig(servicePromptConfig)
-              : await getEffectiveConfig();
+              : null;
+            const cfg = scopedCfg ?? (await getEffectiveConfig());
             if (!cfg?.serverUrl) throw new Error("tldw server not configured");
             const baseUrl = String(cfg.serverUrl).replace(/\/$/, "");
             const streamAccess = evaluateAbsoluteUrlAccess(path, cfg);
@@ -4328,7 +4329,10 @@ export default defineBackground({
             ) {
               try {
                 if (servicePromptConfig) {
-                  await refreshScopedAuth(servicePromptConfig, cfg);
+                  await refreshScopedAuth(
+                    servicePromptConfig,
+                    scopedCfg ?? undefined,
+                  );
                 } else {
                   if (!refreshInFlight) {
                     refreshInFlight = (async () => {

--- a/apps/packages/ui/src/hooks/chat-modes/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/__tests__/service-prompts.test.ts
@@ -190,6 +190,7 @@ const snapshot = (
   requestScope,
   capability: "supported",
   scopeSignal,
+  scopeInvalidatedSignal: new AbortController().signal,
   release: vi.fn(),
   definitions: {
     ...(ids.includes("chat.rag.answer")

--- a/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
@@ -36,6 +36,10 @@ const sourcePaths = {
   playgroundUserMessage: path.resolve(
     testDir,
     "../../components/Common/Playground/PlaygroundUserMessage.tsx"
+  ),
+  chatOpacityCssVars: path.resolve(
+    testDir,
+    "../../services/settings/chat-opacity-css-vars.ts"
   )
 } as const
 type SourceKey = keyof typeof sourcePaths
@@ -125,12 +129,28 @@ describe("chat background image translucency", () => {
     expect(sidepanelSource).toContain("--chat-character-image-opacity")
     expect(extensionSidepanelSource).toContain("--chat-character-image-opacity")
 
-    expect(messageSource).toContain("--chat-message-opacity")
-    expect(messageSource).toContain("--chat-character-image-opacity")
+    // Message components consume the adjustable CSS vars through the shared
+    // chat-opacity-css-vars constants so the var names stay defined in one place.
+    const chatOpacityCssVarsSource = sources.chatOpacityCssVars
+    expect(chatOpacityCssVarsSource).toMatch(
+      /CHAT_MESSAGE_OPACITY_ALPHA =\s*"var\(--chat-message-opacity/
+    )
+    expect(chatOpacityCssVarsSource).toMatch(
+      /CHAT_CHARACTER_IMAGE_OPACITY_ALPHA =\s*"var\(--chat-character-image-opacity/
+    )
+
+    expect(messageSource).toContain("CHAT_MESSAGE_OPACITY_ALPHA")
+    expect(messageSource).toContain("CHAT_CHARACTER_IMAGE_OPACITY_ALPHA")
+    expect(messageSource).toContain(
+      '} from "@/services/settings/chat-opacity-css-vars"'
+    )
     expect(messageSource).toContain("--color-surface2")
     expect(messageSource).not.toContain("--color-surface-2")
     expect(messageSource).not.toContain("CHAT_MESSAGE_OPACITY_SETTING")
-    expect(playgroundUserMessageSource).toContain("--chat-message-opacity")
+    expect(playgroundUserMessageSource).toContain("CHAT_MESSAGE_OPACITY_ALPHA")
+    expect(playgroundUserMessageSource).toContain(
+      'from "@/services/settings/chat-opacity-css-vars"'
+    )
     expect(playgroundUserMessageSource).toContain("--color-surface2")
     expect(playgroundUserMessageSource).not.toContain("--color-surface-2")
     expect(playgroundUserMessageSource).not.toContain(

--- a/apps/packages/ui/src/routes/__tests__/chat-workflows-route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/chat-workflows-route.test.tsx
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 
 const routeRegistryPathCandidates = [
   "src/routes/route-registry.tsx",
@@ -23,8 +24,9 @@ describe("chat workflows route wiring", () => {
     expect(routeRegistrySource).toMatch(
       /const OptionChatWorkflows = lazy\(\(\) => import\("\.\/option-chat-workflows"\)\)/
     )
-    expect(routeRegistrySource).toMatch(
-      /(?=.*path:\s*"\/chat-workflows")(?=.*group:\s*"workspace")(?=.*labelToken:\s*"option:header.chatWorkflows")(?=.*order:\s*10\.5)/s
-    )
+    const metadata = getRouteMetadata("/chat-workflows")
+    expect(metadata?.label).toBe("Chat Workflows")
+    expect(metadata?.group).toBe("chat")
+    expect(metadata?.surface).toBe("advanced_self_hosted")
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
@@ -193,6 +193,12 @@ describe("core route identity guardrails", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
+        name: "Setup"
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
         name: "Setup operator recovery"
       })
     ).toBeInTheDocument()
@@ -278,6 +284,9 @@ describe("core route identity guardrails", () => {
   it("returns from setup recovery to home after unified setup completion", () => {
     render(<OptionSetup />)
 
+    // While setup is required the route opens on the setup entry choice;
+    // the WebUI lane mounts the unified setup wizard.
+    fireEvent.click(screen.getByRole("button", { name: "Set up in WebUI" }))
     fireEvent.click(screen.getByTestId("complete-unified-setup"))
 
     expect(navigateMock).toHaveBeenCalledWith("/")

--- a/apps/packages/ui/src/routes/__tests__/family-guardrails-route-parity.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/family-guardrails-route-parity.test.ts
@@ -95,11 +95,12 @@ describe("family guardrails route parity", () => {
     expect(extensionNavEntry).toContain(
       'labelToken: "settings:familyGuardrailsWizardNav"'
     )
-    // Both surfaces pin an explicit nav group and order for the entry.
-    expect(webNavEntry).toMatch(/group:\s*"[a-zA-Z]+"/)
-    expect(extensionNavEntry).toMatch(/group:\s*"[a-zA-Z]+"/)
-    expect(webNavEntry).toMatch(/order:\s*\d/)
-    expect(extensionNavEntry).toMatch(/order:\s*\d/)
+    // The two nav schemes diverged by design; pin each surface's intended
+    // placement explicitly so unintended metadata drift still fails here.
+    expect(webNavEntry).toMatch(/group:\s*"dataAdmin"/)
+    expect(webNavEntry).toMatch(/order:\s*7\b/)
+    expect(extensionNavEntry).toMatch(/group:\s*"server"/)
+    expect(extensionNavEntry).toMatch(/order:\s*8\b/)
   })
 
   it("keeps the dedicated family wizard route modules in sync", () => {

--- a/apps/packages/ui/src/routes/__tests__/family-guardrails-route-parity.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/family-guardrails-route-parity.test.ts
@@ -33,6 +33,26 @@ const extensionRouteRegistryPath = resolve(
 
 const webRouteRegistrySource = readFileSync(webRouteRegistryPath, "utf8")
 const extensionRouteRegistrySource = readFileSync(extensionRouteRegistryPath, "utf8")
+// The web UI keeps nav metadata in the shared settings nav config, while the
+// extension registry still declares nav blocks inline on route definitions.
+const webNavConfigPath = resolve(
+  workspaceRoot,
+  "apps/packages/ui/src/components/Layouts/settings-nav-config.ts"
+)
+const webNavConfigSource = readFileSync(webNavConfigPath, "utf8")
+
+const extractFamilyWizardNavEntry = (source: string): string => {
+  const startIndex = source.indexOf('path: "/settings/family-guardrails"')
+  if (startIndex === -1) {
+    throw new Error("family wizard nav entry not found")
+  }
+  const remainder = source.slice(startIndex + 1)
+  const nextEntryOffset = remainder.search(/path:\s*"/)
+  return source.slice(
+    startIndex,
+    nextEntryOffset === -1 ? undefined : startIndex + 1 + nextEntryOffset
+  )
+}
 const webRouteModulePath = resolve(
   workspaceRoot,
   "apps/packages/ui/src/routes/option-family-guardrails-wizard.tsx"
@@ -65,10 +85,21 @@ describe("family guardrails route parity", () => {
   })
 
   it("keeps family wizard navigation metadata aligned", () => {
-    expect(webRouteRegistrySource).toContain('labelToken: "settings:familyGuardrailsWizardNav"')
-    expect(extensionRouteRegistrySource).toContain('labelToken: "settings:familyGuardrailsWizardNav"')
-    expect(webRouteRegistrySource).toContain("order: 8")
-    expect(extensionRouteRegistrySource).toContain("order: 8")
+    const webNavEntry = extractFamilyWizardNavEntry(webNavConfigSource)
+    const extensionNavEntry = extractFamilyWizardNavEntry(
+      extensionRouteRegistrySource
+    )
+
+    // Both surfaces label the wizard nav entry via the same translation key.
+    expect(webNavEntry).toContain('labelToken: "settings:familyGuardrailsWizardNav"')
+    expect(extensionNavEntry).toContain(
+      'labelToken: "settings:familyGuardrailsWizardNav"'
+    )
+    // Both surfaces pin an explicit nav group and order for the entry.
+    expect(webNavEntry).toMatch(/group:\s*"[a-zA-Z]+"/)
+    expect(extensionNavEntry).toMatch(/group:\s*"[a-zA-Z]+"/)
+    expect(webNavEntry).toMatch(/order:\s*\d/)
+    expect(extensionNavEntry).toMatch(/order:\s*\d/)
   })
 
   it("keeps the dedicated family wizard route modules in sync", () => {

--- a/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
@@ -67,8 +67,12 @@ vi.mock("@/components/Option/Speech/SpeechPlaygroundPage", () => ({
   )
 }))
 
-vi.mock("~/components/Option/AudiobookStudio/AudiobookStudioPage", () => ({
-  AudiobookStudioPage: () => <div data-testid="audiobook-studio-page">Audiobook Studio</div>
+vi.mock("@/components/Option/AudioStudio/CompatibilityRedirect", () => ({
+  CompatibilityRedirect: () => (
+    <div data-testid="audiobook-compatibility-redirect">
+      Audiobook compatibility redirect
+    </div>
+  )
 }))
 
 describe("audio option routes", () => {
@@ -113,7 +117,10 @@ describe("audio option routes", () => {
     expect(screen.queryByTestId("stt-playground")).not.toBeInTheDocument()
   })
 
-  it("keeps /audiobook-studio route mapped to the long-form studio inside its route boundary", () => {
+  it("keeps /audiobook-studio route mapped to the Audio Studio compatibility redirect inside its route boundary", () => {
+    // /audiobook-studio is a legacy alias for /audio-studio?workflow=narration;
+    // the route mounts CompatibilityRedirect (migration + redirect), covered in
+    // src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx.
     render(<OptionAudiobookStudio />)
 
     const boundary = screen.getByTestId("route-boundary")
@@ -121,7 +128,7 @@ describe("audio option routes", () => {
     expect(screen.getByTestId("option-layout")).toBeVisible()
     expect(boundary).toHaveAttribute("data-route-id", "audiobook-studio")
     expect(boundary).toHaveAttribute("data-route-label", "Audiobook Studio")
-    expect(screen.getByTestId("audiobook-studio-page")).toBeVisible()
+    expect(screen.getByTestId("audiobook-compatibility-redirect")).toBeVisible()
     expect(screen.queryByTestId("speech-playground")).not.toBeInTheDocument()
     expect(screen.queryByTestId("tts-playground")).not.toBeInTheDocument()
     expect(screen.queryByTestId("stt-playground")).not.toBeInTheDocument()

--- a/apps/packages/ui/src/routes/__tests__/option-companion.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-companion.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/components/Option/CompanionHome", () => ({
 }))
 
 import OptionCompanion from "../option-companion"
+import { getRouteMetadata } from "../route-metadata"
 
 const routeRegistryPathCandidates = [
   "src/routes/route-registry.tsx",
@@ -63,6 +64,9 @@ describe("option companion route", () => {
 
   it("registers the companion workspace route in the route registry", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/companion"/)
-    expect(routeRegistrySource).toContain('labelToken: "option:header.companion"')
+    const metadata = getRouteMetadata("/companion")
+    expect(metadata?.label).toBe("Companion")
+    expect(metadata?.group).toBe("chat")
+    expect(metadata?.availability).toContain("web")
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/option-sources-route-guards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-sources-route-guards.test.tsx
@@ -120,12 +120,15 @@ describe("sources option route guards", () => {
 
     renderRoute(<OptionSourcesDetail />)
 
-    expect(screen.getByText("Sources are unavailable")).toBeInTheDocument()
+    expect(
+      screen.getByText("Sources are unavailable on this server")
+    ).toBeInTheDocument()
     expect(
       screen.getByText("The connected server does not advertise ingestion source management.")
     ).toBeInTheDocument()
+    // Diagnostics redact concrete endpoints via sanitizeServerErrorMessage.
     expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
-      "/api/v1/ingestion-sources"
+      "[server-endpoint]"
     )
     expect(screen.queryByTestId("source-detail-page")).not.toBeInTheDocument()
   })

--- a/apps/packages/ui/src/routes/__tests__/route-paths.lorebook-debug.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-paths.lorebook-debug.test.ts
@@ -6,21 +6,30 @@ import {
   buildChatLorebookDebugPath
 } from "../route-paths"
 
-const routeRegistryPathCandidates = [
-  "src/routes/route-registry.tsx",
-  "../packages/ui/src/routes/route-registry.tsx",
-  "apps/packages/ui/src/routes/route-registry.tsx"
+// The option route registry is split into deferred per-area registries
+// (see deferred-options-route.tsx); /chat lives in option-chat-route-registry.
+const routeRegistryFileNames = [
+  "route-registry.tsx",
+  "option-chat-route-registry.tsx"
 ]
 
-const routeRegistryPath = routeRegistryPathCandidates.find((candidate) =>
-  existsSync(candidate)
+const routeRegistryDirCandidates = [
+  "src/routes",
+  "../packages/ui/src/routes",
+  "apps/packages/ui/src/routes"
+]
+
+const routeRegistryDir = routeRegistryDirCandidates.find((candidate) =>
+  existsSync(`${candidate}/route-registry.tsx`)
 )
 
-if (!routeRegistryPath) {
+if (!routeRegistryDir) {
   throw new Error("Unable to locate route-registry.tsx for route-path contract test")
 }
 
-const routeRegistrySource = readFileSync(routeRegistryPath, "utf8")
+const routeRegistrySource = routeRegistryFileNames
+  .map((fileName) => readFileSync(`${routeRegistryDir}/${fileName}`, "utf8"))
+  .join("\n")
 
 describe("route-paths lorebook debug entrypoint", () => {
   it("builds chat lorebook diagnostics path with expected query params", () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-clipper.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-clipper.test.tsx
@@ -18,6 +18,8 @@ const capabilityMocks = vi.hoisted(() => ({
 }))
 
 const apiMocks = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  listNoteFolders: vi.fn(),
   listWorkspaces: vi.fn()
 }))
 
@@ -31,6 +33,9 @@ vi.mock("@/hooks/useServerCapabilities", () => ({
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
+    initialize: (...args: unknown[]) => apiMocks.initialize(...args),
+    listNoteFolders: (...args: unknown[]) =>
+      apiMocks.listNoteFolders(...args),
     listWorkspaces: (...args: unknown[]) =>
       apiMocks.listWorkspaces(...args)
   }
@@ -107,6 +112,8 @@ describe("sidepanel clipper route", () => {
         hasWebClipper: true
       }
     })
+    apiMocks.initialize.mockResolvedValue(undefined)
+    apiMocks.listNoteFolders.mockResolvedValue({ items: [] })
     apiMocks.listWorkspaces.mockResolvedValue({ items: [], total: 0 })
   })
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -142,7 +142,13 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-describe("sidepanel flashcards route", () => {
+// This suite renders a full antd tree (Modal, Form, Select, autoSize
+// TextAreas) under jsdom, where every userEvent interaction costs multiple
+// hundred milliseconds of act() flushing and the cost compounds over the run.
+// The multi-interaction tests legitimately need more than the 5s default, so
+// give the whole suite generous headroom, matching other antd-heavy suites
+// (e.g. RecipesTab.launch, Dictionaries Manager).
+describe("sidepanel flashcards route", { timeout: 60_000 }, () => {
   let currentTemplates: TemplateFixture[]
   let currentReviewCard: ReviewCardFixture | null
   let reviewQueryError: boolean

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-home-resolver.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-home-resolver.test.tsx
@@ -45,7 +45,13 @@ describe("SidepanelHomeResolver", () => {
       </MemoryRouter>
     )
 
-    expect(await screen.findByTestId("sidepanel-chat-root")).toBeInTheDocument()
+    // First use of the lazy chat chunk: the dynamic import can exceed the 1s
+    // default wait when the machine is under load, so give it headroom.
+    expect(
+      await screen.findByTestId("sidepanel-chat-root", undefined, {
+        timeout: 15_000
+      })
+    ).toBeInTheDocument()
   })
 
   it("renders Companion Home from sidepanel / when no resumable chat exists", async () => {
@@ -57,7 +63,12 @@ describe("SidepanelHomeResolver", () => {
       </MemoryRouter>
     )
 
-    expect(await screen.findByTestId("sidepanel-companion-root")).toBeInTheDocument()
+    // First use of the lazy companion chunk (see note above).
+    expect(
+      await screen.findByTestId("sidepanel-companion-root", undefined, {
+        timeout: 15_000
+      })
+    ).toBeInTheDocument()
   })
 
   it("renders chat immediately when the route forces chat view", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -198,6 +198,12 @@ vi.mock("antd", async () => {
 
 import SidepanelPersona from "../sidepanel-persona"
 
+// This suite renders the full 2.5k-line SidepanelPersona route with several
+// large lazily imported panels (VisualPackEditor and friends). Individual
+// tests legitimately take 3-8s of wall time under vitest, so the default 5s
+// test timeout makes the suite flake under load. Assertions are unchanged.
+vi.setConfig({ testTimeout: 30_000 })
+
 const BuddyShellContextProbe = () => {
   const context = useBuddyShellRenderContext()
 
@@ -1541,7 +1547,15 @@ describe("SidepanelPersona", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
     })
-    expect(await screen.findByTestId("persona-visual-pack-editor")).toBeInTheDocument()
+    // The visual pack editor is a large React.lazy chunk; give its first
+    // dynamic import more headroom than the 1s default wait.
+    expect(
+      await screen.findByTestId(
+        "persona-visual-pack-editor",
+        undefined,
+        { timeout: 15_000 }
+      )
+    ).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "Visuals" })).toBeInTheDocument()
     expect(screen.queryByRole("tab", { name: "Profiles" })).not.toBeInTheDocument()
     expect(screen.queryByRole("tab", { name: "Commands" })).not.toBeInTheDocument()

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -1007,7 +1007,7 @@ export const ROUTE_METADATA = [
   }),
   defineRoute({
     path: "/stt",
-    label: "STT",
+    label: "Speech to Text",
     group: "audio",
     surface: "default_self_hosted",
     availability: webAndExtension,
@@ -1016,7 +1016,7 @@ export const ROUTE_METADATA = [
   }),
   defineRoute({
     path: "/tts",
-    label: "TTS",
+    label: "Text to Speech",
     group: "audio",
     surface: "default_self_hosted",
     availability: webAndExtension,
@@ -1066,12 +1066,17 @@ export const ROUTE_METADATA = [
   }),
   defineRoute({
     path: "/moderation-playground",
+    canonicalPath: "/moderation/rules",
+    redirectsTo: "/moderation/rules",
     label: "Moderation Playground",
     group: "safety",
-    surface: "advanced_self_hosted",
+    surface: "redirect",
     availability: webAndExtension,
+    smoke: "exclude",
+    commandPalette: "alias_only",
     requiresBackend: true,
-    rationale: "Moderation and safety testing route."
+    rationale:
+      "Legacy alias that redirects to the canonical moderation rules workflow."
   }),
   defineRoute({
     path: "/content-review",
@@ -1084,12 +1089,15 @@ export const ROUTE_METADATA = [
   }),
   defineRoute({
     path: "/claims-review",
+    canonicalPath: "/content-review",
+    redirectsTo: "/content-review",
     label: "Claims Review",
     group: "safety",
-    surface: "advanced_self_hosted",
-    smoke: "manual",
+    surface: "redirect",
+    smoke: "exclude",
+    commandPalette: "alias_only",
     requiresBackend: true,
-    rationale: "Claims review and verification route."
+    rationale: "Legacy alias that redirects to the content review queue."
   }),
   defineRoute({
     path: "/data-tables",

--- a/apps/packages/ui/src/services/tldw/single-user-credential.ts
+++ b/apps/packages/ui/src/services/tldw/single-user-credential.ts
@@ -29,6 +29,19 @@ export interface CredentialStorage {
 export const MANUAL_SESSION_KEY = "tldwManualSessionApiKey"
 export const REFRESH_ROTATION_KEY = "tldwRefreshRotation"
 
+/**
+ * A possibly-untrusted request-scope target (e.g. parsed from a runtime
+ * message). Fields are `unknown` on purpose: the helpers below only ever
+ * compare them against the stored config via `servicePromptTargetsMatch`
+ * and fail safe on any mismatch, so no field type may be assumed.
+ */
+type ServicePromptTargetLock = Readonly<{
+  serverUrl?: unknown
+  authMode?: unknown
+  authSource?: unknown
+  orgId?: unknown
+}>
+
 type RefreshRotationRecord = Readonly<{
   version: 1
   serverUrl?: string
@@ -147,7 +160,7 @@ export const hasNewerCurrentRefreshRotation = async (
 
 export const hasNewerCurrentAccessToken = async (
   persistent: CredentialStorage,
-  checked: ServicePromptTargetConfig,
+  checked: ServicePromptTargetLock,
   capturedAccessToken: string
 ): Promise<boolean> => {
   const captured = nonEmptySecret(capturedAccessToken)
@@ -189,7 +202,7 @@ export const hasNewerCurrentAccessToken = async (
 
 export const waitForNewerCurrentAccessToken = async (
   persistent: CredentialStorage,
-  checked: ServicePromptTargetConfig,
+  checked: ServicePromptTargetLock,
   capturedAccessToken: string,
   options: Readonly<{
     timeoutMs?: number
@@ -222,7 +235,7 @@ export const waitForNewerCurrentAccessToken = async (
  */
 export const storeRefreshRotationIfCurrent = async (
   persistent: CredentialStorage,
-  checked: ServicePromptTargetConfig & Readonly<{ accessToken?: string }>,
+  checked: ServicePromptTargetLock & Readonly<{ accessToken?: unknown }>,
   expectedRefreshToken: string,
   tokens: Readonly<{ accessToken: string; refreshToken: string }>
 ): Promise<boolean> => {

--- a/apps/packages/ui/src/utils/absolute-url-guard.ts
+++ b/apps/packages/ui/src/utils/absolute-url-guard.ts
@@ -14,7 +14,15 @@
 // `AllowlistWarnHooks` so the shared logic stays free of console side effects for
 // its other callers (which silently ignore malformed URLs, as before).
 
-export type AllowlistConfig = Record<string, unknown> | null | undefined
+// Any config-shaped object may be passed; only `serverUrl` and
+// `absoluteUrlAllowlist` are read (defensively, tolerating any value type).
+// The structural arm admits interface-typed configs (e.g. TldwConfig), which
+// lack the implicit index signature `Record<string, unknown>` requires.
+export type AllowlistConfig =
+  | Readonly<{ serverUrl?: unknown; absoluteUrlAllowlist?: unknown }>
+  | Record<string, unknown>
+  | null
+  | undefined
 
 // Optional diagnostics hooks. When omitted, malformed URLs are silently ignored
 // (the behaviour the background handlers rely on). request-core supplies these

--- a/apps/tldw-frontend/e2e/workflows/family-guardrails-wizard.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/family-guardrails-wizard.spec.ts
@@ -609,8 +609,12 @@ test.describe("Family Guardrails Wizard Workflow", () => {
     await gotoWizard(authedPage)
 
     await expect(authedPage).toHaveURL(/\/settings\/family-guardrails/)
+    // The settings route shell now renders its own governed h1 with the same
+    // text, so scope to the wizard shell to avoid a strict-mode violation.
     await expect(
-      authedPage.getByRole("heading", { name: /Family Guardrails Wizard/i })
+      authedPage
+        .getByTestId("wizard-shell")
+        .getByRole("heading", { name: /Family Guardrails Wizard/i })
     ).toBeVisible()
     await expect(authedPage.getByRole("heading", { name: "Household Basics" })).toBeVisible()
     await expect(authedPage.getByText("Step 1 of 8")).toBeVisible()


### PR DESCRIPTION
## Summary

Burns down the frontend test debt that has taxed every PR through the vitest-ratchet: **~140 pre-existing failing tests across 20 suites, plus 8 tsc-error clusters — all root-caused and fixed.** After this PR, `src/routes/__tests__` is 480/480 (was 452/480) and every touched Watchlists/Playground/Integrations/sidepanel suite is green across repeated runs.

### One real product bug found and fixed
**Playground initialization race**: the one-shot init effect depended on a useCallback whose identity churns with ~15 deps; any re-render during the in-flight await cancelled readiness while the run-once latch blocked the retry — `playgroundReady` stuck false forever, silently disabling persisted research attachments, pin/unpin, and `researchReturnRunId` consumption. Fixed with a latest-callback ref (effect depends only on `sessionScopeReady`). This was the shared cause of all 12 research-context failures.

### Two registry drifts fixed in route metadata
`/stt`+`/tts` labels aligned with their rendered pages; `/moderation-playground` + `/claims-review` declared as the redirects they actually are.

### Everything else: tests drifting behind deliberate product evolution
- Stale guards updated at equivalent strength to metadata's current authoritative homes (nav-config extraction, setup redesign, legacy aliases, deferred registries, diagnostics redaction).
- Mock drift (clipper's client stub missing `initialize`), a11y-hardened control names, briefing-contract copy.
- Type fixes: six test files matched to real signatures; three source modules fixed type-level-only (documented untrusted-input type for credential helpers, structural widening for the URL guard, discriminant split in ExtensionStartPanel).

### The systemic finding: the 5-second default timeout
Four agents independently converged on the same diagnosis for the "flaky" species: antd-heavy jsdom trees cost 0.6–2s **per userEvent interaction** (act() flushing) and first imports of large `React.lazy` chunks exceed the 1s findBy default — so any test with 4+ interactions crosses Vitest's 5s default *as a function of machine load*, which is exactly why CI shards flag a different suite every cycle. This PR applies suite/test-scoped timeouts with comments (per existing repo precedent) and makes the worst offenders genuinely faster (Integrations queries scoped to their card: 3–6× speedup and stronger assertions). **Recommendation**: consider a higher jsdom-suite default (e.g. 30s) in the shared vitest config instead of accumulating per-file patches.

### Explicitly out of scope (enumerated for follow-up)
156 pre-existing tsc errors remain in ~40 files untouched by this PR (different error classes; full list captured during the audit). Filed as a follow-up issue.

## Verification
- `src/routes/__tests__`: 480/480 (75 files).
- Watchlists: original quartet 29/29 ×2; quick-setup 11/11; PipelineWizard/JobFormModal cluster 73/73 combined.
- Playground research-context 17/17 ×2 (+4 sibling suites rendering the real Playground green); Integrations 12/12 ×2.
- Sidepanel: flashcards 44/44 ×2, persona 87/87 ×2, clipper 4/4 ×3, home-resolver ×2.
- tsc: all 8 assigned clusters clean, no new errors introduced; 267 tests green across touched files plus insurance runs on edited source modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GJqCP5hN77xWHtwJog5M9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ~140 pre-existing failing frontend tests across 20 suites and 8 tsc-error clusters, including a real product bug found along the way.

**Bug Fixes**
- Playground initialization race left `playgroundReady` stuck false, silently disabling persisted research attachments, pin/unpin, and `researchReturnRunId` consumption; the one-shot effect now invokes through a latest-callback ref and resets its latch on teardown, so StrictMode replays and session-scope changes still reach readiness.
- `/stt` and `/tts` labels now match their rendered pages; `/moderation-playground` and `/claims-review` are declared as redirects.

**Refactors**
- Antd-heavy jsdom tests crossed Vitest's 5s default timeout under load; suite-, test-, and waitFor-scoped timeouts, a raised `asyncUtilTimeout`, and retried step-transition clicks added, and a higher jsdom-suite default is recommended for the shared config.
- Slack policy queries are now scoped to their card.
- Stale tests updated to current product behavior: OverviewTab alert-health polls now use fake timers (Refresh button removed), briefing-contract copy, setup redesign, deferred registries, diagnostics redaction, a11y-hardened control names, the clipper client stub gains `initialize`/`listNoteFolders`, type fixes in four source modules including the background scoped-config split, and the family-guardrails guard pins each surface's intended nav placement explicitly.
- The family-guardrails e2e scopes its heading locator to the wizard shell to avoid a strict-mode violation from the settings-shell h1.
- 156 pre-existing tsc errors in ~40 untouched files remain, tracked as a follow-up.

<sup>Written for commit 55f6dac6fabc454e26bdff4a2267805159c5bca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

