### PR TITLE
feat(prompts): apply web summary settings to content ingestion

### DIFF
--- a/Docs/Design/web-ingest-service-prompt.md
+++ b/Docs/Design/web-ingest-service-prompt.md
@@ -17,6 +17,9 @@ request schema. Update the existing Settings description; add no setting ID.
 For crawl modes, retrieve articles from the existing ephemeral result envelope
 before mapping summaries to ingestion analysis fields. Retain support for inline
 article/result lists used by compatibility callers. No new storage mechanism.
+Release consumed temporary entries because ingestion does not return their IDs,
+including on malformed-envelope failures. Missing entries use the existing
+domain resource-not-found exception with the safe result ID for diagnostics.
 
 Tests exercise HTTP, real owner prompt databases, real orchestration and ephemeral
 storage, and model-facing messages; substitute only external extraction/model

--- a/Docs/Design/web-ingest-service-prompt.md
+++ b/Docs/Design/web-ingest-service-prompt.md
@@ -1,0 +1,24 @@
+# Web-content ingestion Service Prompt
+
+Approved scope: TASK-13197, following the merged web-summary setting in PR #2907.
+
+Reuse `media.web.summarization` for `/api/v1/media/ingest-web-content`. Capture
+one immutable prompt configuration from the authenticated owner's storage before
+scraping; share it across individual URLs, sitemap, URL-level and recursive
+scraping. Explicit system/user parts win independently, including empty strings.
+Disabled analysis and fully explicit requests bypass saved-prompt lookup.
+
+Keep engine-local defaults, provider configuration, extraction, chunking,
+timestamps, cookies and output fields unchanged. Direct service callers and
+scheduled workflows do not acquire user prompt configuration. Reuse the current
+resolver with explicit input parameters rather than coupling it to either HTTP
+request schema. Update the existing Settings description; add no setting ID.
+
+For crawl modes, retrieve articles from the existing ephemeral result envelope
+before mapping summaries to ingestion analysis fields. Retain support for inline
+article/result lists used by compatibility callers. No new storage mechanism.
+
+Tests exercise HTTP, real owner prompt databases, real orchestration and ephemeral
+storage, and model-facing messages; substitute only external extraction/model
+operations. Cover all modes, engine fallback, independent overrides, owner edits
+mid-request, disabled analysis, reset/defaults, and existing ingestion controls.

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -69,7 +69,7 @@
       },
       "mediaWebSummarization": {
         "label": "Web article summarization",
-        "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
+        "description": "Controls summary instructions for synchronous web scraping and web-content ingestion. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
       },
       "mediaEmailSummarization": {
         "label": "Email summarization",
@@ -96,7 +96,7 @@
       "emailSummarization": "Synchronous email analysis",
       "audioAnalysis": "Synchronous audio analysis",
       "videoSummarization": "Synchronous video analysis",
-      "webSummarization": "Synchronous web scraping",
+      "webSummarization": "Synchronous web scraping and ingestion",
       "automaticNotesTitles": "Automatic Notes titles"
     },
     "titleGeneration": {

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -178,7 +178,7 @@ const KNOWN_DEFINITIONS = {
     key: "mediaWebSummarization",
     label: "Web article summarization",
     description:
-      "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
+      "Controls summary instructions for synchronous web scraping and web-content ingestion. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts."
   },
   "media.email.summarization": {
     key: "mediaEmailSummarization",
@@ -248,7 +248,7 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
   },
   "media.web.summarization": {
     key: "webSummarization",
-    label: "Synchronous web scraping"
+    label: "Synchronous web scraping and ingestion"
   },
   "notes.title.generate": {
     key: "automaticNotesTitles",

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -648,7 +648,7 @@ describe("ServicePromptsSettings", () => {
     await openPrompt("Web article summarization")
     expect(screen.getByLabelText("System instructions")).toHaveValue("Web system guidance.")
     expect(screen.getByLabelText("User instructions")).toHaveValue("Web summary guidance.")
-    expect(screen.getByText("Synchronous web scraping")).toBeVisible()
+    expect(screen.getByText("Synchronous web scraping and ingestion")).toBeVisible()
     expect(screen.getByText(/Reset restores each scraping engine/, { selector: "p" })).toBeVisible()
     fireEvent.change(screen.getByLabelText("System instructions"), { target: { value: "Web {system}" } })
     fireEvent.change(screen.getByLabelText("User instructions"), { target: { value: "Web {summary}" } })

--- a/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
+++ b/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
@@ -4,9 +4,11 @@ title: Apply Web article Service Prompt to web-content ingestion
 status: In Progress
 assignee: []
 created_date: '2026-09-06 01:34'
-updated_date: '2026-09-06 01:52'
+updated_date: '2026-09-06 01:56'
 labels: []
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2913'
 documentation:
   - Docs/Design/web-ingest-service-prompt.md
 ---
@@ -40,6 +42,8 @@ Baseline: 40 passed. Targeted RED tests demonstrated missing owner prompt lookup
 Independent reviewer found no blocking correctness/security/compatibility/over-engineering issues. Added the requested direct-ingestion unscoped regression (real model assembly and saved owner storage) to make that compatibility requirement explicit. Initial complete feature matrix: 75 passed. Final rerun includes this regression, connection cleanup cases, ephemeral boundaries, and strict forwarding contracts. Ruff is clean on changed code; existing B004 at process_web_scraping.py:41 is identical on dev and not modified. Python compilation passed. Temporary dependency symlinks removed without modifying shared dependencies.
 
 Final verification: 87 feature/owner/cleanup/crawl/strict-contract tests passed; 136 registry/API/ingestion compatibility tests passed (223 focused backend total). Shared Settings 76 passed and WebUI Settings 76 passed (152 UI total). Both full feature runs eventually reported success; interpreter/session cleanup was slow, and a stack sample located finalization outside application request handling. No broad full-repository suite was run. All new lint issues fixed; one unchanged pre-existing B004 remains in the touched older endpoint. Bandit: zero findings. OpenAPI fingerprint unchanged. Independent review complete; direct-ingestion regression added. All four implementation stages complete; temporary plan removed per repository convention. Ready for integration choice; no PR created yet.
+
+Published PR #2913 against dev at requester option 2. Implementation commit 75329803a1; existing verification applies unchanged. Worktree preserved for review follow-up. No merge or recurring monitor initiated.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
+++ b/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
@@ -1,0 +1,59 @@
+---
+id: TASK-13197
+title: Apply Web article Service Prompt to web-content ingestion
+status: In Progress
+assignee: []
+created_date: '2026-09-06 01:34'
+updated_date: '2026-09-06 01:52'
+labels: []
+dependencies: []
+documentation:
+  - Docs/Design/web-ingest-service-prompt.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the merged media.web.summarization setting to ingest-web-content using one authenticated-owner snapshot and recover real ephemeral crawl results. Scheduled workflows remain unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All four ingest scraping modes use one owner-scoped saved prompt snapshot.
+- [x] #2 Explicit parts including empty strings, historical defaults, provider behavior, and disabled analysis remain compatible.
+- [x] #3 URL-level and recursive ingestion return articles from real ephemeral task results.
+- [x] #4 The existing Settings entry documents web-content ingestion; no new prompt setting is added.
+- [x] #5 Focused tests, lint, security validation, and independent review pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: Record approved design and establish regression baseline. Stage 2: Add failing end-to-end prompt and crawl-result tests. Stage 3: Implement minimal resolver and orchestration wiring and update existing Settings metadata. Stage 4: Run compatibility checks, Bandit, review, and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline: 40 passed. Targeted RED tests demonstrated missing owner prompt lookup and discarded enhanced URL-level results before implementation. Implemented shared explicit-parameter resolver, authenticated ingestion snapshot, minimal ephemeral result retrieval, and existing Settings copy update. Compatibility/registry/API tests: 136 passed. Shared Settings and WebUI Settings: 76 passed each. Extra crawl-result and lookup cleanup boundary selection: 17 passed. Bandit on five touched runtime files: zero findings. OpenAPI export/type generation and fingerprint check passed unchanged. Full prompt matrix and independent review in progress.
+
+Independent reviewer found no blocking correctness/security/compatibility/over-engineering issues. Added the requested direct-ingestion unscoped regression (real model assembly and saved owner storage) to make that compatibility requirement explicit. Initial complete feature matrix: 75 passed. Final rerun includes this regression, connection cleanup cases, ephemeral boundaries, and strict forwarding contracts. Ruff is clean on changed code; existing B004 at process_web_scraping.py:41 is identical on dev and not modified. Python compilation passed. Temporary dependency symlinks removed without modifying shared dependencies.
+
+Final verification: 87 feature/owner/cleanup/crawl/strict-contract tests passed; 136 registry/API/ingestion compatibility tests passed (223 focused backend total). Shared Settings 76 passed and WebUI Settings 76 passed (152 UI total). Both full feature runs eventually reported success; interpreter/session cleanup was slow, and a stack sample located finalization outside application request handling. No broad full-repository suite was run. All new lint issues fixed; one unchanged pre-existing B004 remains in the touched older endpoint. Bandit: zero findings. OpenAPI fingerprint unchanged. Independent review complete; direct-ingestion regression added. All four implementation stages complete; temporary plan removed per repository convention. Ready for integration choice; no PR created yet.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Extended the existing Web article summarization Service Prompt to authenticated web-content ingestion with one immutable owner snapshot across all four scraping modes. Preserved independent explicit overrides, disabled behavior, engine defaults and unscoped service calls. Recovered enhanced crawl articles from existing ephemeral storage while retaining legacy inline results. Updated the shared Settings scope description without adding another setting. Added real HTTP/storage/model-facing regressions and crawl-result boundary coverage. Verified 223 focused backend and 152 UI tests, clean Bandit, unchanged OpenAPI, and independent review.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
+++ b/backlog/tasks/task-13197 - Apply-Web-article-Service-Prompt-to-web-content-ingestion.md
@@ -4,7 +4,7 @@ title: Apply Web article Service Prompt to web-content ingestion
 status: In Progress
 assignee: []
 created_date: '2026-09-06 01:34'
-updated_date: '2026-09-06 01:56'
+updated_date: '2026-09-06 02:05'
 labels: []
 dependencies: []
 references:
@@ -44,6 +44,10 @@ Independent reviewer found no blocking correctness/security/compatibility/over-e
 Final verification: 87 feature/owner/cleanup/crawl/strict-contract tests passed; 136 registry/API/ingestion compatibility tests passed (223 focused backend total). Shared Settings 76 passed and WebUI Settings 76 passed (152 UI total). Both full feature runs eventually reported success; interpreter/session cleanup was slow, and a stack sample located finalization outside application request handling. No broad full-repository suite was run. All new lint issues fixed; one unchanged pre-existing B004 remains in the touched older endpoint. Bandit: zero findings. OpenAPI fingerprint unchanged. Independent review complete; direct-ingestion regression added. All four implementation stages complete; temporary plan removed per repository convention. Ready for integration choice; no PR created yet.
 
 Published PR #2913 against dev at requester option 2. Implementation commit 75329803a1; existing verification applies unchanged. Worktree preserved for review follow-up. No merge or recurring monitor initiated.
+
+Rebased cleanly onto dev 7fe169e8c5; range-diff confirms both original commits unchanged. Qodo posted three actionable findings: domain exception with safe result ID, public-ingestion boundary tests rather than a private-helper import, and cleanup of consumed ephemeral crawl payloads. Addressing test-first before publishing the rebased head.
+
+All three Qodo findings addressed: reuse centralized ResourceNotFoundError with the safe result ID; exercise public ingestion orchestration rather than private helper; release enhanced and legacy temporary crawl entries, including malformed-envelope failure. RED: 10 failed and 6 passed before fixes. GREEN: 16 boundary cases passed. Rebased full focused backend suite: 234 passed; final boundary rerun: 16 passed. Ruff/compilation/diff checks passed and Bandit across five runtime files has zero findings. Independent follow-up review found no actionable issues. Publishing rebased fixes with an exact-head force-with-lease, then waiting for current-head Qodo and required CI. Human-summary waiver question for this PR is pending.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
@@ -15,13 +15,16 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
 )
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     IngestWebContentRequest,
 )
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
 )
+from tldw_Server_API.app.core.Web_Scraping.summary_prompts import resolve_web_summary_overrides
 from tldw_Server_API.app.services.web_scraping_service import (
     ingest_web_content_orchestrate,
 )
@@ -45,10 +48,12 @@ router = APIRouter()
 )
 async def ingest_web_content(
     request: IngestWebContentRequest,
+    http_request: Request,
     background_tasks: BackgroundTasks,  # Parity with legacy signature
     token: str = Header(..., description="Authentication token"),
     db: Any = Depends(get_media_db_for_user),
     usage_log: UsageEventLogger = Depends(get_usage_event_logger),
+    current_user: User = Depends(get_request_user),
 ) -> dict[str, Any]:
     """
     Ingest and process web content from various scraping strategies.
@@ -68,10 +73,17 @@ async def ingest_web_content(
     # handled by the orchestration helper.
     raw_results: list[dict[str, Any]] = []
     try:
+        summary_prompt_overrides = await resolve_web_summary_overrides(
+            lambda: get_prompts_db_for_user(http_request, current_user),
+            enabled=request.perform_analysis,
+            system_prompt=request.system_prompt,
+            custom_prompt=request.custom_prompt,
+        )
         helper_results = await ingest_web_content_orchestrate(
             request=request,
             db=db,
             usage_log=usage_log,
+            summary_prompt_overrides=summary_prompt_overrides,
         )
     except HTTPException:
         # Preserve explicit HTTP errors from downstream helpers (e.g., cookie

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -87,7 +87,10 @@ async def process_web_scraping_endpoint(
 
         task = _resolve_process_web_scraping_task()
         summary_prompt_overrides = await resolve_web_summary_overrides(
-            payload, lambda: get_prompts_db_for_user(request, current_user)
+            lambda: get_prompts_db_for_user(request, current_user),
+            enabled=payload.summarize_checkbox,
+            system_prompt=payload.system_prompt,
+            custom_prompt=payload.custom_prompt,
         )
 
         result = await task(

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -362,7 +362,7 @@ _DEFINITION_SEQUENCE = (
     ServicePromptDefinition(
         id="media.web.summarization",
         label="Web article summarization",
-        description="Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+        description="Controls summary instructions for synchronous web scraping and web-content ingestion. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
         parts=(
             ServicePromptPart(key="system", label="System instructions", mode="literal", required_variables=()),
             ServicePromptPart(key="user", label="User instructions", mode="literal", required_variables=()),
@@ -371,7 +371,7 @@ _DEFINITION_SEQUENCE = (
             "system": "You are a professional summarizer who produces accurate, concise summaries of web content.",
             "user": "Summarize this article concisely. Focus on the main points, facts, and any actionable insights.",
         }),
-        affected_workflows=(ServicePromptWorkflow(id="media.web.summarization", label="Synchronous web scraping"),),
+        affected_workflows=(ServicePromptWorkflow(id="media.web.summarization", label="Synchronous web scraping and ingestion"),),
     ),
     ServicePromptDefinition(
         id="media.text.translation",

--- a/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
+++ b/tldw_Server_API/app/core/Web_Scraping/summary_prompts.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from tldw_Server_API.app.core.Prompt_Management.service_prompts import resolve_service_prompt
 
@@ -19,18 +19,24 @@ if TYPE_CHECKING:
 
 
 async def resolve_web_summary_overrides(
-    payload: Any, get_prompts_db: Callable[[], Awaitable[PromptsDatabase]]
+    get_prompts_db: Callable[[], Awaitable[PromptsDatabase]],
+    *,
+    enabled: bool,
+    system_prompt: str | None,
+    custom_prompt: str | None,
 ) -> Mapping[str, str] | None:
     """Freeze explicit/saved parts while leaving absent engine defaults untouched.
 
