### PR TITLE
Round-4 multi-user admin fixes: orgs, data-ops contract, login screen, RBAC seed, backup visibility

### DIFF
--- a/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
@@ -33,6 +33,27 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 // ── Backups Tab ──
 
+// Mirrors the backend's _BACKUP_DATASETS allowlist (#2917): the UI used to
+// offer "chachanotes"/"users", which the API rejects, and missed three valid
+// datasets entirely. All datasets except authnz are per-user and require a
+// target user id.
+const PER_USER_BACKUP_DATASETS = new Set([
+  "media",
+  "chacha",
+  "prompts",
+  "evaluations",
+  "audit"
+])
+
+const useBackupDatasetOptions = (t: (k: string, d: string) => string) => [
+  { value: "media", label: t("settings:adminDataOps.datasetMedia", "Media") },
+  { value: "chacha", label: t("settings:adminDataOps.datasetChaCha", "Chats & Notes") },
+  { value: "prompts", label: t("settings:adminDataOps.datasetPrompts", "Prompts") },
+  { value: "evaluations", label: t("settings:adminDataOps.datasetEvaluations", "Evaluations") },
+  { value: "audit", label: t("settings:adminDataOps.datasetAudit", "Audit log") },
+  { value: "authnz", label: t("settings:adminDataOps.datasetAuthnz", "Users & auth (server-wide)") }
+]
+
 const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardError }) => {
   const { t } = useTranslation(["settings", "common"])
   const [backups, setBackups] = useState<any[]>([])
@@ -40,12 +61,15 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
   const [createForm] = Form.useForm()
   const [creating, setCreating] = useState(false)
   const [restoring, setRestoring] = useState<string | null>(null)
+  const datasetOptions = useBackupDatasetOptions(t)
+  const selectedBackupDataset = Form.useWatch("dataset", createForm)
 
   // Schedules
   const [schedules, setSchedules] = useState<any[]>([])
   const [schedulesLoading, setSchedulesLoading] = useState(false)
   const [scheduleForm] = Form.useForm()
   const [creatingSchedule, setCreatingSchedule] = useState(false)
+  const selectedScheduleDataset = Form.useWatch("dataset", scheduleForm)
 
   const loadBackups = useCallback(async () => {
     setLoading(true)
@@ -114,8 +138,10 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
       setCreatingSchedule(true)
       await tldwClient.createBackupSchedule({
         dataset: values.dataset,
-        cron: values.cron || undefined,
-        retention_days: values.retention_days || undefined
+        target_user_id: values.target_user_id || undefined,
+        frequency: values.frequency,
+        time_of_day: values.time_of_day,
+        retention_count: values.retention_count
       })
       message.success(t("settings:adminDataOps.scheduleCreated", "Backup schedule created"))
       scheduleForm.resetFields()
@@ -208,16 +234,19 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
       render: (v: string) => <Tag>{v}</Tag>
     },
     {
-      title: t("settings:adminDataOps.colCron", "Cron"),
-      dataIndex: "cron",
-      key: "cron",
-      render: (v: string) => <code>{v || "\u2014"}</code>
+      title: t("settings:adminDataOps.colSchedule", "Schedule"),
+      key: "schedule",
+      render: (_: unknown, r: any) => (
+        <code>
+          {r.frequency || "\u2014"} @ {r.time_of_day || "\u2014"}
+        </code>
+      )
     },
     {
-      title: t("settings:adminDataOps.colRetentionDays", "Retention (days)"),
-      dataIndex: "retention_days",
-      key: "retention_days",
-      width: 130,
+      title: t("settings:adminDataOps.colRetentionCount", "Keep"),
+      dataIndex: "retention_count",
+      key: "retention_count",
+      width: 90,
       render: (v: number) => v ?? "\u2014"
     },
     {
@@ -256,17 +285,31 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
             >
               <Select
                 placeholder={t("settings:adminDataOps.datasetPlaceholder", "Dataset")}
-                style={{ width: 180 }}
-                options={[
-                  { value: "media", label: t("settings:adminDataOps.datasetMedia", "Media") },
-                  { value: "chachanotes", label: t("settings:adminDataOps.datasetChaChaNotes", "ChaChaNotes") },
-                  { value: "users", label: t("settings:adminDataOps.datasetUsers", "Users") },
-                  { value: "evaluations", label: t("settings:adminDataOps.datasetEvaluations", "Evaluations") }
-                ]}
+                style={{ width: 200 }}
+                options={datasetOptions}
               />
             </Form.Item>
-            <Form.Item name="user_id">
-              <InputNumber placeholder={t("settings:adminDataOps.userIdPlaceholder", "User ID (optional)")} min={1} style={{ width: 160 }} />
+            <Form.Item
+              name="user_id"
+              rules={[
+                {
+                  required: PER_USER_BACKUP_DATASETS.has(selectedBackupDataset),
+                  message: t(
+                    "settings:adminDataOps.userIdRequired",
+                    "This dataset is per-user - pick the user to back up"
+                  )
+                }
+              ]}
+            >
+              <InputNumber
+                placeholder={
+                  PER_USER_BACKUP_DATASETS.has(selectedBackupDataset)
+                    ? t("settings:adminDataOps.userIdPlaceholderRequired", "User ID (required)")
+                    : t("settings:adminDataOps.userIdPlaceholder", "User ID")
+                }
+                min={1}
+                style={{ width: 160 }}
+              />
             </Form.Item>
             <Form.Item>
               <Button
@@ -305,34 +348,40 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
         }
       >
         {/* Starter chips fill the form, mirroring the Monitoring alert-rule
-            pattern - the cron syntax stops being a prerequisite (#2899 I1). */}
+            pattern (#2899 I1) - now speaking the API's actual schedule
+            contract (frequency/time/keep-count, #2917). */}
         <div style={{ marginBottom: 8 }}>
           <Space size="small" wrap>
             {[
               {
+                key: "nightly",
                 label: t(
                   "settings:adminDataOps.schedulePresetNightly",
-                  "Nightly at 02:00, keep 14 days"
+                  "Nightly at 02:00, keep 14"
                 ),
-                cron: "0 2 * * *",
-                retention: 14
+                frequency: "daily",
+                time_of_day: "02:00",
+                retention_count: 14
               },
               {
+                key: "weekly",
                 label: t(
                   "settings:adminDataOps.schedulePresetWeekly",
-                  "Weekly on Sunday 03:00, keep 8 weeks"
+                  "Weekly at 03:00, keep 8"
                 ),
-                cron: "0 3 * * 0",
-                retention: 56
+                frequency: "weekly",
+                time_of_day: "03:00",
+                retention_count: 8
               }
             ].map((preset) => (
               <Tag
-                key={preset.cron}
+                key={preset.key}
                 style={{ cursor: "pointer" }}
                 onClick={() =>
                   scheduleForm.setFieldsValue({
-                    cron: preset.cron,
-                    retention_days: preset.retention
+                    frequency: preset.frequency,
+                    time_of_day: preset.time_of_day,
+                    retention_count: preset.retention_count
                   })
                 }
               >
@@ -349,20 +398,68 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
             >
               <Select
                 placeholder={t("settings:adminDataOps.datasetPlaceholder", "Dataset")}
-                style={{ width: 160 }}
+                style={{ width: 200 }}
+                options={datasetOptions}
+              />
+            </Form.Item>
+            <Form.Item
+              name="target_user_id"
+              rules={[
+                {
+                  required: PER_USER_BACKUP_DATASETS.has(selectedScheduleDataset),
+                  message: t(
+                    "settings:adminDataOps.userIdRequired",
+                    "This dataset is per-user - pick the user to back up"
+                  )
+                }
+              ]}
+            >
+              <InputNumber
+                placeholder={
+                  PER_USER_BACKUP_DATASETS.has(selectedScheduleDataset)
+                    ? t("settings:adminDataOps.userIdPlaceholderRequired", "User ID (required)")
+                    : t("settings:adminDataOps.userIdPlaceholder", "User ID")
+                }
+                min={1}
+                style={{ width: 150 }}
+              />
+            </Form.Item>
+            <Form.Item
+              name="frequency"
+              rules={[{ required: true, message: t("settings:adminDataOps.frequencyRequired", "Frequency is required") }]}
+            >
+              <Select
+                placeholder={t("settings:adminDataOps.frequencyPlaceholder", "Frequency")}
+                style={{ width: 130 }}
                 options={[
-                  { value: "media", label: t("settings:adminDataOps.datasetMedia", "Media") },
-                  { value: "chachanotes", label: t("settings:adminDataOps.datasetChaChaNotes", "ChaChaNotes") },
-                  { value: "users", label: t("settings:adminDataOps.datasetUsers", "Users") },
-                  { value: "evaluations", label: t("settings:adminDataOps.datasetEvaluations", "Evaluations") }
+                  { value: "daily", label: t("settings:adminDataOps.frequencyDaily", "Daily") },
+                  { value: "weekly", label: t("settings:adminDataOps.frequencyWeekly", "Weekly") },
+                  { value: "monthly", label: t("settings:adminDataOps.frequencyMonthly", "Monthly") }
                 ]}
               />
             </Form.Item>
-            <Form.Item name="cron">
-              <Input placeholder={t("settings:adminDataOps.cronPlaceholder", "Cron (e.g. 0 2 * * *)")} style={{ width: 180 }} />
+            <Form.Item
+              name="time_of_day"
+              rules={[
+                { required: true, message: t("settings:adminDataOps.timeRequired", "Time is required") },
+                {
+                  pattern: /^\d{2}:\d{2}$/,
+                  message: t("settings:adminDataOps.timeFormat", "Use 24h HH:MM, e.g. 02:00")
+                }
+              ]}
+            >
+              <Input placeholder={t("settings:adminDataOps.timePlaceholder", "Time (HH:MM)")} style={{ width: 130 }} />
             </Form.Item>
-            <Form.Item name="retention_days">
-              <InputNumber placeholder={t("settings:adminDataOps.retentionDaysPlaceholder", "Retention days")} min={1} style={{ width: 140 }} />
+            <Form.Item
+              name="retention_count"
+              rules={[{ required: true, message: t("settings:adminDataOps.retentionRequired", "Retention is required") }]}
+            >
+              <InputNumber
+                placeholder={t("settings:adminDataOps.retentionCountPlaceholder", "Backups to keep")}
+                min={1}
+                max={1000}
+                style={{ width: 150 }}
+              />
             </Form.Item>
             <Form.Item>
               <Button

--- a/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
@@ -75,7 +75,7 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
     setLoading(true)
     try {
       const result = await tldwClient.listBackups()
-      setBackups(Array.isArray(result) ? result : result?.data ?? result?.backups ?? [])
+      setBackups(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.backups ?? [])
     } catch (err) {
       onGuardError(err)
     } finally {
@@ -87,7 +87,7 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
     setSchedulesLoading(true)
     try {
       const result = await tldwClient.listBackupSchedules()
-      setSchedules(Array.isArray(result) ? result : result?.data ?? result?.schedules ?? [])
+      setSchedules(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.schedules ?? [])
     } catch (err) {
       onGuardError(err)
     } finally {
@@ -443,7 +443,7 @@ const BackupsTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardErr
               rules={[
                 { required: true, message: t("settings:adminDataOps.timeRequired", "Time is required") },
                 {
-                  pattern: /^\d{2}:\d{2}$/,
+                  pattern: /^([01]\d|2[0-3]):[0-5]\d$/,
                   message: t("settings:adminDataOps.timeFormat", "Use 24h HH:MM, e.g. 02:00")
                 }
               ]}

--- a/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
@@ -71,7 +71,7 @@ const OrgMembersTable: React.FC<{ orgId: number }> = ({ orgId }) => {
     setLoading(true)
     try {
       const result = await tldwClient.listOrgMembers(orgId)
-      setMembers(Array.isArray(result) ? result : result?.data ?? result?.members ?? [])
+      setMembers(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.members ?? [])
     } catch {
       // silently handled by parent guard
     } finally {
@@ -238,7 +238,7 @@ const TeamMembersTable: React.FC<{ teamId: number }> = ({ teamId }) => {
     setLoading(true)
     try {
       const result = await tldwClient.listTeamMembers(teamId)
-      setMembers(Array.isArray(result) ? result : result?.data ?? result?.members ?? [])
+      setMembers(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.members ?? [])
     } catch {
       // silently handled
     } finally {
@@ -397,7 +397,7 @@ const TeamsTable: React.FC<{ orgId: number }> = ({ orgId }) => {
     setLoading(true)
     try {
       const result = await tldwClient.listTeams(orgId)
-      setTeams(Array.isArray(result) ? result : result?.data ?? result?.teams ?? [])
+      setTeams(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.teams ?? [])
     } catch {
       // silently handled
     } finally {
@@ -509,7 +509,7 @@ const OrgsTeamsPage: React.FC = () => {
       const params: { search?: string; limit?: number; offset?: number } = { limit: 100 }
       if (search) params.search = search
       const result = await tldwClient.listOrgs(params)
-      setOrgs(Array.isArray(result) ? result : result?.data ?? result?.organizations ?? [])
+      setOrgs(Array.isArray(result) ? result : result?.items ?? result?.data ?? result?.organizations ?? [])
     } catch (err) {
       markAdminGuardFromError(err)
     } finally {

--- a/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -12,7 +12,8 @@ import {
   Divider,
   Input,
   Popconfirm,
-  Form
+  Form,
+  message
 } from "antd"
 import { useTranslation } from "react-i18next"
 import {
@@ -321,6 +322,30 @@ export const ServerAdminPage: React.FC = () => {
     }
   }
 
+  const handleResetUserPassword = async (user: AdminUserSummary) => {
+    try {
+      setUpdatingUserId(user.id)
+      const result = await tldwClient.resetAdminUserPassword(user.id)
+      message.success(
+        result?.message ||
+          t(
+            "settings:admin.users.resetPasswordDone",
+            "Password reset - {{username}} must set a new password on next login.",
+            { username: user.username }
+          )
+      )
+    } catch (e) {
+      message.error(
+        sanitizeAdminErrorMessage(
+          e,
+          t("settings:admin.users.resetPasswordFailed", "Failed to reset the password")
+        )
+      )
+    } finally {
+      setUpdatingUserId(null)
+    }
+  }
+
   const handleChangeUserRole = async (user: AdminUserSummary, role: string) => {
     try {
       setUpdatingUserId(user.id)
@@ -437,6 +462,25 @@ export const ServerAdminPage: React.FC = () => {
           {formatMegabytesForAdmin(record.storage_used_mb)} /{" "}
           {formatMegabytesForAdmin(record.storage_quota_mb)}
         </span>
+      )
+    },
+    {
+      title: t("settings:admin.users.actions", "Actions"),
+      key: "actions",
+      render: (_: any, record: AdminUserSummary) => (
+        <Popconfirm
+          title={t(
+            "settings:admin.users.resetPasswordConfirm",
+            "Reset {{username}}'s password? They must set a new one on next login.",
+            { username: record.username }
+          )}
+          okText={t("settings:admin.users.resetPasswordOk", "Reset password")}
+          onConfirm={() => handleResetUserPassword(record)}
+        >
+          <Button size="small" loading={updatingUserId === record.id}>
+            {t("settings:admin.users.resetPassword", "Reset password")}
+          </Button>
+        </Popconfirm>
       )
     }
   ]

--- a/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -13,6 +13,7 @@ import {
   Input,
   Popconfirm,
   Form,
+  Modal,
   message
 } from "antd"
 import { useTranslation } from "react-i18next"
@@ -116,6 +117,10 @@ export const ServerAdminPage: React.FC = () => {
   const [usersPage, setUsersPage] = React.useState(1)
   const [usersPageSize, setUsersPageSize] = React.useState(20)
   const [updatingUserId, setUpdatingUserId] = React.useState<number | null>(null)
+  const [resetPasswordResult, setResetPasswordResult] = React.useState<{
+    username: string
+    temporaryPassword: string
+  } | null>(null)
   const [creatingRole, setCreatingRole] = React.useState(false)
   const [deletingRoleId, setDeletingRoleId] = React.useState<number | null>(null)
   const [roleForm] = Form.useForm()
@@ -322,18 +327,31 @@ export const ServerAdminPage: React.FC = () => {
     }
   }
 
+  // The reset endpoint requires the admin to supply the temporary password
+  // and an audit reason; generate a strong one and reveal it exactly once so
+  // the admin can hand it to the user.
+  const generateTemporaryPassword = (): string => {
+    const bytes = new Uint8Array(12)
+    crypto.getRandomValues(bytes)
+    const encoded = Array.from(bytes, (b) =>
+      "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789".charAt(b % 57)
+    ).join("")
+    return `T!${encoded}`
+  }
+
   const handleResetUserPassword = async (user: AdminUserSummary) => {
+    const temporaryPassword = generateTemporaryPassword()
     try {
       setUpdatingUserId(user.id)
-      const result = await tldwClient.resetAdminUserPassword(user.id)
-      message.success(
-        result?.message ||
-          t(
-            "settings:admin.users.resetPasswordDone",
-            "Password reset - {{username}} must set a new password on next login.",
-            { username: user.username }
-          )
-      )
+      await tldwClient.resetAdminUserPassword(user.id, {
+        temporary_password: temporaryPassword,
+        reason: "Admin-initiated password reset from Server Admin",
+        force_password_change: true
+      })
+      setResetPasswordResult({
+        username: user.username,
+        temporaryPassword
+      })
     } catch (e) {
       message.error(
         sanitizeAdminErrorMessage(
@@ -1051,6 +1069,46 @@ export const ServerAdminPage: React.FC = () => {
             (health, users, budgets) per the 2026-09 UX audit (#2878). */}
         <AdminAudioInstallerCard />
       </Space>
+
+      <Modal
+        title={t("settings:admin.users.resetPasswordDoneTitle", "Temporary password created")}
+        open={Boolean(resetPasswordResult)}
+        onCancel={() => setResetPasswordResult(null)}
+        onOk={() => setResetPasswordResult(null)}
+        okText={t("common:done", "Done")}
+        cancelButtonProps={{ style: { display: "none" } }}
+      >
+        {resetPasswordResult ? (
+          <div data-testid="admin-reset-password-result">
+            <p>
+              {t(
+                "settings:admin.users.resetPasswordDoneBody",
+                "Share this temporary password with {{username}} - it will not be shown again. They must set a new password on next login.",
+                { username: resetPasswordResult.username }
+              )}
+            </p>
+            <code className="block break-all rounded border border-border bg-surface2 px-3 py-2 font-mono text-sm">
+              {resetPasswordResult.temporaryPassword}
+            </code>
+            <Button
+              size="small"
+              type="primary"
+              className="mt-2"
+              onClick={() => {
+                void navigator.clipboard
+                  ?.writeText(resetPasswordResult.temporaryPassword)
+                  .then(() =>
+                    message.success(
+                      t("settings:admin.users.resetPasswordCopied", "Copied")
+                    )
+                  )
+              }}
+            >
+              {t("settings:admin.users.resetPasswordCopy", "Copy password")}
+            </Button>
+          </div>
+        ) : null}
+      </Modal>
     </PageShell>
   )
 }

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
@@ -50,4 +50,26 @@ describe("OrgsTeamsPage design-system states", () => {
       "Organization management is not available on this server."
     )
   })
+
+  it("renders orgs from the items-envelope response (#2916)", async () => {
+    apiMock.listOrgs.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          name: "alice Workspace",
+          slug: null,
+          owner_user_id: 2,
+          is_active: true,
+          created_at: "2026-09-06T02:50:34"
+        }
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0
+    })
+
+    render(<OrgsTeamsPage />)
+
+    expect(await screen.findByText("alice Workspace")).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
@@ -11,6 +11,7 @@ const apiMock = vi.hoisted(() => ({
   listAdminRoles: vi.fn(),
   getMediaIngestionBudgetDiagnostics: vi.fn(),
   updateAdminUser: vi.fn(),
+  resetAdminUserPassword: vi.fn(),
   createAdminRole: vi.fn(),
   deleteAdminRole: vi.fn()
 }))
@@ -244,5 +245,37 @@ describe("ServerAdminPage design-system states", () => {
       "Unable to load media ingestion budget diagnostics"
     )
     expect(alert).toHaveTextContent("Budget exploded")
+  })
+
+  it("resets a user's password with a generated secret and reveals it once (#2918)", async () => {
+    apiMock.resetAdminUserPassword.mockResolvedValue({
+      user_id: 7,
+      force_password_change: true,
+      message: "ok"
+    })
+
+    render(<ServerAdminPage />)
+
+    const rowButton = (
+      await screen.findAllByRole("button", { name: "Reset password" })
+    )[0]
+    fireEvent.click(rowButton)
+    // Popconfirm opens with a verb-labeled confirm of the same name.
+    const confirmButtons = await screen.findAllByRole("button", {
+      name: "Reset password"
+    })
+    fireEvent.click(confirmButtons[confirmButtons.length - 1])
+
+    await waitFor(() => {
+      expect(apiMock.resetAdminUserPassword).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = apiMock.resetAdminUserPassword.mock.calls[0]
+    expect(payload.temporary_password.length).toBeGreaterThanOrEqual(10)
+    expect(payload.reason.length).toBeGreaterThanOrEqual(8)
+    expect(payload.force_password_change).toBe(true)
+
+    // The generated secret is revealed exactly once for the admin to share.
+    const reveal = await screen.findByTestId("admin-reset-password-result")
+    expect(reveal).toHaveTextContent(payload.temporary_password)
   })
 })

--- a/apps/packages/ui/src/services/tldw/domains/admin.ts
+++ b/apps/packages/ui/src/services/tldw/domains/admin.ts
@@ -36,7 +36,12 @@ export const adminMethods = {
   },
 
   async resetAdminUserPassword(
-    userId: number
+    userId: number,
+    payload: {
+      temporary_password: string
+      reason: string
+      force_password_change?: boolean
+    }
   ): Promise<{ user_id: number; force_password_change: boolean; message: string }> {
     return await bgRequest<{
       user_id: number
@@ -46,7 +51,10 @@ export const adminMethods = {
       path: `/api/v1/admin/users/${userId}/reset-password`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: {}
+      body: {
+        force_password_change: true,
+        ...payload
+      }
     })
   },
 

--- a/apps/packages/ui/src/services/tldw/domains/admin.ts
+++ b/apps/packages/ui/src/services/tldw/domains/admin.ts
@@ -35,6 +35,21 @@ export const adminMethods = {
     })
   },
 
+  async resetAdminUserPassword(
+    userId: number
+  ): Promise<{ user_id: number; force_password_change: boolean; message: string }> {
+    return await bgRequest<{
+      user_id: number
+      force_password_change: boolean
+      message: string
+    }>({
+      path: `/api/v1/admin/users/${userId}/reset-password`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: {}
+    })
+  },
+
   async listAdminRoles(): Promise<AdminRole[]> {
     return await bgRequest<AdminRole[]>({
       path: "/api/v1/admin/roles",
@@ -422,7 +437,14 @@ export const adminMethods = {
     return await bgRequest<any>({ path: "/api/v1/admin/backup-schedules", method: "GET" })
   },
 
-  async createBackupSchedule(payload: { dataset: string; cron?: string; retention_days?: number }): Promise<any> {
+  async createBackupSchedule(payload: {
+    dataset: string
+    target_user_id?: number
+    frequency: "daily" | "weekly" | "monthly"
+    time_of_day: string
+    timezone?: string
+    retention_count: number
+  }): Promise<any> {
     return await bgRequest<any>({
       path: "/api/v1/admin/backup-schedules",
       method: "POST",

--- a/apps/tldw-frontend/__tests__/pages/login-page.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/login-page.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const routerMock = vi.hoisted(() => ({ push: vi.fn() }))
+vi.mock("next/router", () => ({ useRouter: () => routerMock }))
+vi.mock("next/dynamic", () => ({
+  default: () => () => <div data-testid="hosted-settings" />
+}))
+
+const deploymentMock = vi.hoisted(() => ({ hosted: false }))
+vi.mock("@/services/tldw/deployment-mode", () => ({
+  isHostedTldwDeployment: () => deploymentMock.hosted
+}))
+
+const clientMock = vi.hoisted(() => ({ getConfig: vi.fn() }))
+vi.mock("@/services/tldw/TldwApiClient", () => ({ tldwClient: clientMock }))
+
+const authMock = vi.hoisted(() => ({ login: vi.fn() }))
+vi.mock("@/services/tldw/TldwAuth", () => ({ tldwAuth: authMock }))
+
+vi.mock("@/services/auth-errors", () => ({
+  mapMultiUserLoginErrorMessage: () => "Login failed. Check your credentials."
+}))
+
+vi.mock("@web/components/navigation/RouteRedirect", () => ({
+  RouteRedirect: ({ title }: { title: string }) => (
+    <div data-testid="route-redirect">{title}</div>
+  )
+}))
+
+import LoginPage from "../../pages/login"
+
+describe("LoginPage (#2919)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deploymentMock.hosted = false
+    clientMock.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8001",
+      authMode: "multi-user"
+    })
+    authMock.login.mockResolvedValue(undefined)
+  })
+
+  it("renders a focused sign-in screen for configured multi-user servers", async () => {
+    render(<LoginPage />)
+
+    expect(
+      await screen.findByRole("heading", { name: "Sign in to tldw" })
+    ).toBeInTheDocument()
+    expect(screen.getByText("http://127.0.0.1:8001", { exact: false })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Change server" })).toHaveAttribute(
+      "href",
+      "/settings/tldw"
+    )
+  })
+
+  it("signs in and navigates home", async () => {
+    render(<LoginPage />)
+    await screen.findByRole("heading", { name: "Sign in to tldw" })
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "audit-admin" }
+    })
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "secret" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }))
+
+    await waitFor(() => {
+      expect(authMock.login).toHaveBeenCalledWith({
+        username: "audit-admin",
+        password: "secret"
+      })
+    })
+    await waitFor(() => {
+      expect(routerMock.push).toHaveBeenCalledWith("/")
+    })
+  })
+
+  it("shows a friendly error on failed login and stays put", async () => {
+    authMock.login.mockRejectedValue(new Error("401"))
+    render(<LoginPage />)
+    await screen.findByRole("heading", { name: "Sign in to tldw" })
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "audit-admin" }
+    })
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "wrong" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Login failed. Check your credentials."
+    )
+    expect(routerMock.push).not.toHaveBeenCalled()
+  })
+
+  it("redirects to settings when no multi-user server is configured", async () => {
+    clientMock.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user"
+    })
+
+    render(<LoginPage />)
+
+    expect(await screen.findByTestId("route-redirect")).toHaveTextContent(
+      "Connect a server first"
+    )
+  })
+})

--- a/apps/tldw-frontend/pages/login.tsx
+++ b/apps/tldw-frontend/pages/login.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import dynamic from "next/dynamic"
+import Link from "next/link"
 import { useRouter } from "next/router"
 
 import { RouteRedirect } from "@web/components/navigation/RouteRedirect"
@@ -68,9 +69,9 @@ const SelfHostLogin: React.FC<{ serverUrl: string }> = ({ serverUrl }) => {
         <h1 className="text-2xl font-semibold text-text">Sign in to tldw</h1>
         <p className="mt-1 text-sm text-text-muted">
           {serverUrl}{" "}
-          <a className="underline hover:text-text" href="/settings/tldw">
+          <Link className="underline hover:text-text" href="/settings/tldw">
             Change server
-          </a>
+          </Link>
         </p>
         <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
           <label className="block">
@@ -110,9 +111,9 @@ const SelfHostLogin: React.FC<{ serverUrl: string }> = ({ serverUrl }) => {
         </form>
         <p className="mt-4 text-xs text-text-muted">
           Trouble signing in? Server URL and auth mode are configured in{" "}
-          <a className="underline hover:text-text" href="/settings/tldw">
+          <Link className="underline hover:text-text" href="/settings/tldw">
             tldw settings
-          </a>
+          </Link>
           .
         </p>
       </div>

--- a/apps/tldw-frontend/pages/login.tsx
+++ b/apps/tldw-frontend/pages/login.tsx
@@ -1,4 +1,6 @@
+import React from "react"
 import dynamic from "next/dynamic"
+import { useRouter } from "next/router"
 
 import { RouteRedirect } from "@web/components/navigation/RouteRedirect"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
@@ -8,25 +10,175 @@ const TldwSettings = dynamic(
   { ssr: false }
 )
 
-const LoginPage = () => {
-  const hostedMode = isHostedTldwDeployment()
+type LoginTarget = {
+  resolved: boolean
+  serverUrl: string | null
+  multiUser: boolean
+}
 
-  if (!hostedMode) {
-    return (
-      <RouteRedirect
-        to="/settings/tldw"
-        title="Login is managed in local settings"
-        description="Self-host deployments configure server URL and authentication from the tldw settings page."
-      />
-    )
+/**
+ * Focused sign-in screen for self-host multi-user servers (#2919).
+ *
+ * Multi-user visitors used to be redirected into the full settings shell
+ * with a below-the-fold "Login Required" banner - there was no login
+ * screen at all. This page puts username/password front and center once a
+ * multi-user server is configured; server configuration itself stays in
+ * settings, one small link away.
+ */
+const SelfHostLogin: React.FC<{ serverUrl: string }> = ({ serverUrl }) => {
+  const router = useRouter()
+  const [username, setUsername] = React.useState("")
+  const [password, setPassword] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!username.trim() || !password) {
+      setError("Enter your username and password.")
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const { tldwAuth } = await import("@/services/tldw/TldwAuth")
+      await tldwAuth.login({ username: username.trim(), password })
+      void router.push("/")
+    } catch (err) {
+      const { mapMultiUserLoginErrorMessage } = await import(
+        "@/services/auth-errors"
+      )
+      // The mapper is i18n-aware; the login page renders English defaults,
+      // matching the rest of the web shell's fallback behavior.
+      setError(
+        mapMultiUserLoginErrorMessage(
+          ((key: string, fallback?: string) => fallback ?? key) as never,
+          err,
+          "settings"
+        )
+      )
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
-    <div className="min-h-screen bg-bg">
-      <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
-        <TldwSettings />
+    <div className="flex min-h-screen items-center justify-center bg-bg px-4">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-surface p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold text-text">Sign in to tldw</h1>
+        <p className="mt-1 text-sm text-text-muted">
+          {serverUrl}{" "}
+          <a className="underline hover:text-text" href="/settings/tldw">
+            Change server
+          </a>
+        </p>
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+          <label className="block">
+            <span className="text-sm font-medium text-text">Username</span>
+            <input
+              name="username"
+              autoComplete="username"
+              autoFocus
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              className="mt-1 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text outline-none focus:border-primary"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-text">Password</span>
+            <input
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text outline-none focus:border-primary"
+            />
+          </label>
+          {error ? (
+            <p role="alert" className="text-sm text-danger">
+              {error}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primaryStrong disabled:opacity-60"
+          >
+            {submitting ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+        <p className="mt-4 text-xs text-text-muted">
+          Trouble signing in? Server URL and auth mode are configured in{" "}
+          <a className="underline hover:text-text" href="/settings/tldw">
+            tldw settings
+          </a>
+          .
+        </p>
       </div>
     </div>
+  )
+}
+
+const LoginPage = () => {
+  const hostedMode = isHostedTldwDeployment()
+  const [target, setTarget] = React.useState<LoginTarget>({
+    resolved: false,
+    serverUrl: null,
+    multiUser: false
+  })
+
+  React.useEffect(() => {
+    if (hostedMode) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const { tldwClient } = await import("@/services/tldw/TldwApiClient")
+        const config = await tldwClient.getConfig()
+        if (cancelled) return
+        setTarget({
+          resolved: true,
+          serverUrl:
+            typeof config?.serverUrl === "string" ? config.serverUrl : null,
+          multiUser: config?.authMode === "multi-user"
+        })
+      } catch {
+        if (!cancelled) {
+          setTarget({ resolved: true, serverUrl: null, multiUser: false })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [hostedMode])
+
+  if (hostedMode) {
+    return (
+      <div className="min-h-screen bg-bg">
+        <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+          <TldwSettings />
+        </div>
+      </div>
+    )
+  }
+
+  if (!target.resolved) {
+    return <div className="min-h-screen bg-bg" />
+  }
+
+  if (target.multiUser && target.serverUrl) {
+    return <SelfHostLogin serverUrl={target.serverUrl} />
+  }
+
+  // No multi-user server configured: signing in is not the next step -
+  // configuring a server is.
+  return (
+    <RouteRedirect
+      to="/settings/tldw"
+      title="Connect a server first"
+      description="Configure your tldw server URL and authentication mode in settings; multi-user servers then sign in here."
+    />
   )
 }
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -323,6 +323,22 @@ async def create_backup(
         raise HTTPException(status_code=400, detail="invalid_backup_request") from exc
     except HTTPException:
         raise
+    except RuntimeError as exc:
+        # The backup layer reports failures as messages; surface the
+        # actionable configuration case instead of a generic 500, without
+        # echoing raw filesystem paths (#2921).
+        if "Invalid database path" in str(exc):
+            logger.error("Failed to create backup: source outside allowed roots")
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "backup_source_not_allowed: the dataset's database is "
+                    "outside the allowed backup roots. Use a canonical "
+                    "database location or extend TLDW_DB_ALLOWED_BASE_DIRS."
+                ),
+            ) from exc
+        logger.error("Failed to create backup")
+        raise HTTPException(status_code=500, detail="Failed to create backup") from exc
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
         logger.error("Failed to create backup")
         raise HTTPException(status_code=500, detail="Failed to create backup") from exc

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -238,7 +238,11 @@ async def list_backups(
             _require_user_id_for_dataset(normalized_dataset, user_id)
         if user_id is not None:
             await _enforce_admin_user_scope(principal, user_id, require_hierarchy=False)
-        items, total = svc_list_backup_items(
+        # Directory scans (now spanning every user_<id>/ subtree for the
+        # unfiltered admin view) are synchronous filesystem work - keep them
+        # off the event loop.
+        items, total = await asyncio.to_thread(
+            svc_list_backup_items,
             dataset=normalized_dataset,
             user_id=user_id,
             limit=limit,

--- a/tldw_Server_API/app/core/AuthNZ/initialize.py
+++ b/tldw_Server_API/app/core/AuthNZ/initialize.py
@@ -679,6 +679,31 @@ async def ensure_authnz_schema_ready_once() -> None:
             raise RuntimeError(
                 "SQLite in-memory AuthNZ database target cannot be validated by path"
             )
+
+        # Seed baseline RBAC roles/permissions for SQLite in every auth mode.
+        # Postgres bootstrap and the single-user backstop already run this
+        # idempotent seed; SQLite multi-user previously fell through the gap,
+        # leaving the permission catalog empty and the RBAC admin page
+        # unusable on a fresh install (#2920).
+        try:
+            from tldw_Server_API.app.core.AuthNZ.rbac_seed import (
+                ensure_baseline_rbac_seed,
+            )
+
+            async with pool.transaction() as conn:
+                await ensure_baseline_rbac_seed(
+                    conn,
+                    include_mcp_permissions=True,
+                    is_postgres=False,
+                )
+                with contextlib.suppress(_AUTHNZ_INIT_NONCRITICAL_EXCEPTIONS):
+                    await conn.commit()  # type: ignore[attr-defined]
+        except _AUTHNZ_INIT_NONCRITICAL_EXCEPTIONS as seed_err:
+            logger.warning(
+                "AuthNZ Startup: baseline RBAC seed failed (continuing): {}",
+                seed_err,
+            )
+
         _SCHEMA_ENSURED_KEYS.add(key)
 
 

--- a/tldw_Server_API/app/core/AuthNZ/initialize.py
+++ b/tldw_Server_API/app/core/AuthNZ/initialize.py
@@ -703,6 +703,11 @@ async def ensure_authnz_schema_ready_once() -> None:
                 "AuthNZ Startup: baseline RBAC seed failed (continuing): {}",
                 seed_err,
             )
+            # Do not latch the ensured key on a failed seed: the schema
+            # ensure above is idempotent, and skipping here lets the next
+            # call retry the seed instead of leaving the catalog empty for
+            # the process lifetime.
+            return
 
         _SCHEMA_ENSURED_KEYS.add(key)
 

--- a/tldw_Server_API/app/services/admin_data_ops_service.py
+++ b/tldw_Server_API/app/services/admin_data_ops_service.py
@@ -149,6 +149,22 @@ def _list_backup_files(dataset: str, user_id: int | None) -> list[BackupFile]:
     return files
 
 
+def _list_all_users_backup_files(dataset: str) -> list[BackupFile]:
+    """Every user's backups for a per-user dataset (admin unfiltered view)."""
+    base_dir = _backup_base_dir()
+    if not os.path.isdir(base_dir):
+        return []
+    items: list[BackupFile] = []
+    for entry in os.scandir(base_dir):
+        if not entry.is_dir(follow_symlinks=False):
+            continue
+        match = re.fullmatch(r"user_(\d+)", entry.name)
+        if not match:
+            continue
+        items.extend(_list_backup_files(dataset, int(match.group(1))))
+    return items
+
+
 def list_backup_items(
     *,
     dataset: str | None,
@@ -159,8 +175,17 @@ def list_backup_items(
     datasets = [_validate_backup_dataset(dataset)] if dataset is not None else [*DATASET_DB_RESOLVERS.keys(), "authnz"]
     items: list[BackupFile] = []
     for key in datasets:
-        dataset_user_id = None if key == "authnz" else user_id
-        items.extend(_list_backup_files(key, dataset_user_id))
+        if key == "authnz":
+            items.extend(_list_backup_files(key, None))
+            continue
+        if user_id is not None:
+            items.extend(_list_backup_files(key, user_id))
+            continue
+        # Unfiltered admin view: per-user datasets live under user_<id>/
+        # subdirectories, which the userless scan never visited - so the
+        # most common backups were invisible without a filter (#2921).
+        items.extend(_list_backup_files(key, None))
+        items.extend(_list_all_users_backup_files(key))
     items.sort(key=lambda item: item.created_at, reverse=True)
     total = len(items)
     return items[offset: offset + limit], total

--- a/tldw_Server_API/tests/Admin/test_data_ops.py
+++ b/tldw_Server_API/tests/Admin/test_data_ops.py
@@ -299,3 +299,50 @@ async def test_admin_data_ops_per_user_backup_success(tmp_path):
         assert payload["pagination"]["offset"] == 0
         listed = payload["items"]
         assert any(item["id"] == backup_id for item in listed)
+
+
+@pytest.mark.asyncio
+async def test_admin_unfiltered_backup_list_includes_per_user_backups(tmp_path):
+    """Unfiltered admin listing must include user_<id>/ backups (#2921)."""
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+    await reset_db_pool()
+    reset_settings()
+    await reset_session_manager()
+
+    user_id = DatabasePaths.get_single_user_id()
+    media_db_path = DatabasePaths.get_media_db_path(user_id)
+    media_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    import sqlite3
+
+    with sqlite3.connect(media_db_path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS test_table (id INTEGER PRIMARY KEY, name TEXT)"
+        )
+        conn.commit()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        create_resp = client.post(
+            "/api/v1/admin/backups",
+            json={"dataset": "media", "user_id": user_id, "backup_type": "full"},
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        backup_id = create_resp.json()["item"]["id"]
+
+        # No dataset/user filters at all: the per-user backup must appear.
+        list_resp = client.get("/api/v1/admin/backups")
+        assert list_resp.status_code == 200, list_resp.text
+        listed = list_resp.json()["items"]
+        assert any(item["id"] == backup_id for item in listed), (
+            "per-user backup missing from unfiltered admin listing"
+        )
+        matching = next(item for item in listed if item["id"] == backup_id)
+        assert matching["user_id"] == user_id


### PR DESCRIPTION
## Summary

Fixes all six implementable findings from the round-4 multi-user admin audit (#2915–#2922), each verified live against a seeded multi-user server (3 users, org, watchlists, alert rules, backups):

- **#2916 — Orgs list could never display an org**: `GET /admin/orgs` returns an `{items}` envelope the page never read. All four list parses now try `items` first; regression test renders an org from the real envelope.
- **#2917 — Data Ops spoke a fictional API contract**: dataset options now mirror the backend allowlist (the old `chachanotes`/`users` options were always rejected; three valid datasets were missing), per-user datasets require a target user exactly when the backend does, and the schedule form/client/table/preset-chips speak `frequency`/`time_of_day`/`retention_count` instead of the `cron` fields that guaranteed a 422.
- **#2918 — user lifecycle**: corrected scope (inline role/active controls already existed — the audit probe misread controls for buttons); the genuinely missing action lands: a verb-labeled Reset-password row action wired to the existing endpoint via a new client method.
- **#2919 — no login screen**: `/login` on self-host deliberately bounced to settings, so multi-user visitors were captured by the settings shell with a below-fold "Login Required" banner. It now renders a focused sign-in card (username/password front and center, server URL with a change link, friendly mapped errors). Verified live end-to-end: first contact lands on "Sign in to tldw", bad creds → mapped error, real creds → home. 4 new page tests.
- **#2920 — RBAC page unusable on fresh multi-user installs**: Postgres bootstrap and the single-user backstop both ran the idempotent baseline RBAC seed; SQLite multi-user fell through the gap, leaving an empty permission catalog. The schema-ensure path now seeds for SQLite in every auth mode (verified live: 6 roles + full catalog; AuthNZ_SQLite 220/220).
- **#2921 — invisible backups + opaque failures**: the unfiltered admin listing now walks `user_<id>/` subdirectories, so per-user backups (5 of 6 datasets) appear without a filter (live: 1 → 3 items; regression test). Out-of-roots backup sources return an actionable 400 naming `TLDW_DB_ALLOWED_BASE_DIRS` instead of a log-only generic 500, with log sanitization preserved (the policy test caught and shaped this).

Remaining round-4 issues are product decisions, left open: #2915 (billing targets a phantom API — build it or descope the page) and #2922 (admin watchlists pages show the operator's own data, not the fleet's).

## Verification

- Live multi-user stack: every fix probed against the seeded server (login flow, org render, RBAC catalog, backup visibility).
- Frontend: 184 admin-component tests + 4 new login-page tests; tsc clean in touched files.
- Backend: tests/Admin/test_data_ops 8/8 (incl. new unfiltered-visibility regression test), tests/AuthNZ_SQLite 220/220 with the seed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GJqCP5hN77xWHtwJog5M9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the six implementable round-4 multi-user admin audit findings across the admin UI and backend: orgs now render, backup forms speak the real API contract, multi-user self-host servers get a focused login screen, SQLite installs seed RBAC, per-user backups are visible without filters, and user passwords can be reset.

**Bug Fixes**
- Org, member/team, backup, and schedule lists read the `items` envelope returned by `GET /admin/orgs`, so data renders instead of "No data".
- Data Ops backup options mirror the backend allowlist; schedule creation uses `frequency`/`time_of_day`/`retention_count`, requires a target user for per-user datasets, and validates time format client-side instead of round-tripping to a server 500.
- Users table gains a Reset password action that generates a temporary password, sends it with an audit reason and `force_password_change`, and reveals it once in a copyable modal.
- `/login` on self-host multi-user servers renders a sign-in card instead of redirecting into settings; 4 new page tests cover the flow.
- SQLite schema ensure seeds baseline RBAC roles and permissions in every auth mode, and retries the seed on failure instead of leaving the catalog empty for the process lifetime; backup directory scans run off the event loop.
- Unfiltered admin backup listing walks `user_<id>/` subdirectories, and out-of-roots backup sources return a 400 naming `TLDW_DB_ALLOWED_BASE_DIRS` instead of a log-only 500.

<sup>Written for commit da2fb8e3b70506c2d5c4659614b7707af78ca135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

