### PR TITLE
Admin: watchlists fleet oversight (#2922) + billing storage-summary fix (#2915)

### DIFF
--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -95,25 +95,40 @@ const OverviewTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardEr
 
       {storageSummary && (
         <Card title={t("settings:adminBilling.storageSummary", "Storage Summary")}>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 16 }}>
-            <Statistic title={t("settings:adminBilling.totalUsers", "Total Users")} value={storageSummary.total_users ?? 0} />
-            <Statistic
-              title={t("settings:adminBilling.totalUsedMb", "Total Used (MB)")}
-              value={storageSummary.total_used_mb ?? 0}
-              precision={1}
-            />
-            <Statistic
-              title={t("settings:adminBilling.totalQuotaMb", "Total Quota (MB)")}
-              value={storageSummary.total_quota_mb ?? 0}
-              precision={1}
-            />
-            <Statistic
-              title={t("settings:adminBilling.avgUtilization", "Avg Utilization")}
-              value={storageSummary.avg_utilization_pct ?? 0}
-              suffix="%"
-              precision={1}
-            />
-          </div>
+          {(() => {
+            // GET /admin/storage-quotas/summary returns {total_quotas, items:
+            // [{quota_mb, used_mb, ...}]} - aggregate here; the flat
+            // total_used_mb/avg_utilization_pct fields never existed.
+            const quotaItems: Array<{ quota_mb?: number; used_mb?: number }> =
+              storageSummary.items ?? []
+            const totalQuotaMb = quotaItems.reduce((sum, q) => sum + (q.quota_mb ?? 0), 0)
+            const totalUsedMb = quotaItems.reduce((sum, q) => sum + (q.used_mb ?? 0), 0)
+            const utilizationPct = totalQuotaMb > 0 ? (totalUsedMb / totalQuotaMb) * 100 : 0
+            return (
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 16 }}>
+                <Statistic
+                  title={t("settings:adminBilling.totalQuotas", "Quota Records")}
+                  value={storageSummary.total_quotas ?? quotaItems.length}
+                />
+                <Statistic
+                  title={t("settings:adminBilling.totalUsedMb", "Total Used (MB)")}
+                  value={totalUsedMb}
+                  precision={1}
+                />
+                <Statistic
+                  title={t("settings:adminBilling.totalQuotaMb", "Total Quota (MB)")}
+                  value={totalQuotaMb}
+                  precision={1}
+                />
+                <Statistic
+                  title={t("settings:adminBilling.avgUtilization", "Utilization")}
+                  value={utilizationPct}
+                  suffix="%"
+                  precision={1}
+                />
+              </div>
+            )
+          })()}
         </Card>
       )}
     </div>

--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -28,6 +28,22 @@ const BILLING_OVERVIEW_PATH = "/api/v1/admin/billing/overview"
 
 // ── Overview Tab ──
 