-    Only the synchronous HTTP caller supplies owner-bound storage. No lookup is
+    Only synchronous HTTP callers supply owner-bound storage. No lookup is
     needed for disabled summarization or a complete pair of explicit parts.
 
     Args:
-        payload: Request carrying summarize_checkbox, system_prompt, and
-            custom_prompt. None means an absent part; an empty string is explicit.
         get_prompts_db: Async factory bound to the authenticated request owner.
             Its database is read and its worker connection closed in one worker.
+        enabled: Whether this request enables summarization.
+        system_prompt: Explicit system instructions; None means absent.
+        custom_prompt: Explicit user instructions; None means absent. Empty
+            strings in either part remain explicit overrides.
 
     Returns:
         None when summarization is disabled; otherwise an immutable mapping of
@@ -41,13 +47,9 @@ async def resolve_web_summary_overrides(
         ServicePromptCorruptOverride: Saved instructions fail validation.
         Exception: Database acquisition, lookup, or cleanup errors propagate.
     """
-    if not payload.summarize_checkbox:
+    if not enabled:
         return None
-    parts = {
-        key: value
-        for key, value in (("system", payload.system_prompt), ("user", payload.custom_prompt))
-        if value is not None
-    }
+    parts = {key: value for key, value in (("system", system_prompt), ("user", custom_prompt)) if value is not None}
     if len(parts) < 2:
         database = await get_prompts_db()
 

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -695,16 +695,37 @@ async def process_web_scraping_task(
             ) from e
 
 
+def _ingest_crawl_articles(service_result: Any) -> list[dict[str, Any]]:
+    """Recover crawl articles from the enhanced envelope or legacy inline result."""
+    if isinstance(service_result, dict) and service_result.get("ephemeral_id"):
+        stored = ephemeral_storage.get_data(service_result["ephemeral_id"])
+        if stored is None:
+            raise RuntimeError("Web crawl results expired before ingestion")
+        service_result = stored["result"]
+    if isinstance(service_result, dict):
+        service_result = service_result.get("articles") or service_result.get("results") or []
+    articles = service_result if isinstance(service_result, list) else []
+    for article in articles:
+        if isinstance(article, dict) and "summary" in article and "analysis" not in article:
+            article["analysis"] = article.get("summary")
+    return articles
+
+
 async def ingest_web_content_orchestrate(
     request: Any,
     db: Any,
     usage_log: Any,
+    *,
+    summary_prompt_overrides: Mapping[str, str] | None = None,
 ) -> Optional[list[dict[str, Any]]]:
     """
-    Shared helper for `/media/ingest-web-content` side effects and, for
-    selected scrape methods, the scraping + summarization:
+    Shared helper for `/media/ingest-web-content` side effects and summarization:
       - ScrapeMethod.INDIVIDUAL: per-URL scrape + summary
       - ScrapeMethod.SITEMAP: sitemap scrape + summary
+      - URL_LEVEL / RECURSIVE: crawl task + ephemeral result retrieval
+
+    The HTTP caller may supply one owner-bound prompt snapshot. Unscoped callers
+    retain existing defaults without acquiring user prompt storage.
     """
 
     # Log usage for web scraping ingest
@@ -774,10 +795,14 @@ async def ingest_web_content_orchestrate(
 
         analysis_results = analyze(
             input_data=content,
-            custom_prompt_arg=getattr(request, "custom_prompt", None) or "Summarize this article.",
+            custom_prompt_arg=(summary_prompt_overrides or {}).get(
+                "user", getattr(request, "custom_prompt", None) or "Summarize this article."
+            ),
             api_name=api_name,
             temp=0.7,
-            system_message=getattr(request, "system_prompt", None) or "Act as a professional summarizer.",
+            system_message=(summary_prompt_overrides or {}).get(
+                "system", getattr(request, "system_prompt", None) or "Act as a professional summarizer."
+            ),
         )
         if not _sanitize_analysis_result(article, "analysis", analysis_results):
             article["analysis"] = analysis_results
@@ -928,6 +953,7 @@ async def ingest_web_content_orchestrate(
                 max_pages=requested_max_pages,
                 max_depth=level,
                 summarize_checkbox=bool(getattr(request, "perform_analysis", False)),
+                summary_prompt_overrides=summary_prompt_overrides,
                 custom_prompt=getattr(request, "custom_prompt", None),
                 api_name=getattr(request, "api_name", None),
                 api_key=None,
@@ -951,18 +977,7 @@ async def ingest_web_content_orchestrate(
                 auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
                 auto_chunking_use_llm=bool(getattr(request, "auto_chunking_use_llm", False)),
             )
-            articles: list[dict[str, Any]] = []
-            if isinstance(service_result, dict):
-                if service_result.get("articles"):
-                    articles = service_result["articles"]
-                elif service_result.get("results"):
-                    articles = service_result["results"]
-
-            for r in articles:
-                if isinstance(r, dict) and "summary" in r and "analysis" not in r:
-                    r["analysis"] = r.get("summary")
-
-            return articles
+            return _ingest_crawl_articles(service_result)
         except Exception as exc:  # pragma: no cover - propagate for fallback handler
             logging.exception(f"Enhanced URL Level crawl failed: {exc}")
             raise
@@ -994,6 +1009,7 @@ async def ingest_web_content_orchestrate(
                 max_pages=max_pages,
                 max_depth=max_depth,
                 summarize_checkbox=bool(getattr(request, "perform_analysis", False)),
+                summary_prompt_overrides=summary_prompt_overrides,
                 custom_prompt=getattr(request, "custom_prompt", None),
                 api_name=getattr(request, "api_name", None),
                 api_key=None,
@@ -1017,20 +1033,7 @@ async def ingest_web_content_orchestrate(
                 auto_chunking_goal=getattr(request, "auto_chunking_goal", "balanced"),
                 auto_chunking_use_llm=bool(getattr(request, "auto_chunking_use_llm", False)),
             )
-            articles: list[dict[str, Any]] = []
-            if isinstance(service_result, list):
-                articles = service_result
-            elif isinstance(service_result, dict):
-                if service_result.get("articles"):
-                    articles = service_result.get("articles") or []
-                elif service_result.get("results"):
-                    articles = service_result.get("results") or []
-
-            for r in articles:
-                if isinstance(r, dict) and "summary" in r and "analysis" not in r:
-                    r["analysis"] = r.get("summary")
-
-            return articles
+            return _ingest_crawl_articles(service_result)
         except Exception as exc:  # pragma: no cover - propagate for fallback handler
             logging.exception(f"Enhanced recursive crawl failed: {exc}")
             raise

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -25,6 +25,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.api import (
     managed_media_database,
 )
 from tldw_Server_API.app.core.deprecations import log_runtime_deprecation
+from tldw_Server_API.app.core.exceptions import ResourceNotFoundError
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
@@ -696,12 +697,27 @@ async def process_web_scraping_task(
 
 
 def _ingest_crawl_articles(service_result: Any) -> list[dict[str, Any]]:
-    """Recover crawl articles from the enhanced envelope or legacy inline result."""
+    """Recover articles and release temporary payloads not exposed by ingestion.
+
+    Missing enhanced payloads raise ResourceNotFoundError with their result ID.
+    Malformed stored envelopes still release their storage before propagating.
+    """
     if isinstance(service_result, dict) and service_result.get("ephemeral_id"):
-        stored = ephemeral_storage.get_data(service_result["ephemeral_id"])
-        if stored is None:
-            raise RuntimeError("Web crawl results expired before ingestion")
-        service_result = stored["result"]
+        result_id = service_result["ephemeral_id"]
+        try:
+            stored = ephemeral_storage.get_data(result_id)
+            if stored is None:
+                raise ResourceNotFoundError("Web crawl results", result_id, "expired before ingestion")
+            service_result = stored["result"]
+        finally:
+            ephemeral_storage.remove_data(result_id)
+    elif (
+        isinstance(service_result, dict)
+        and service_result.get("status") == "ephemeral-ok"
+        and service_result.get("media_id")
+    ):
+        # Legacy crawls also store a copy, but already return the articles inline.
+        ephemeral_storage.remove_data(service_result["media_id"])
     if isinstance(service_result, dict):
         service_result = service_result.get("articles") or service_result.get("results") or []
     articles = service_result if isinstance(service_result, list) else []

--- a/tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from fastapi import BackgroundTasks, HTTPException
+from fastapi import BackgroundTasks, HTTPException, Request
 
 from tldw_Server_API.app.api.v1.endpoints.media import ingest_web_content as ingest_endpoint
 from tldw_Server_API.app.api.v1.schemas.media_request_models import IngestWebContentRequest
@@ -58,7 +58,8 @@ async def test_ingest_web_content_sanitizes_orchestration_failure_log(monkeypatc
 
     with pytest.raises(HTTPException) as exc_info:
         await ingest_endpoint.ingest_web_content(
-            request=IngestWebContentRequest(urls=["https://example.com/"]),
+            request=IngestWebContentRequest(urls=["https://example.com/"], perform_analysis=False),
+            http_request=Request({"type": "http"}),
             background_tasks=BackgroundTasks(),
             token=object(),
             db=object(),

--- a/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
+++ b/tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
@@ -12,7 +12,9 @@ import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.endpoints.media import ingest_web_content as ingest_endpoint
 from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint
+from tldw_Server_API.app.api.v1.schemas.media_request_models import IngestWebContentRequest
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
 from tldw_Server_API.app.core.LLM_Calls import Summarization_General_Lib as summary
@@ -27,6 +29,7 @@ from tldw_Server_API.app.services.ephemeral_store import ephemeral_storage
 pytestmark = pytest.mark.integration
 PROMPT_ID = "media.web.summarization"
 METHODS = ["Individual URLs", "Sitemap", "URL Level", "Recursive Scraping"]
+INGEST_METHODS = ["individual", "sitemap", "url_level", "recursive_scraping"]
 
 
 def article(url: str = "https://example.com/a") -> dict[str, Any]:
@@ -93,6 +96,7 @@ def context(
 
     monkeypatch.setitem(client.app.dependency_overrides, get_request_user, user)
     monkeypatch.setattr(endpoint, "get_prompts_db_for_user", database, raising=False)
+    monkeypatch.setattr(ingest_endpoint, "get_prompts_db_for_user", database, raising=False)
     monkeypatch.setattr(scraper_mod, "get_database_dir", lambda: str(tmp_path))
     state.scraper = scraper_mod.EnhancedWebScraper({})
     monkeypatch.setattr(state.scraper.job_queue, "add_job", queue)
@@ -104,6 +108,7 @@ def context(
     state.service._initialized = True
     monkeypatch.setattr(service, "get_web_scraping_service", lambda: state.service)
     monkeypatch.setattr(legacy, "scrape_article", page)
+    monkeypatch.setattr(service, "scrape_article", page)
     monkeypatch.setattr(
         service, "scrape_from_sitemap", lambda *args, **kwargs: [article(), article("https://example.com/b")]
     )
@@ -152,6 +157,129 @@ def process(context: SimpleNamespace, method: str = "Individual URLs", **options
     if "ephemeral_id" in result:
         return ephemeral_storage.get_data(result["ephemeral_id"])["result"]
     return {"articles": result["results"]}
+
+
+def ingest(context: SimpleNamespace, method: str = "individual", **options: Any) -> dict[str, Any]:
+    """Exercise ingestion without replacing its prompt, crawl or result orchestration."""
+    response = context.client.post(
+        "/api/v1/media/ingest-web-content",
+        headers={"token": "test-token"},
+        json={
+            "urls": ["https://example.com/a", "https://example.com/b"],
+            "scrape_method": method,
+            "max_pages": 2,
+            "perform_analysis": True,
+            "api_name": "openai",
+            "perform_chunking": False,
+            **options,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+@pytest.mark.parametrize("method", INGEST_METHODS)
+@pytest.mark.parametrize("fallback", [False, True])
+def test_ingest_saved_pair_and_real_crawl_results(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, method: str, fallback: bool
+) -> None:
+    """Saved owner instructions must reach every article, including stored crawl results."""
+    save(context, 1)
+    save(context, 2)
+    context.owner = 2
+    if fallback:
+
+        def unavailable() -> None:
+            """Select the compatibility engine without mocking its result envelope."""
+            raise RuntimeError("enhanced unavailable")
+
+        monkeypatch.setattr(service, "get_web_scraping_service", unavailable)
+        monkeypatch.setenv("TLDW_ENABLE_LEGACY_WEB_SCRAPING_FALLBACK", "1")
+    result = ingest(context, method)
+    assert [item["analysis"] for item in result["results"]] == ["Summary result."] * 2
+    assert all(item.get("ingested_at") for item in result["results"])
+    assert context.reads == [2]
+    assert len(context.calls) == 2
+    assert {call["system_message"] for call in context.calls} == {"Owner 2 system {literal}"}
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts.\n\n\n\nOwner 2 summary {literal}"
+    }
+
+
+@pytest.mark.parametrize("method", INGEST_METHODS)
+@pytest.mark.parametrize("part", ["system_prompt", "custom_prompt"])
+@pytest.mark.parametrize("value", ["Explicit {literal}", ""])
+def test_ingest_explicit_parts_win_independently(context: SimpleNamespace, method: str, part: str, value: str) -> None:
+    """Empty strings are explicit overrides, not requests to restore saved defaults."""
+    save(context)
+    result = ingest(context, method, **{part: value})
+    assert len(result["results"]) == 2
+    assert {call["system_message"] for call in context.calls} == {
+        value if part == "system_prompt" else "Owner 1 system {literal}"
+    }
+    suffix = value if part == "custom_prompt" else "Owner 1 summary {literal}"
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts." + ("\n\n\n\n" + suffix if suffix else "")
+    }
+
+
+@pytest.mark.parametrize("method", INGEST_METHODS)
+@pytest.mark.parametrize("disabled", [False, True])
+def test_ingest_irrelevant_storage_is_not_read(context: SimpleNamespace, method: str, disabled: bool) -> None:
+    """Disabled or fully explicit ingestion must work even with corrupt saved prompts."""
+    context.databases[1].save_service_prompt_override(PROMPT_ID, {"bad": "corrupt"}, None)
+    options = {"perform_analysis": False} if disabled else {"system_prompt": "", "custom_prompt": ""}
+    result = ingest(context, method, **options)
+    assert len(result["results"]) == 2
+    assert context.reads == []
+    if disabled:
+        assert context.calls == []
+    else:
+        assert {call["system_message"] for call in context.calls} == {""}
+        assert {call["messages"][0]["content"] for call in context.calls} == {"Article facts."}
+
+
+@pytest.mark.parametrize("method", INGEST_METHODS)
+def test_ingest_snapshot_survives_mid_request_edit(
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    """A settings/account change after the first model call must not affect later pages."""
+    row = save(context)
+    original = OpenAIAdapter.chat
+
+    def edit(self: OpenAIAdapter, request: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+        """Change real storage and current identity while the request is running."""
+        if not context.calls:
+            db = context.databases[1]
+            try:
+                db.save_service_prompt_override(PROMPT_ID, {"system": "Future", "user": "Future"}, row.revision)
+            finally:
+                db.close_connection()
+            context.owner = 2
+        return original(self, request, timeout=timeout)
+
+    monkeypatch.setattr(OpenAIAdapter, "chat", edit)
+    result = ingest(context, method)
+    assert len(result["results"]) == 2
+    assert context.reads == [1]
+    assert {call["system_message"] for call in context.calls} == {"Owner 1 system {literal}"}
+
+
+@pytest.mark.parametrize("method", INGEST_METHODS)
+def test_ingest_reset_restores_engine_defaults(context: SimpleNamespace, method: str) -> None:
+    """Reset keeps friendly-ingest defaults distinct from enhanced crawl defaults."""
+    row = save(context)
+    context.databases[1].reset_service_prompt_override(PROMPT_ID, row.revision)
+    result = ingest(context, method)
+    assert len(result["results"]) == 2
+    if method in ("individual", "sitemap"):
+        system = "Act as a professional summarizer."
+        user = "Summarize this article."
+    else:
+        system = "You are a professional summarizer who produces accurate, concise summaries of web content."
+        user = "Summarize this article concisely. Focus on the main points, facts, and any actionable insights."
+    assert {call["system_message"] for call in context.calls} == {system}
+    assert {call["messages"][0]["content"] for call in context.calls} == {"Article facts.\n\n\n\n" + user}
 
 
 @pytest.mark.parametrize("method", METHODS)
@@ -237,8 +365,9 @@ def test_snapshot_survives_mid_request_edit(context: SimpleNamespace, monkeypatc
 
 
 @pytest.mark.parametrize("corrupt", [False, True])
+@pytest.mark.parametrize("ingestion", [False, True])
 def test_lookup_connection_closes_on_worker(
-    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, corrupt: bool
+    context: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, corrupt: bool, ingestion: bool
 ) -> None:
     """Prompt storage cleanup runs on its read thread even when validation fails."""
     database = context.databases[1]
@@ -263,8 +392,11 @@ def test_lookup_connection_closes_on_worker(
     monkeypatch.setattr(database, "close_connection", track_close)
     if corrupt:
         response = context.client.post(
-            "/api/v1/media/process-web-scraping",
-            json={
+            "/api/v1/media/ingest-web-content" if ingestion else "/api/v1/media/process-web-scraping",
+            headers={"token": "test-token"},
+            json={"urls": ["https://example.com"], "api_name": "openai"}
+            if ingestion
+            else {
                 "scrape_method": "Individual URLs",
                 "url_input": "https://example.com",
                 "summarize_checkbox": True,
@@ -274,7 +406,7 @@ def test_lookup_connection_closes_on_worker(
         assert response.status_code >= 400
         assert context.fetches == []
     else:
-        process(context)
+        ingest(context) if ingestion else process(context)
     assert len(reads) == 1
     assert closes == reads
 
@@ -352,6 +484,23 @@ def test_explicit_system_reaches_individual_scraper_without_saved_override(
     """The HTTP system_prompt name reaches the individual scraper's model call."""
     process(context, system_prompt="Explicit system")
     assert {call["system_message"] for call in context.calls} == {"Explicit system"}
+
+
+@pytest.mark.asyncio
+async def test_direct_ingestion_does_not_acquire_owner_prompts(context: SimpleNamespace) -> None:
+    """Direct ingestion retains historical defaults even when the HTTP owner has saved prompts."""
+    save(context)
+    result = await service.ingest_web_content_orchestrate(
+        IngestWebContentRequest(urls=["https://example.com/a"], api_name="openai", perform_chunking=False),
+        db=SimpleNamespace(client_id="unscoped"),
+        usage_log=SimpleNamespace(),
+    )
+    assert [item["analysis"] for item in result] == ["Summary result."]
+    assert context.reads == []
+    assert {call["system_message"] for call in context.calls} == {"Act as a professional summarizer."}
+    assert {call["messages"][0]["content"] for call in context.calls} == {
+        "Article facts.\n\n\n\nSummarize this article."
+    }
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -115,9 +115,9 @@ EXPECTED_REGISTRY = {
     },
     "media.web.summarization": {
         "label": "Web article summarization",
-        "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+        "description": "Controls summary instructions for synchronous web scraping and web-content ingestion. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
         "parts": (("system", "System instructions", "literal", ()), ("user", "User instructions", "literal", ())),
-        "workflows": (("media.web.summarization", "Synchronous web scraping"),),
+        "workflows": (("media.web.summarization", "Synchronous web scraping and ingestion"),),
     },
     "media.text.translation": {
         "label": "Text translation",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -231,12 +231,12 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
         {
             "id": "media.web.summarization",
             "label": "Web article summarization",
-            "description": "Controls summary instructions for synchronous web scraping. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
+            "description": "Controls summary instructions for synchronous web scraping and web-content ingestion. Reset restores each scraping engine's existing defaults; the displayed defaults are the deployed web-article prompts.",
             "parts": [
                 {"key": "system", "label": "System instructions", "mode": "literal", "required_variables": []},
                 {"key": "user", "label": "User instructions", "mode": "literal", "required_variables": []},
             ],
-            "affected_workflows": [{"id": "media.web.summarization", "label": "Synchronous web scraping"}],
+            "affected_workflows": [{"id": "media.web.summarization", "label": "Synchronous web scraping and ingestion"}],
         },
         {
             "id": "media.text.translation",

--- a/tldw_Server_API/tests/Web_Scraping/test_ingest_crawl_results.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_ingest_crawl_results.py
@@ -1,35 +1,104 @@
-"""Compatibility and failure boundaries for crawl-result retrieval."""
+"""Public ingestion compatibility and crawl-storage lifecycle boundaries."""
+
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.api.v1.endpoints import media
+from tldw_Server_API.app.api.v1.schemas.media_request_models import IngestWebContentRequest
+from tldw_Server_API.app.core.exceptions import ResourceNotFoundError
 from tldw_Server_API.app.services.ephemeral_store import ephemeral_storage
-from tldw_Server_API.app.services.web_scraping_service import _ingest_crawl_articles
+from tldw_Server_API.app.services.web_scraping_service import ingest_web_content_orchestrate
 
 pytestmark = pytest.mark.unit
+IngestResult = Callable[[Any], Awaitable[list[dict[str, Any]] | None]]
+
+
+@pytest.fixture(params=["url_level", "recursive_scraping"])
+def ingest_result(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> IngestResult:
+    """Replace only the crawl producer; keep public orchestration and storage real."""
+
+    async def ingest(result: Any) -> list[dict[str, Any]] | None:
+        """Feed a crawl response through either public ingestion crawl mode."""
+
+        async def scrape_task(**kwargs: Any) -> Any:
+            """Stand in for the remote crawl's completed result."""
+            return result
+
+        monkeypatch.setattr(media, "process_web_scraping_task", scrape_task)
+        return await ingest_web_content_orchestrate(
+            IngestWebContentRequest(
+                urls=["https://example.com"],
+                scrape_method=request.param,
+                perform_analysis=False,
+                perform_chunking=False,
+            ),
+            db=SimpleNamespace(),
+            usage_log=SimpleNamespace(),
+        )
+
+    return ingest
 
 
 @pytest.mark.parametrize("wrapper", [None, "articles", "results"])
-def test_inline_results_keep_existing_analysis(wrapper: str | None) -> None:
+async def test_inline_results_keep_existing_analysis(ingest_result: IngestResult, wrapper: str | None) -> None:
     """Legacy list/envelope results retain analysis rather than overwriting it."""
     articles = [{"summary": "summary", "analysis": "existing"}, {"summary": "new"}]
     result = {wrapper: articles} if wrapper else articles
-    assert _ingest_crawl_articles(result) == [
+    assert await ingest_result(result) == [
         {"summary": "summary", "analysis": "existing"},
         {"summary": "new", "analysis": "new"},
     ]
 
 
-def test_expired_crawl_results_do_not_look_like_empty_scraping_success() -> None:
+async def test_expired_crawl_results_do_not_look_like_empty_scraping_success(ingest_result: IngestResult) -> None:
     """An expired real store entry must surface retrieval failure, not no articles."""
     result_id = ephemeral_storage.store_data({"result": {"articles": []}}, ttl_seconds=0)
-    with pytest.raises(RuntimeError, match="expired before ingestion"):
-        _ingest_crawl_articles({"ephemeral_id": result_id})
+    with pytest.raises(ResourceNotFoundError) as error:
+        await ingest_result({"ephemeral_id": result_id})
+    assert error.value.identifier == result_id
+    assert result_id in str(error.value)
 
 
-def test_empty_crawl_is_a_valid_empty_result() -> None:
-    """Successful extraction of zero pages remains distinct from missing storage."""
-    result_id = ephemeral_storage.store_data({"result": {"articles": []}})
+@pytest.mark.parametrize("articles", [[], [{"summary": "Crawl summary"}]])
+async def test_ingestion_consumes_stored_crawl_result(
+    ingest_result: IngestResult, articles: list[dict[str, str]]
+) -> None:
+    """Successful crawls return their articles and release storage, including empty crawls."""
+    result_id = ephemeral_storage.store_data({"result": {"articles": articles}})
     try:
-        assert _ingest_crawl_articles({"ephemeral_id": result_id}) == []
+        result = await ingest_result({"ephemeral_id": result_id})
+        assert result == ([{"summary": "Crawl summary", "analysis": "Crawl summary"}] if articles else [])
+        assert ephemeral_storage.get_data(result_id) is None
+    finally:
+        ephemeral_storage.remove_data(result_id)
+
+
+async def test_malformed_stored_result_is_removed_even_when_ingestion_fails(ingest_result: IngestResult) -> None:
+    """Invalid stored envelopes must not leak their payload on the failure path."""
+    result_id = ephemeral_storage.store_data({"unexpected": "payload"})
+    try:
+        with pytest.raises(KeyError):
+            await ingest_result({"ephemeral_id": result_id})
+        assert ephemeral_storage.get_data(result_id) is None
+    finally:
+        ephemeral_storage.remove_data(result_id)
+
+
+async def test_legacy_inline_result_releases_its_unused_storage(ingest_result: IngestResult) -> None:
+    """Legacy crawls return inline articles and an unused temporary media ID."""
+    result_id = ephemeral_storage.store_data({"articles": [{"summary": "Legacy summary"}]})
+    try:
+        result = await ingest_result(
+            {
+                "status": "ephemeral-ok",
+                "media_id": result_id,
+                "results": [{"summary": "Legacy summary"}],
+            }
+        )
+        assert result == [{"summary": "Legacy summary", "analysis": "Legacy summary"}]
+        assert ephemeral_storage.get_data(result_id) is None
     finally:
         ephemeral_storage.remove_data(result_id)

--- a/tldw_Server_API/tests/Web_Scraping/test_ingest_crawl_results.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_ingest_crawl_results.py
@@ -1,0 +1,35 @@
+"""Compatibility and failure boundaries for crawl-result retrieval."""
+
+import pytest
+
+from tldw_Server_API.app.services.ephemeral_store import ephemeral_storage
+from tldw_Server_API.app.services.web_scraping_service import _ingest_crawl_articles
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("wrapper", [None, "articles", "results"])
+def test_inline_results_keep_existing_analysis(wrapper: str | None) -> None:
+    """Legacy list/envelope results retain analysis rather than overwriting it."""
+    articles = [{"summary": "summary", "analysis": "existing"}, {"summary": "new"}]
+    result = {wrapper: articles} if wrapper else articles
+    assert _ingest_crawl_articles(result) == [
+        {"summary": "summary", "analysis": "existing"},
+        {"summary": "new", "analysis": "new"},
+    ]
+
+
+def test_expired_crawl_results_do_not_look_like_empty_scraping_success() -> None:
+    """An expired real store entry must surface retrieval failure, not no articles."""
+    result_id = ephemeral_storage.store_data({"result": {"articles": []}}, ttl_seconds=0)
+    with pytest.raises(RuntimeError, match="expired before ingestion"):
+        _ingest_crawl_articles({"ephemeral_id": result_id})
+
+
+def test_empty_crawl_is_a_valid_empty_result() -> None:
+    """Successful extraction of zero pages remains distinct from missing storage."""
+    result_id = ephemeral_storage.store_data({"result": {"articles": []}})
+    try:
+        assert _ingest_crawl_articles({"ephemeral_id": result_id}) == []
+    finally:
+        ephemeral_storage.remove_data(result_id)


### PR DESCRIPTION
## Summary

- What changed: Apply the existing Web article summarization Service Prompt to `/api/v1/media/ingest-web-content` across individual URLs, sitemap, URL-level and recursive scraping. Recover real enhanced crawl articles from the existing ephemeral result envelope, and clarify the shared Settings entry's scope.
- Why: Reusing the existing setting, owner storage and resolver keeps customization consistent without adding another configuration system. One immutable authenticated-owner snapshot preserves consistent instructions across pages and isolates concurrent settings changes. Explicit parts (including empty strings), engine defaults, disabled analysis and unscoped service callers retain their intended behavior.

TASK-13197. Design: `Docs/Design/web-ingest-service-prompt.md`. Follows #2907; scheduled workflows remain unchanged.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated
- 223 focused backend tests passed: 87 prompt/owner/cleanup/crawl/strict-contract cases and 136 registry/API/ingestion compatibility cases.
- 152 UI tests passed: 76 shared Settings cases and 76 WebUI Settings cases.
- Bandit: zero findings across all five touched runtime files.
- OpenAPI export, TypeScript generation and fingerprint check passed; API schema unchanged.
- Python compilation and changed-code Ruff checks passed. One unchanged pre-existing B004 remains at `process_web_scraping.py:41`.
- Independent review found no blocking issues; its direct-ingestion coverage suggestion was added and verified.
- The full repository suite and browser smoke suites were not run. The full focused prompt runs exited successfully after slow test-session/interpreter cleanup.

## UX Audit Checklist (v2 Stage 5)

- [x] WebUI/extension parity validated for shared UI fixes (shared Settings and WebUI test contexts)
- Browser smoke/console audit not run; this slice changes existing Settings copy only, not layout or interaction.
- Flashcards and Watchlists checklists: not applicable; those features are unchanged.

## Risk & Rollback

- Risk level: Low. Scoped to request-time web summary instruction selection and existing crawl-result retrieval; no schema or storage migration.
- Rollback plan: Revert this PR. Existing saved `media.web.summarization` overrides remain valid for synchronous web scraping from #2907.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the existing Web article summarization Service Prompt to `/api/v1/media/ingest-web-content` and recovers real enriched crawl articles that URL-level and recursive scraping previously discarded. Implements TASK-13197.

- All four ingestion modes use one immutable snapshot of the authenticated owner's saved prompts.
- Explicit system/user parts win independently, including empty strings; disabled analysis and unscoped callers keep existing defaults.
- URL-level and recursive ingestion now return articles from the ephemeral crawl result envelope instead of empty result lists; consumed entries are released from temporary storage, and expired entries raise a resource-not-found error with the result ID.
- The existing Settings copy now covers web-content ingestion; no new setting was added.

<sup>Written for commit 600a45facf5b0c9b81119661e6c0ba25bc6340a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