+// GET /admin/storage-quotas/summary returns {total_quotas, items:
+// [{quota_mb, used_mb, ...}], pagination} - the flat total_used_mb /
+// avg_utilization_pct fields never existed, so aggregate the page here.
+export const aggregateStorageSummary = (summary: any) => {
+  const quotaItems: Array<{ quota_mb?: number; used_mb?: number }> = summary?.items ?? []
+  const totalQuotaMb = quotaItems.reduce((sum, q) => sum + (q.quota_mb ?? 0), 0)
+  const totalUsedMb = quotaItems.reduce((sum, q) => sum + (q.used_mb ?? 0), 0)
+  return {
+    totalQuotas: summary?.total_quotas ?? quotaItems.length,
+    totalQuotaMb,
+    totalUsedMb,
+    utilizationPct: totalQuotaMb > 0 ? (totalUsedMb / totalQuotaMb) * 100 : 0,
+    hasMore: Boolean(summary?.has_more ?? summary?.pagination?.has_more)
+  }
+}
+
 const OverviewTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardError }) => {
   const { t } = useTranslation(["settings", "common"])
   const [overview, setOverview] = useState<any>(null)
@@ -39,7 +55,8 @@ const OverviewTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardEr
     try {
       const [billing, storage] = await Promise.allSettled([
         tldwClient.getBillingOverview(),
-        tldwClient.getStorageQuotaSummary()
+        // 200 is the endpoint's max page size; hasMore flags any remainder.
+        tldwClient.getStorageQuotaSummary({ limit: 200 })
       ])
       if (billing.status === "fulfilled") {
         setOverview(billing.value)
@@ -93,44 +110,45 @@ const OverviewTab: React.FC<{ onGuardError: (err: any) => void }> = ({ onGuardEr
         </Card>
       )}
 
-      {storageSummary && (
-        <Card title={t("settings:adminBilling.storageSummary", "Storage Summary")}>
-          {(() => {
-            // GET /admin/storage-quotas/summary returns {total_quotas, items:
-            // [{quota_mb, used_mb, ...}]} - aggregate here; the flat
-            // total_used_mb/avg_utilization_pct fields never existed.
-            const quotaItems: Array<{ quota_mb?: number; used_mb?: number }> =
-              storageSummary.items ?? []
-            const totalQuotaMb = quotaItems.reduce((sum, q) => sum + (q.quota_mb ?? 0), 0)
-            const totalUsedMb = quotaItems.reduce((sum, q) => sum + (q.used_mb ?? 0), 0)
-            const utilizationPct = totalQuotaMb > 0 ? (totalUsedMb / totalQuotaMb) * 100 : 0
-            return (
+      {storageSummary &&
+        (() => {
+          const storage = aggregateStorageSummary(storageSummary)
+          return (
+            <Card title={t("settings:adminBilling.storageSummary", "Storage Summary")}>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 16 }}>
                 <Statistic
                   title={t("settings:adminBilling.totalQuotas", "Quota Records")}
-                  value={storageSummary.total_quotas ?? quotaItems.length}
+                  value={storage.totalQuotas}
+                  suffix={storage.hasMore ? "+" : undefined}
                 />
                 <Statistic
                   title={t("settings:adminBilling.totalUsedMb", "Total Used (MB)")}
-                  value={totalUsedMb}
+                  value={storage.totalUsedMb}
                   precision={1}
                 />
                 <Statistic
                   title={t("settings:adminBilling.totalQuotaMb", "Total Quota (MB)")}
-                  value={totalQuotaMb}
+                  value={storage.totalQuotaMb}
                   precision={1}
                 />
                 <Statistic
                   title={t("settings:adminBilling.avgUtilization", "Utilization")}
-                  value={utilizationPct}
+                  value={storage.utilizationPct}
                   suffix="%"
                   precision={1}
                 />
               </div>
-            )
-          })()}
-        </Card>
-      )}
+              {storage.hasMore && (
+                <p style={{ marginTop: 12, marginBottom: 0, color: "var(--color-text-secondary, #888)", fontSize: "0.85rem" }}>
+                  {t(
+                    "settings:adminBilling.storageTruncated",
+                    "Totals cover the first 200 quota records; this server has more."
+                  )}
+                </p>
+              )}
+            </Card>
+          )
+        })()}
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/Admin/WatchlistsOversightPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/WatchlistsOversightPage.tsx
@@ -51,39 +51,51 @@ const WatchlistsOversightPage: React.FC = () => {
   const [sources, setSources] = useState<WatchlistSource[]>([])
   const [items, setItems] = useState<ScrapedItem[]>([])
   const [runs, setRuns] = useState<WatchlistRun[]>([])
+  const [sourceTotal, setSourceTotal] = useState<number | null>(null)
+  const [runTotal, setRunTotal] = useState<number | null>(null)
   const [counts, setCounts] = useState<ScrapedItemSmartCounts | null>(null)
 
   const initialLoadRef = useRef(false)
+  // Guards against out-of-order responses: only the latest load may commit
+  // state, so fast user switching can't show a previous user's data.
+  const loadSeqRef = useRef(0)
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const markAdminGuardFromError = useCallback((err: unknown) => {
     const guardState = deriveAdminGuardFromError(err)
     if (guardState) setAdminGuard(guardState)
   }, [])
 
-  const loadUsers = useCallback(async () => {
-    setUsersLoading(true)
-    setUsersError(null)
-    try {
-      const result = await tldwClient.listAdminUsers({ limit: 100 })
-      const loaded = result.users || []
-      setUsers(loaded)
-      // Single-user servers have exactly one account - select it directly
-      // instead of asking the operator to search for themselves.
-      if (loaded.length === 1) {
-        setSelectedUserId((current) => current ?? loaded[0].id)
-      }
-    } catch (err) {
-      markAdminGuardFromError(err)
-      setUsersError(
-        sanitizeAdminErrorMessage(
-          err,
-          t("settings:adminWatchlistsOversight.usersLoadFailed", "Failed to load the user list.")
+  const loadUsers = useCallback(
+    async (search?: string) => {
+      setUsersLoading(true)
+      setUsersError(null)
+      try {
+        const result = await tldwClient.listAdminUsers({
+          limit: 100,
+          ...(search ? { search } : {})
+        })
+        const loaded = result.users || []
+        setUsers(loaded)
+        // Single-user servers have exactly one account - select it directly
+        // instead of asking the operator to search for themselves.
+        if (!search && loaded.length === 1) {
+          setSelectedUserId((current) => current ?? loaded[0].id)
+        }
+      } catch (err) {
+        markAdminGuardFromError(err)
+        setUsersError(
+          sanitizeAdminErrorMessage(
+            err,
+            t("settings:adminWatchlistsOversight.usersLoadFailed", "Failed to load the user list.")
+          )
         )
-      )
-    } finally {
-      setUsersLoading(false)
-    }
-  }, [markAdminGuardFromError, t])
+      } finally {
+        setUsersLoading(false)
+      }
+    },
+    [markAdminGuardFromError, t]
+  )
 
   useEffect(() => {
     if (initialLoadRef.current) return
@@ -91,8 +103,27 @@ const WatchlistsOversightPage: React.FC = () => {
     void loadUsers()
   }, [loadUsers])
 
+  // Remote search so accounts beyond the first page stay reachable on large
+  // servers; the Select filters nothing locally (filterOption={false}).
+  const handleUserSearch = useCallback(
+    (term: string) => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+      searchTimerRef.current = setTimeout(() => {
+        void loadUsers(term.trim() || undefined)
+      }, 300)
+    },
+    [loadUsers]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+    }
+  }, [])
+
   const loadUserData = useCallback(
     async (userId: number) => {
+      const seq = ++loadSeqRef.current
       setLoading(true)
       setLoadError(null)
       setPrivacy(null)
@@ -104,12 +135,16 @@ const WatchlistsOversightPage: React.FC = () => {
           fetchWatchlistRuns({ ...scope, size: 25 }),
           fetchScrapedItemSmartCounts(scope)
         ])
+        if (seq !== loadSeqRef.current) return
         setSources(sourcesResp?.items ?? [])
         setItems(itemsResp?.items ?? [])
         setRuns(runsResp?.items ?? [])
+        setSourceTotal(sourcesResp?.total ?? null)
+        setRunTotal(runsResp?.total ?? null)
         setCounts(countsResp ?? null)
         setPrivacy("allowed")
       } catch (err) {
+        if (seq !== loadSeqRef.current) return
         // Sharing can be disabled per deployment; render that as a designed
         // state, not an error wall.
         if (/watchlists_private_only_mode|watchlists_admin_same_org_required/.test(extractDetail(err))) {
@@ -127,7 +162,7 @@ const WatchlistsOversightPage: React.FC = () => {
           )
         }
       } finally {
-        setLoading(false)
+        if (seq === loadSeqRef.current) setLoading(false)
       }
     },
     [markAdminGuardFromError, t]
@@ -137,9 +172,12 @@ const WatchlistsOversightPage: React.FC = () => {
     if (selectedUserId) {
       void loadUserData(selectedUserId)
     } else {
+      loadSeqRef.current += 1
       setSources([])
       setItems([])
       setRuns([])
+      setSourceTotal(null)
+      setRunTotal(null)
       setCounts(null)
       setPrivacy(null)
     }
@@ -165,6 +203,18 @@ const WatchlistsOversightPage: React.FC = () => {
       </Alert>
     )
   }
+
+  // Oversight fetches bounded snapshots (100 feeds / 50 items / 25 runs);
+  // when the server holds more, say so instead of implying completeness.
+  const showingOf = (shown: number, total: number | null) =>
+    total != null && total > shown ? (
+      <span style={{ color: "var(--color-text-secondary, #888)", fontSize: "0.85rem" }}>
+        {t("settings:adminWatchlistsOversight.showingOf", "Showing {{shown}} of {{total}}", {
+          shown,
+          total
+        })}
+      </span>
+    ) : null
 
   const sourceColumns = [
     {
@@ -293,7 +343,8 @@ const WatchlistsOversightPage: React.FC = () => {
             loading={usersLoading}
             value={selectedUserId}
             onChange={(val) => setSelectedUserId(val)}
-            optionFilterProp="label"
+            onSearch={handleUserSearch}
+            filterOption={false}
             options={users.map((u: any) => ({
               value: u.id,
               label: `${u.username} (${u.email || t("settings:adminWatchlistsOversight.noEmail", "no email")})`
@@ -345,7 +396,7 @@ const WatchlistsOversightPage: React.FC = () => {
             <Space size="large" wrap>
               <Statistic
                 title={t("settings:adminWatchlistsOversight.statFeeds", "Feeds")}
-                value={sources.length}
+                value={sourceTotal ?? sources.length}
               />
               <Statistic
                 title={t("settings:adminWatchlistsOversight.statItems", "Collected items")}
@@ -356,14 +407,15 @@ const WatchlistsOversightPage: React.FC = () => {
                 value={counts?.unread ?? 0}
               />
               <Statistic
-                title={t("settings:adminWatchlistsOversight.statRuns", "Recent runs")}
-                value={runs.length}
+                title={t("settings:adminWatchlistsOversight.statRuns", "Runs")}
+                value={runTotal ?? runs.length}
               />
             </Space>
           </Card>
 
           <Card
             title={t("settings:adminWatchlistsOversight.feedsCardTitle", "Feeds")}
+            extra={showingOf(sources.length, sourceTotal)}
             size="small"
             style={{ marginBottom: 16 }}
           >
@@ -385,6 +437,7 @@ const WatchlistsOversightPage: React.FC = () => {
 
           <Card
             title={t("settings:adminWatchlistsOversight.itemsCardTitle", "Latest collected items")}
+            extra={showingOf(items.length, counts?.all ?? null)}
             size="small"
             style={{ marginBottom: 16 }}
           >
@@ -406,6 +459,7 @@ const WatchlistsOversightPage: React.FC = () => {
 
           <Card
             title={t("settings:adminWatchlistsOversight.runsCardTitle", "Recent runs")}
+            extra={showingOf(runs.length, runTotal)}
             size="small"
           >
             <Table

--- a/apps/packages/ui/src/components/Option/Admin/WatchlistsOversightPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/WatchlistsOversightPage.tsx
@@ -1,0 +1,432 @@
+import React, { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Card, Select, Space, Statistic, Table, Tag } from "antd"
+
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import {
+  fetchScrapedItemSmartCounts,
+  fetchScrapedItems,
+  fetchWatchlistRuns,
+  fetchWatchlistSources
+} from "@/services/watchlists"
+import type {
+  ScrapedItem,
+  ScrapedItemSmartCounts,
+  WatchlistRun,
+  WatchlistSource
+} from "@/types/watchlists"
+import { Alert } from "@/components/ui/primitives"
+import {
+  deriveAdminGuardFromError,
+  sanitizeAdminErrorMessage
+} from "./admin-error-utils"
+
+/**
+ * Fleet oversight for watchlists (#2922): a read-only, user-scoped view of
+ * any user's feeds, collected items, and run history. The decision behind
+ * this page: the /admin watchlists surface is FLEET oversight with an
+ * explicit user selector (like API Keys) - the personal triage tool stays
+ * on /watchlists. The backend already gates cross-user reads behind
+ * WATCHLIST_SHARING_MODE + admin claims via target_user_id.
+ */
+
+type PrivacyState = "allowed" | "private_only" | null
+
+const extractDetail = (err: unknown): string => {
+  const message = err instanceof Error ? err.message : String(err ?? "")
+  return message
+}
+
+const WatchlistsOversightPage: React.FC = () => {
+  const { t } = useTranslation(["settings", "common"])
+  const [adminGuard, setAdminGuard] = useState<"forbidden" | "notFound" | null>(null)
+  const [users, setUsers] = useState<any[]>([])
+  const [usersLoading, setUsersLoading] = useState(false)
+  const [usersError, setUsersError] = useState<string | null>(null)
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null)
+
+  const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [privacy, setPrivacy] = useState<PrivacyState>(null)
+  const [sources, setSources] = useState<WatchlistSource[]>([])
+  const [items, setItems] = useState<ScrapedItem[]>([])
+  const [runs, setRuns] = useState<WatchlistRun[]>([])
+  const [counts, setCounts] = useState<ScrapedItemSmartCounts | null>(null)
+
+  const initialLoadRef = useRef(false)
+
+  const markAdminGuardFromError = useCallback((err: unknown) => {
+    const guardState = deriveAdminGuardFromError(err)
+    if (guardState) setAdminGuard(guardState)
+  }, [])
+
+  const loadUsers = useCallback(async () => {
+    setUsersLoading(true)
+    setUsersError(null)
+    try {
+      const result = await tldwClient.listAdminUsers({ limit: 100 })
+      const loaded = result.users || []
+      setUsers(loaded)
+      // Single-user servers have exactly one account - select it directly
+      // instead of asking the operator to search for themselves.
+      if (loaded.length === 1) {
+        setSelectedUserId((current) => current ?? loaded[0].id)
+      }
+    } catch (err) {
+      markAdminGuardFromError(err)
+      setUsersError(
+        sanitizeAdminErrorMessage(
+          err,
+          t("settings:adminWatchlistsOversight.usersLoadFailed", "Failed to load the user list.")
+        )
+      )
+    } finally {
+      setUsersLoading(false)
+    }
+  }, [markAdminGuardFromError, t])
+
+  useEffect(() => {
+    if (initialLoadRef.current) return
+    initialLoadRef.current = true
+    void loadUsers()
+  }, [loadUsers])
+
+  const loadUserData = useCallback(
+    async (userId: number) => {
+      setLoading(true)
+      setLoadError(null)
+      setPrivacy(null)
+      try {
+        const scope = { target_user_id: userId }
+        const [sourcesResp, itemsResp, runsResp, countsResp] = await Promise.all([
+          fetchWatchlistSources({ ...scope, size: 100 }),
+          fetchScrapedItems({ ...scope, size: 50, sort: "created_desc" }),
+          fetchWatchlistRuns({ ...scope, size: 25 }),
+          fetchScrapedItemSmartCounts(scope)
+        ])
+        setSources(sourcesResp?.items ?? [])
+        setItems(itemsResp?.items ?? [])
+        setRuns(runsResp?.items ?? [])
+        setCounts(countsResp ?? null)
+        setPrivacy("allowed")
+      } catch (err) {
+        // Sharing can be disabled per deployment; render that as a designed
+        // state, not an error wall.
+        if (/watchlists_private_only_mode|watchlists_admin_same_org_required/.test(extractDetail(err))) {
+          setPrivacy("private_only")
+        } else {
+          markAdminGuardFromError(err)
+          setLoadError(
+            sanitizeAdminErrorMessage(
+              err,
+              t(
+                "settings:adminWatchlistsOversight.loadFailed",
+                "Failed to load this user's watchlist data."
+              )
+            )
+          )
+        }
+      } finally {
+        setLoading(false)
+      }
+    },
+    [markAdminGuardFromError, t]
+  )
+
+  useEffect(() => {
+    if (selectedUserId) {
+      void loadUserData(selectedUserId)
+    } else {
+      setSources([])
+      setItems([])
+      setRuns([])
+      setCounts(null)
+      setPrivacy(null)
+    }
+  }, [selectedUserId, loadUserData])
+
+  if (adminGuard === "forbidden") {
+    return (
+      <Alert variant="error" title={t("settings:adminWatchlistsOversight.forbiddenTitle", "Access Denied")}>
+        {t(
+          "settings:adminWatchlistsOversight.forbiddenBody",
+          "You don't have permission to inspect other users' watchlists."
+        )}
+      </Alert>
+    )
+  }
+  if (adminGuard === "notFound") {
+    return (
+      <Alert variant="warning" title={t("settings:adminWatchlistsOversight.notFoundTitle", "Not Available")}>
+        {t(
+          "settings:adminWatchlistsOversight.notFoundBody",
+          "Watchlist oversight endpoints are not available on this server."
+        )}
+      </Alert>
+    )
+  }
+
+  const sourceColumns = [
+    {
+      title: t("settings:adminWatchlistsOversight.colFeed", "Feed"),
+      dataIndex: "name",
+      key: "name"
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colUrl", "URL"),
+      dataIndex: "url",
+      key: "url",
+      ellipsis: true,
+      render: (value: string) => <code>{value}</code>
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colActive", "Active"),
+      dataIndex: "active",
+      key: "active",
+      width: 90,
+      render: (value: boolean) =>
+        value ? (
+          <Tag color="green">{t("settings:adminWatchlistsOversight.active", "Active")}</Tag>
+        ) : (
+          <Tag>{t("settings:adminWatchlistsOversight.inactive", "Inactive")}</Tag>
+        )
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colLastScraped", "Last scraped"),
+      dataIndex: "last_scraped_at",
+      key: "last_scraped_at",
+      width: 180,
+      render: (value: string | null) =>
+        value ? new Date(value).toLocaleString() : "—"
+    }
+  ]
+
+  const itemColumns = [
+    {
+      title: t("settings:adminWatchlistsOversight.colTitle", "Item"),
+      dataIndex: "title",
+      key: "title",
+      ellipsis: true,
+      render: (value: string | null) =>
+        value || t("settings:adminWatchlistsOversight.untitled", "Untitled")
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colPublished", "Published"),
+      dataIndex: "published_at",
+      key: "published_at",
+      width: 180,
+      render: (value: string | null) =>
+        value ? new Date(value).toLocaleString() : "—"
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colReviewed", "Reviewed"),
+      dataIndex: "reviewed",
+      key: "reviewed",
+      width: 100,
+      render: (value: boolean) =>
+        value ? (
+          <Tag color="green">{t("settings:adminWatchlistsOversight.reviewed", "Reviewed")}</Tag>
+        ) : (
+          <Tag color="blue">{t("settings:adminWatchlistsOversight.unread", "Unread")}</Tag>
+        )
+    }
+  ]
+
+  const runColumns = [
+    {
+      title: t("settings:adminWatchlistsOversight.colRunStarted", "Started"),
+      dataIndex: "started_at",
+      key: "started_at",
+      width: 180,
+      render: (value: string | null) =>
+        value ? new Date(value).toLocaleString() : "—"
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colRunStatus", "Status"),
+      dataIndex: "status",
+      key: "status",
+      width: 120,
+      render: (value: string) => (
+        <Tag color={value === "success" ? "green" : value === "failed" ? "red" : "blue"}>
+          {value}
+        </Tag>
+      )
+    },
+    {
+      title: t("settings:adminWatchlistsOversight.colRunError", "Error"),
+      dataIndex: "error_msg",
+      key: "error_msg",
+      ellipsis: true,
+      render: (value: string | null) => value || "—"
+    }
+  ]
+
+  return (
+    <div style={{ padding: "24px", maxWidth: 1200 }}>
+      <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>
+        {t("settings:adminWatchlistsOversight.title", "Watchlists Oversight")}
+      </h1>
+      <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
+        {t(
+          "settings:adminWatchlistsOversight.description",
+          "Read-only fleet view of any user's watchlist feeds, collected items, and run health. Users manage their own watchlists on the Watchlists page."
+        )}
+      </p>
+
+      {usersError && (
+        <Alert
+          variant="error"
+          title={t("settings:adminWatchlistsOversight.usersErrorTitle", "Unable to load users")}
+          className="mb-4"
+        >
+          {usersError}
+        </Alert>
+      )}
+
+      <Card size="small" style={{ marginBottom: 16 }}>
+        <Space>
+          <span>{t("settings:adminWatchlistsOversight.selectUser", "Select User:")}</span>
+          <Select
+            showSearch
+            placeholder={t("settings:adminWatchlistsOversight.searchUsers", "Search users...")}
+            style={{ width: 300 }}
+            loading={usersLoading}
+            value={selectedUserId}
+            onChange={(val) => setSelectedUserId(val)}
+            optionFilterProp="label"
+            options={users.map((u: any) => ({
+              value: u.id,
+              label: `${u.username} (${u.email || t("settings:adminWatchlistsOversight.noEmail", "no email")})`
+            }))}
+          />
+        </Space>
+      </Card>
+
+      {!selectedUserId && !usersLoading && !usersError && (
+        <Card size="small">
+          <p style={{ margin: 0, color: "var(--color-text-secondary, #888)" }}>
+            {users.length === 0
+              ? t("settings:adminWatchlistsOversight.noUsers", "No users were found on this server.")
+              : t(
+                  "settings:adminWatchlistsOversight.selectUserHint",
+                  "Select a user above to inspect their watchlist activity."
+                )}
+          </p>
+        </Card>
+      )}
+
+      {privacy === "private_only" && (
+        <Alert
+          variant="info"
+          title={t(
+            "settings:adminWatchlistsOversight.privateTitle",
+            "Watchlist sharing is disabled on this server"
+          )}
+        >
+          {t(
+            "settings:adminWatchlistsOversight.privateBody",
+            "This deployment runs with WATCHLIST_SHARING_MODE set to private_only (or same-org restrictions apply), so admins cannot inspect other users' watchlists. Change the sharing mode on the server to enable fleet oversight."
+          )}
+        </Alert>
+      )}
+
+      {loadError && (
+        <Alert
+          variant="error"
+          title={t("settings:adminWatchlistsOversight.loadErrorTitle", "Unable to load watchlist data")}
+        >
+          {loadError}
+        </Alert>
+      )}
+
+      {selectedUserId && privacy === "allowed" && (
+        <>
+          <Card size="small" style={{ marginBottom: 16 }} data-testid="oversight-summary">
+            <Space size="large" wrap>
+              <Statistic
+                title={t("settings:adminWatchlistsOversight.statFeeds", "Feeds")}
+                value={sources.length}
+              />
+              <Statistic
+                title={t("settings:adminWatchlistsOversight.statItems", "Collected items")}
+                value={counts?.all ?? items.length}
+              />
+              <Statistic
+                title={t("settings:adminWatchlistsOversight.statUnread", "Unread")}
+                value={counts?.unread ?? 0}
+              />
+              <Statistic
+                title={t("settings:adminWatchlistsOversight.statRuns", "Recent runs")}
+                value={runs.length}
+              />
+            </Space>
+          </Card>
+
+          <Card
+            title={t("settings:adminWatchlistsOversight.feedsCardTitle", "Feeds")}
+            size="small"
+            style={{ marginBottom: 16 }}
+          >
+            <Table
+              dataSource={sources}
+              columns={sourceColumns}
+              rowKey="id"
+              loading={loading}
+              pagination={sources.length > 10 ? { pageSize: 10 } : false}
+              size="small"
+              locale={{
+                emptyText: t(
+                  "settings:adminWatchlistsOversight.feedsEmpty",
+                  "This user has no watchlist feeds."
+                )
+              }}
+            />
+          </Card>
+
+          <Card
+            title={t("settings:adminWatchlistsOversight.itemsCardTitle", "Latest collected items")}
+            size="small"
+            style={{ marginBottom: 16 }}
+          >
+            <Table
+              dataSource={items}
+              columns={itemColumns}
+              rowKey="id"
+              loading={loading}
+              pagination={items.length > 10 ? { pageSize: 10 } : false}
+              size="small"
+              locale={{
+                emptyText: t(
+                  "settings:adminWatchlistsOversight.itemsEmpty",
+                  "No collected items for this user yet."
+                )
+              }}
+            />
+          </Card>
+
+          <Card
+            title={t("settings:adminWatchlistsOversight.runsCardTitle", "Recent runs")}
+            size="small"
+          >
+            <Table
+              dataSource={runs}
+              columns={runColumns}
+              rowKey="id"
+              loading={loading}
+              pagination={false}
+              size="small"
+              locale={{
+                emptyText: t(
+                  "settings:adminWatchlistsOversight.runsEmpty",
+                  "No scrape runs recorded for this user."
+                )
+              }}
+            />
+          </Card>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default WatchlistsOversightPage

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
@@ -76,6 +76,41 @@ describe("BillingDashboardPage", () => {
     expect(mocks.listBillingEvents).not.toHaveBeenCalled()
   })
 
+  it("aggregates the storage summary from the real {total_quotas, items} envelope", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        paths: {
+          "/api/v1/admin/billing/overview": {}
+        }
+      })
+    })
+    mocks.getBillingOverview.mockResolvedValueOnce({
+      mrr: 0,
+      active_subscriptions: 0,
+      canceled_subscriptions: 0,
+      past_due_subscriptions: 0
+    })
+    // Actual StorageQuotaSummaryResponse shape: no flat total_used_mb /
+    // avg_utilization_pct fields exist - the page must aggregate items.
+    mocks.getStorageQuotaSummary.mockResolvedValueOnce({
+      total_quotas: 2,
+      items: [
+        { id: 1, org_id: 1, quota_mb: 1000, used_mb: 250 },
+        { id: 2, org_id: 2, quota_mb: 1000, used_mb: 250 }
+      ]
+    })
+
+    render(<BillingDashboardPage />)
+
+    expect(await screen.findByText("Quota Records")).toBeInTheDocument()
+    expect(screen.getByText("Total Used (MB)")).toBeInTheDocument()
+    // 500 used of 2000 total -> 25.0% (antd splits digits across spans, so
+    // assert on the statistic container's text)
+    const utilizationStat = screen.getByText("Utilization").closest(".ant-statistic")
+    expect(utilizationStat?.textContent).toContain("25.0")
+  })
+
   it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
-import BillingDashboardPage from "../BillingDashboardPage"
+import BillingDashboardPage, { aggregateStorageSummary } from "../BillingDashboardPage"
 
 const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
@@ -109,6 +109,20 @@ describe("BillingDashboardPage", () => {
     // assert on the statistic container's text)
     const utilizationStat = screen.getByText("Utilization").closest(".ant-statistic")
     expect(utilizationStat?.textContent).toContain("25.0")
+  })
+
+  it("flags truncated storage summaries so paginated servers aren't understated silently", () => {
+    const truncated = aggregateStorageSummary({
+      total_quotas: 200,
+      items: [{ quota_mb: 100, used_mb: 50 }],
+      pagination: { has_more: true }
+    })
+    expect(truncated.hasMore).toBe(true)
+    expect(truncated.utilizationPct).toBe(50)
+
+    const complete = aggregateStorageSummary({ total_quotas: 1, items: [], has_more: false })
+    expect(complete.hasMore).toBe(false)
+    expect(complete.utilizationPct).toBe(0)
   })
 
   it("renders forbidden guard feedback through the design-system Alert primitive", async () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsOversightPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsOversightPage.test.tsx
@@ -189,6 +189,60 @@ describe("WatchlistsOversightPage (#2922)", () => {
     expect(watchlistsMock.fetchScrapedItems).not.toHaveBeenCalled()
   })
 
+  it("discards stale responses when the operator switches users quickly", async () => {
+    let resolveSlowSources: (value: unknown) => void = () => {}
+    const slowSources = new Promise((resolve) => {
+      resolveSlowSources = resolve
+    })
+    // First selection (alice) hangs; second (audit-admin) resolves instantly.
+    watchlistsMock.fetchWatchlistSources
+      .mockImplementationOnce(() => slowSources)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 21,
+            name: "Admin Own Feed",
+            url: "https://example.com/admin.xml",
+            source_type: "rss",
+            active: true,
+            tags: [],
+            created_at: "2026-09-06T00:00:00Z",
+            last_scraped_at: null
+          }
+        ],
+        total: 1
+      })
+
+    render(<WatchlistsOversightPage />)
+    const select = await screen.findByLabelText("Select User")
+    fireEvent.change(select, { target: { value: "2" } })
+    fireEvent.change(select, { target: { value: "1" } })
+
+    expect(await screen.findByText("Admin Own Feed")).toBeInTheDocument()
+
+    // Alice's late response must not overwrite audit-admin's data.
+    resolveSlowSources({
+      items: [
+        {
+          id: 11,
+          name: "Battery Tech News",
+          url: "https://example.com/feed.xml",
+          source_type: "rss",
+          active: true,
+          tags: [],
+          created_at: "2026-09-06T00:00:00Z",
+          last_scraped_at: null
+        }
+      ],
+      total: 1
+    })
+    // Give the stale promise chain time to (incorrectly) commit before
+    // asserting it did not.
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(screen.queryByText("Battery Tech News")).not.toBeInTheDocument()
+    expect(screen.getByText("Admin Own Feed")).toBeInTheDocument()
+  })
+
   it("renders private-only sharing mode as a designed state, not an error", async () => {
     watchlistsMock.fetchWatchlistSources.mockRejectedValue(
       new Error("403 watchlists_private_only_mode")

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsOversightPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsOversightPage.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiMock = vi.hoisted(() => ({
+  listAdminUsers: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const watchlistsMock = vi.hoisted(() => ({
+  fetchWatchlistSources: vi.fn(),
+  fetchScrapedItems: vi.fn(),
+  fetchWatchlistRuns: vi.fn(),
+  fetchScrapedItemSmartCounts: vi.fn()
+}))
+
+vi.mock("@/services/watchlists", () => watchlistsMock)
+
+// The page's data-loading callbacks list `t` as a useCallback dependency, so
+// the mock must hand back a STABLE t reference - a fresh closure per render
+// retriggers the load effect forever.
+const stableT = vi.hoisted(
+  () =>
+    (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string },
+      maybeOptions?: Record<string, unknown>
+    ) => {
+      if (typeof fallbackOrOptions === "string") {
+        return fallbackOrOptions
+      }
+      if (
+        fallbackOrOptions &&
+        typeof fallbackOrOptions === "object" &&
+        typeof fallbackOrOptions.defaultValue === "string"
+      ) {
+        return fallbackOrOptions.defaultValue
+      }
+      return (maybeOptions?.defaultValue as string) || key
+    }
+)
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: stableT })
+}))
+
+vi.mock("antd", async () => {
+  const actual = await vi.importActual<typeof import("antd")>("antd")
+  const Select = ({
+    options = [],
+    value,
+    onChange,
+    placeholder,
+    loading
+  }: {
+    options?: Array<{ value: number; label: string }>
+    value?: number | null
+    onChange?: (value: number) => void
+    placeholder?: string
+    loading?: boolean
+  }) => (
+    <select
+      aria-label="Select User"
+      disabled={loading}
+      value={value ?? ""}
+      onChange={(event) => onChange?.(Number(event.currentTarget.value))}
+    >
+      <option value="">{placeholder ?? "Select"}</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+  return { ...actual, Select }
+})
+
+import WatchlistsOversightPage from "../WatchlistsOversightPage"
+
+describe("WatchlistsOversightPage (#2922)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.listAdminUsers.mockResolvedValue({
+      users: [
+        { id: 1, username: "audit-admin", email: "admin@example.local" },
+        { id: 2, username: "alice", email: "alice@example.local" }
+      ]
+    })
+    watchlistsMock.fetchWatchlistSources.mockResolvedValue({
+      items: [
+        {
+          id: 11,
+          name: "Battery Tech News",
+          url: "https://example.com/feed.xml",
+          source_type: "rss",
+          active: true,
+          tags: [],
+          created_at: "2026-09-06T00:00:00Z",
+          last_scraped_at: null
+        }
+      ],
+      total: 1
+    })
+    watchlistsMock.fetchScrapedItems.mockResolvedValue({
+      items: [
+        {
+          id: 101,
+          run_id: 1,
+          job_id: 1,
+          source_id: 11,
+          title: "Recycling supply chain shifts",
+          published_at: "2026-09-05T12:00:00Z",
+          tags: [],
+          status: "ingested",
+          reviewed: false,
+          created_at: "2026-09-05T12:00:00Z"
+        }
+      ],
+      total: 1
+    })
+    watchlistsMock.fetchWatchlistRuns.mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          job_id: 1,
+          status: "success",
+          started_at: "2026-09-05T11:00:00Z",
+          finished_at: "2026-09-05T11:01:00Z"
+        }
+      ],
+      total: 1
+    })
+    watchlistsMock.fetchScrapedItemSmartCounts.mockResolvedValue({
+      all: 1,
+      today: 0,
+      today_unread: 0,
+      unread: 1,
+      reviewed: 0,
+      queued: 0
+    })
+  })
+
+  const selectAlice = async () => {
+    render(<WatchlistsOversightPage />)
+    const select = await screen.findByLabelText("Select User")
+    fireEvent.change(select, { target: { value: "2" } })
+  }
+
+  it("scopes every fleet read to the selected user via target_user_id", async () => {
+    await selectAlice()
+
+    await waitFor(() => {
+      expect(watchlistsMock.fetchWatchlistSources).toHaveBeenCalledWith(
+        expect.objectContaining({ target_user_id: 2 })
+      )
+    })
+    expect(watchlistsMock.fetchScrapedItems).toHaveBeenCalledWith(
+      expect.objectContaining({ target_user_id: 2 })
+    )
+    expect(watchlistsMock.fetchWatchlistRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ target_user_id: 2 })
+    )
+    expect(watchlistsMock.fetchScrapedItemSmartCounts).toHaveBeenCalledWith(
+      expect.objectContaining({ target_user_id: 2 })
+    )
+  })
+
+  it("renders the selected user's feeds, items, and runs", async () => {
+    await selectAlice()
+
+    expect(await screen.findByText("Battery Tech News")).toBeInTheDocument()
+    expect(screen.getByText("Recycling supply chain shifts")).toBeInTheDocument()
+    const summary = screen.getByTestId("oversight-summary")
+    expect(within(summary).getByText("Unread")).toBeInTheDocument()
+  })
+
+  it("does not load any data before a user is selected", async () => {
+    render(<WatchlistsOversightPage />)
+    await screen.findByLabelText("Select User")
+
+    expect(
+      screen.getByText("Select a user above to inspect their watchlist activity.")
+    ).toBeInTheDocument()
+    expect(watchlistsMock.fetchScrapedItems).not.toHaveBeenCalled()
+  })
+
+  it("renders private-only sharing mode as a designed state, not an error", async () => {
+    watchlistsMock.fetchWatchlistSources.mockRejectedValue(
+      new Error("403 watchlists_private_only_mode")
+    )
+    watchlistsMock.fetchScrapedItems.mockRejectedValue(
+      new Error("403 watchlists_private_only_mode")
+    )
+    watchlistsMock.fetchWatchlistRuns.mockRejectedValue(
+      new Error("403 watchlists_private_only_mode")
+    )
+    watchlistsMock.fetchScrapedItemSmartCounts.mockRejectedValue(
+      new Error("403 watchlists_private_only_mode")
+    )
+
+    await selectAlice()
+
+    expect(
+      await screen.findByText("Watchlist sharing is disabled on this server")
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
+++ b/apps/packages/ui/src/components/Option/Admin/admin-modules.ts
@@ -134,8 +134,8 @@ export const ADMIN_MODULES: AdminModule[] = [
   },
   {
     route: "/admin/watchlists-items",
-    label: "Watchlist Items",
-    description: "Review collected watchlist updates, matches, and briefings.",
+    label: "Watchlists Oversight",
+    description: "Inspect any user's watchlist feeds, items, and run health.",
     group: "Workspace"
   },
   {

--- a/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
+++ b/apps/packages/ui/src/routes/option-admin-watchlists-items.tsx
@@ -1,24 +1,20 @@
 import OptionLayout from "~/components/Layouts/Layout"
 import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
-import { ItemsTab } from "@/components/Option/Watchlists/ItemsTab"
+import WatchlistsOversightPage from "@/components/Option/Admin/WatchlistsOversightPage"
 import { AdminRouteShell } from "@/components/Option/Admin/AdminRouteShell"
 
+/**
+ * Fleet oversight route (#2922): this admin surface inspects ANY user's
+ * watchlists via an explicit user selector. It used to embed the personal
+ * ItemsTab triage tool, which silently showed the operator's own (usually
+ * empty) data - the personal tool lives on /watchlists.
+ */
 const OptionAdminWatchlistsItems = () => {
   return (
-    <RouteErrorBoundary routeId="admin-watchlists-items" routeLabel="Watchlists Items">
+    <RouteErrorBoundary routeId="admin-watchlists-items" routeLabel="Watchlists Oversight">
       <OptionLayout>
         <AdminRouteShell path="/admin/watchlists-items">
-          <div style={{ padding: "24px", maxWidth: "100%" }}>
-            <h1 style={{ marginBottom: 4, fontSize: "1.5rem", fontWeight: 600 }}>
-              Watchlists Items
-            </h1>
-            {/* ItemsTab renders the "review collected updates" line itself;
-                this wrapper only adds the guidance it can't know (#2891). */}
-            <p style={{ marginBottom: 16, color: "var(--color-text-secondary, #888)" }}>
-              Create and configure watchlists on the Watchlists page.
-            </p>
-            <ItemsTab />
-          </div>
+          <WatchlistsOversightPage />
         </AdminRouteShell>
       </OptionLayout>
     </RouteErrorBoundary>

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -911,14 +911,15 @@ export const ROUTE_METADATA = [
   }),
   defineRoute({
     path: "/admin/watchlists-items",
-    label: "Admin Watchlist Items",
+    label: "Watchlists Oversight",
     group: "settings",
     surface: "admin_operator",
     availability: webAndExtension,
     smoke: "manual",
     commandPalette: "show",
     requiresBackend: true,
-    rationale: "Admin route for reviewing collected watchlist updates."
+    rationale:
+      "Fleet-oversight route: inspect any user's watchlist feeds, items, and run health (#2922)."
   }),
   defineRoute({
     path: "/admin/watchlists-runs",

--- a/apps/packages/ui/src/services/tldw/domains/admin.ts
+++ b/apps/packages/ui/src/services/tldw/domains/admin.ts
@@ -667,8 +667,12 @@ export const adminMethods = {
     })
   },
 
-  async getStorageQuotaSummary(): Promise<any> {
-    return await bgRequest<any>({ path: "/api/v1/admin/storage-quotas/summary", method: "GET" })
+  async getStorageQuotaSummary(params?: { limit?: number; offset?: number }): Promise<any> {
+    const query = buildQuery(params as Record<string, any>)
+    return await bgRequest<any>({
+      path: `/api/v1/admin/storage-quotas/summary${query}`,
+      method: "GET"
+    })
   },
 }
 

--- a/apps/packages/ui/src/services/watchlists.ts
+++ b/apps/packages/ui/src/services/watchlists.ts
@@ -144,6 +144,8 @@ export const updateWatchlist = async (
 }
 
 export interface FetchSourcesParams {
+  /** Admin-only: inspect another user's data (backend-gated). */
+  target_user_id?: number
   q?: string
   tags?: string[]
   groups?: number[]
@@ -649,6 +651,8 @@ export const addJobFilters = async (
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface FetchRunsParams {
+  /** Admin-only: inspect another user's data (backend-gated). */
+  target_user_id?: number
   q?: string
   watchlist_id?: number
   page?: number
@@ -819,6 +823,8 @@ export const exportRunTalliesCsv = async (runId: number): Promise<string> => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface FetchItemsParams extends ScrapedItemAlertFilterParams {
+  /** Admin-only: inspect another user's data (backend-gated). */
+  target_user_id?: number
   run_id?: number
   job_id?: number
   source_id?: number
@@ -846,6 +852,8 @@ export const fetchScrapedItems = async (
 }
 
 export interface FetchItemSmartCountsParams extends ScrapedItemAlertFilterParams {
+  /** Admin-only: inspect another user's data (backend-gated). */
+  target_user_id?: number
   run_id?: number
   job_id?: number
   source_id?: number

--- a/apps/tldw-frontend/scripts/oversight-live-probe.mjs
+++ b/apps/tldw-frontend/scripts/oversight-live-probe.mjs
@@ -32,6 +32,9 @@ const check = (name, ok, detail) => {
 }
 
 await page.goto(WEB + "/admin/watchlists-items", { waitUntil: "domcontentloaded" })
+// networkidle regularly times out on this SPA (long-lived connections keep the
+// network busy); the timeout is a best-effort settle, not a pass/fail signal -
+// the explicit checks below are what decide the probe's outcome.
 try { await page.waitForLoadState("networkidle", { timeout: 12000 }) } catch {}
 await page.waitForTimeout(2500)
 await page.screenshot({ path: `${OUT}/1-initial.png` })

--- a/apps/tldw-frontend/scripts/oversight-live-probe.mjs
+++ b/apps/tldw-frontend/scripts/oversight-live-probe.mjs
@@ -1,0 +1,61 @@
+/* Live probe for #2922: open /admin/watchlists-items as an admin, pick alice
+ * in the user selector, and assert her seeded feeds render in the read-only
+ * oversight tables. Uses the API-key context (round-4 Part B pattern) since
+ * hard navigation with a fresh JWT races the auth redirect. */
+import { chromium } from "@playwright/test"
+import fs from "node:fs/promises"
+
+const WEB = process.env.WEB_URL || "http://localhost:8080"
+const SERVER = process.env.SERVER_URL || "http://127.0.0.1:8001"
+const ADMIN_KEY = process.env.ADMIN_KEY || ""
+const OUT = process.env.OUT_DIR || "/tmp/oversight-probe"
+if (!ADMIN_KEY) {
+  console.error("Set ADMIN_KEY to an admin user's API key")
+  process.exit(2)
+}
+await fs.mkdir(OUT, { recursive: true })
+
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+await ctx.addInitScript(({ serverUrl, apiKey }) => {
+  localStorage.setItem(
+    "tldwConfig",
+    JSON.stringify({ serverUrl, authMode: "single-user", apiKey })
+  )
+  localStorage.setItem("isMigrated", "true")
+}, { serverUrl: SERVER, apiKey: ADMIN_KEY })
+const page = await ctx.newPage()
+const fails = []
+const check = (name, ok, detail) => {
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}${detail ? ` — ${detail}` : ""}`)
+  if (!ok) fails.push(name)
+}
+
+await page.goto(WEB + "/admin/watchlists-items", { waitUntil: "domcontentloaded" })
+try { await page.waitForLoadState("networkidle", { timeout: 12000 }) } catch {}
+await page.waitForTimeout(2500)
+await page.screenshot({ path: `${OUT}/1-initial.png` })
+const initial = await page.evaluate(() => document.body.innerText)
+check("oversight-title", /Watchlists Oversight/.test(initial))
+check("user-selector", /Select User:/.test(initial))
+check("hint-before-selection", /Select a user above to inspect/.test(initial))
+check("no-personal-triage", !/Mark selected as reviewed|Create a watchlist/.test(initial))
+
+await page.locator(".ant-select").first().click()
+await page.waitForTimeout(600)
+await page.locator(".ant-select-item-option", { hasText: "alice" }).first().click()
+await page.waitForTimeout(3000)
+await page.screenshot({ path: `${OUT}/2-alice.png` })
+const after = await page.evaluate(() => document.body.innerText)
+check("alice-feed-battery", /Battery Tech News/.test(after))
+check("alice-feed-grid", /Grid Storage Policy/.test(after))
+check("summary-stats", /Feeds[\s\S]*Collected items[\s\S]*Unread[\s\S]*Recent runs/.test(after))
+const summaryVisible = await page.locator('[data-testid="oversight-summary"]').count()
+check("summary-testid", summaryVisible === 1, `count=${summaryVisible}`)
+
+await browser.close()
+if (fails.length) {
+  console.log(`RESULT: ${fails.length} failure(s): ${fails.join(", ")}`)
+  process.exit(1)
+}
+console.log("RESULT: all checks passed")

--- a/apps/tldw-frontend/scripts/round3-verify.mjs
+++ b/apps/tldw-frontend/scripts/round3-verify.mjs
@@ -179,22 +179,24 @@ try {
   })
 
   await section("watchlists-items", async () => {
+    // #2922 replaced the embedded personal triage tool with a fleet
+    // oversight page (user selector, read-only tables) - the round-2 M1/I5
+    // findings no longer apply to this route by construction.
     await go("/admin/watchlists-items", 2500)
     const wl = await page.evaluate(() => {
       const text = document.body.innerText
       return {
+        oversight: /Watchlists Oversight/.test(text),
         staleCopy: /from this Watchlist/.test(text),
-        descCount: (text.match(/Review collected updates, alert matches/g) || []).length,
-        toolboxHidden: !/Mark selected as reviewed/.test(text),
-        cta: /Create a watchlist/.test(text)
+        selector: /Select User:/.test(text),
+        personalToolbox: /Mark selected as reviewed/.test(text)
       }
     })
     check(
-      "M1 no-stale-copy",
-      !wl.staleCopy && wl.descCount === 1,
-      `stale: ${wl.staleCopy}, description count: ${wl.descCount}`
+      "M1+I5 fleet-oversight",
+      wl.oversight && wl.selector && !wl.staleCopy && !wl.personalToolbox,
+      `oversight page: ${wl.oversight}, user selector: ${wl.selector}, no personal triage machinery: ${!wl.personalToolbox}`
     )
-    check("I5 toolbox-hidden", wl.toolboxHidden && wl.cta, `toolbox hidden: ${wl.toolboxHidden}, CTA: ${wl.cta}`)
   })
 
   await section("watchlists-runs", async () => {


### PR DESCRIPTION
## Summary
- **#2922 — Watchlists Oversight**: `/admin/watchlists-items` previously embedded the personal ItemsTab, silently showing the operator's own (usually empty) data. It is now a read-only fleet oversight page: an explicit user selector (same pattern as API Keys), summary statistics, and per-user feeds/items/runs tables driven by the watchlists API's existing admin-gated `target_user_id` support. Deployments with `WATCHLIST_SHARING_MODE=private_only` get a designed info state instead of an error wall.
- **#2915 — storage summary fix**: the billing dashboard's storage card read `total_users`/`total_used_mb`/`total_quota_mb`/`avg_utilization_pct`, fields `StorageQuotaSummaryResponse` never had, so it always rendered zeros. It now aggregates `quota_mb`/`used_mb` from the real `{total_quotas, items}` envelope and labels the count as quota records. The billing API itself stays absent by design (open-core extraction, enforced by the boundary checker denylist and smoke tests); #2915 was closed as by-design accordingly.

## Verification
- New `WatchlistsOversightPage.test.tsx` (4 tests: `target_user_id` scoping on all four reads, rendering, no-load-before-selection, private-only-mode designed state)
- New storage-envelope aggregation test in `BillingDashboardPage.test.tsx`
- Full admin suite: 33 files / 189 tests green; route-metadata + visibility + command-palette sync: 19 green; tsc clean on changed files
- Live-verified against a seeded multi-user backend (admin selects alice; her feeds render cross-user, read-only) via the committed `oversight-live-probe.mjs`; `round3-verify.mjs` watchlists section updated to the new page contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns `/admin/watchlists-items` into a read-only fleet oversight page for any user's watchlists, and fixes the billing storage summary so it stops rendering zeros.

**Watchlists Oversight**
- The route previously embedded the personal ItemsTab, which silently showed the operator's own (usually empty) data.
- It now shows an explicit user selector with debounced remote search (same pattern as API Keys), summary statistics, and per-user feeds, items, and runs tables.
- All reads pass the existing admin-gated `target_user_id` param; a request sequence guards against stale responses so fast user switching can't show the wrong user's data.
- Tables show bounded snapshots with a "Showing N of M" note when the server holds more.
- Deployments with `WATCHLIST_SHARING_MODE=private_only` get a designed info state instead of an error wall.

**Storage Summary Fix**
- The billing storage card read fields `StorageQuotaSummaryResponse` never had, so every statistic rendered as zero.
- It now aggregates `quota_mb` and `used_mb` from the real `{total_quotas, items}` envelope, labels the count as quota records, and flags truncation when the 200-record cap hides more rows.

<sup>Written for commit e4cf381af0ea9b5a3926cf5e52f4cb952737bd0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

