### PR TITLE
feat(prompts): customize Writing Agent mode instructions

### DIFF
--- a/Docs/Design/writing-agent-service-prompts.md
+++ b/Docs/Design/writing-agent-service-prompts.md
@@ -1,0 +1,27 @@
+# Writing Agent Service Prompts
+
+Approved bounded slice, tracked by TASK-13209.
+
+Expose literal `system` parts for `writing.agent.quick`,
+`writing.agent.planning`, and `writing.agent.brainstorm` in the existing shared
+Service Prompts editor. Keep current default bytes, model/provider settings,
+temperatures, token limits, and manuscript context formatting/bounds.
+
+Load one owner-scoped snapshot per send before manuscript reads, and pass its
+scope through those reads and model dispatch.
+The three manuscript GET paths join the existing exact scoped-transport
+allowlist and enforce the existing optional expected-user header on the server.
+Unscoped clients remain compatible. Retain the scope lease while
+conversation history is visible so an account/server boundary clears completed
+history too. Cancel and discard stale context, replies, and errors when the
+account/server, project, or mode changes or the component unmounts. Ordinary
+context-fetch failures remain best-effort; scope failures must stop generation.
+
+Reuse packaged-default fallback for older servers that lack Service Prompts or
+these definitions. Authentication, validation, and non-404 failures must not
+silently become defaults. Existing unscoped manuscript service callers retain
+their API behavior. No new storage, endpoints, jobs, or configuration system.
+
+Tests cover mode selection, save/reset, default compatibility, literal braces,
+bounded context, scoped transport, invalid configuration, and asynchronous
+boundaries. Run focused backend/frontend suites, lint, Bandit and code review.

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -23,6 +23,18 @@
     "title": "Workflow prompts",
     "description": "Review and customize the instructions used by supported content workflows.",
     "definitions": {
+      "writingAgentQuick": {
+        "label": "Writing Agent: Quick",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+      },
+      "writingAgentPlanning": {
+        "label": "Writing Agent: Planning",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+      },
+      "writingAgentBrainstorm": {
+        "label": "Writing Agent: Brainstorm",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+      },
       "studyAssistantExplain": {
         "label": "Study explanation",
         "description": "Controls study response guidance. Grounding instructions, study context and provider settings remain fixed."
@@ -101,6 +113,7 @@
       }
     },
     "workflows": {
+      "writingAgent": "Writing Playground AI Agent",
       "studyAssistantFlashcard": "Flashcard Study Assistant",
       "studyAssistantQuiz": "Quiz Study Assistant",
       "mainChatRag": "Main chat RAG",

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -150,6 +150,21 @@ const KNOWN_DEFINITIONS = {
     description:
       "Controls system instructions for synchronous document analysis. Without a saved override, server defaults apply."
   },
+  "writing.agent.quick": {
+    key: "writingAgentQuick",
+    label: "Writing Agent: Quick",
+    description: "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
+  "writing.agent.planning": {
+    key: "writingAgentPlanning",
+    label: "Writing Agent: Planning",
+    description: "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
+  "writing.agent.brainstorm": {
+    key: "writingAgentBrainstorm",
+    label: "Writing Agent: Brainstorm",
+    description: "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
   "study.assistant.explain": {
     key: "studyAssistantExplain",
     label: "Study explanation",
@@ -222,6 +237,7 @@ const KNOWN_DEFINITIONS = {
 
 const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
   "study.assistant.flashcard": { key: "studyAssistantFlashcard", label: "Flashcard Study Assistant" },
+  "writing.agent": { key: "writingAgent", label: "Writing Playground AI Agent" },
   "study.assistant.quiz": { key: "studyAssistantQuiz", label: "Quiz Study Assistant" },
   "chat.main.rag": { key: "mainChatRag", label: "Main chat RAG" },
   "chat.tab.rag": { key: "tabChatRag", label: "Tab chat RAG" },

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -310,6 +310,13 @@ const catalog: ServicePromptCatalogItem[] = [
     ],
     affected_workflows: [{ id: "media.document.insights", label: "Server insights workflow" }]
   },
+  ...["quick", "planning", "brainstorm"].map((mode) => ({
+    id: `writing.agent.${mode}`,
+    label: `Server ${mode}`,
+    description: "Server writing instruction",
+    parts: [{ key: "system", label: "System instructions", mode: "literal" as const, required_variables: [] }],
+    affected_workflows: [{ id: "writing.agent", label: "Server writing workflow" }],
+  })),
   ...["explain", "mnemonic", "followup", "freeform"].map((action) => ({
     id: `study.assistant.${action}`,
     label: `Server ${action} prompt`,
@@ -330,7 +337,9 @@ const detailFor = (
     parts?: Record<string, string>
   } = {}
 ): ServicePromptDetail => {
-  const defaults = definition.id.startsWith("study.assistant.")
+  const defaults = definition.id.startsWith("writing.agent.")
+    ? { system: "Assist the writer." }
+    : definition.id.startsWith("study.assistant.")
     ? { guidance: "Help the learner." }
     : definition.id === "media.document.insights"
     ? { analysis_guidance: "Extract research insights.", presentation_guidance: "Use concise titles." }
@@ -605,7 +614,7 @@ describe("ServicePromptsSettings", () => {
     renderSettings()
 
     expect(await screen.findAllByTestId("service-prompt-list-item"))
-      .toHaveLength(19)
+      .toHaveLength(22)
     expect(await screen.findByRole("heading", { name: "Text translation" }))
       .toBeInTheDocument()
     expect(screen.getByText("Server default")).toBeInTheDocument()
@@ -685,6 +694,35 @@ describe("ServicePromptsSettings", () => {
       { parts: { guidance: "Teach in French {literally}." }, expected_revision: null },
       { signal: expect.any(AbortSignal), requestScope: scopeOne }
     ))
+  })
+
+  it.each(["Quick", "Planning", "Brainstorm"])("edits the Writing Agent %s prompt", async (mode) => {
+    renderSettings()
+    await openPrompt(`Writing Agent: ${mode}`)
+    expect(screen.getByText("Writing Playground AI Agent")).toBeVisible()
+    expect(screen.getByLabelText("System instructions")).toHaveValue("Assist the writer.")
+    fireEvent.change(screen.getByLabelText("System instructions"), { target: { value: "Advise in French {literally}." } })
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }))
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledWith(
+      `writing.agent.${mode.toLowerCase()}`,
+      { parts: { system: "Advise in French {literally}." }, expected_revision: null },
+      { signal: expect.any(AbortSignal), requestScope: scopeOne }
+    ))
+  })
+
+  it.each(["Quick", "Planning", "Brainstorm"])("resets the Writing Agent %s prompt", async (mode) => {
+    const id = `writing.agent.${mode.toLowerCase()}`
+    mocks.get.mockImplementation(async (key: string) => detailFor(catalog.find((item) => item.id === key)!, {
+      source: "user", revision: "saved-writing", parts: { system: "Custom writing style." }
+    }))
+    renderSettings()
+    await openPrompt(`Writing Agent: ${mode}`)
+    fireEvent.click(screen.getByRole("button", { name: "Reset to default" }))
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Reset" }))
+    await waitFor(() => expect(mocks.reset).toHaveBeenCalledWith(
+      id, "saved-writing", { signal: expect.any(AbortSignal), requestScope: scopeOne }
+    ))
+    await waitFor(() => expect(screen.getByLabelText("System instructions")).toHaveValue("Assist the writer."))
   })
 
   it("edits document insights guidance without exposing its JSON contract", async () => {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/AIAgentTab.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/AIAgentTab.tsx
@@ -160,7 +160,7 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
         controller.abort()
       }
       const system = snapshot.definitions[id]?.parts.system
-      if (typeof system !== "string" || !system.trim()) throw new Error("Writing Agent prompt is unavailable.")
+      if (typeof system !== "string" || !system.trim()) throw new Error(`Writing Agent prompt ${id} is unavailable.`)
       const context = await buildContextSnippet(snapshot)
       if (!isCurrent()) return
       const systemPrompt = system + context

--- a/apps/packages/ui/src/components/Option/WritingPlayground/AIAgentTab.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/AIAgentTab.tsx
@@ -1,10 +1,12 @@
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react"
 import { Button, Empty, Input, Segmented, Spin, Typography } from "antd"
 import { Send } from "lucide-react"
 import { useWritingPlaygroundStore } from "@/store/writing-playground"
 import { TldwChatService } from "@/services/tldw/TldwChat"
 import { useStoreChatModelSettings } from "@/store/model"
 import { useStorage } from "@plasmohq/storage/hook"
+import { loadServicePromptSnapshot, subscribeToServicePromptConfigChanges, type ServicePromptSnapshot } from "@/services/service-prompts"
+import { isRequestConfigScopeChangedError } from "@/services/tldw/service-prompt-scope-error"
 import {
   getManuscriptScene,
   listManuscriptCharacters,
@@ -17,12 +19,6 @@ import {
 type AIAgentTabProps = { isOnline: boolean }
 type AgentMode = "quick" | "planning" | "brainstorm"
 type AgentMessage = { role: "user" | "assistant"; content: string }
-
-const SYSTEM_PROMPTS: Record<AgentMode, string> = {
-  quick: "You are a writing assistant. Give brief, direct answers (3 sentences max). The WRITER writes. You ASSIST and ADVISE.",
-  planning: "You are a story planning assistant. Help with plot structure, character arcs, and world-building. Provide structured suggestions. The WRITER writes. You ASSIST and ADVISE.",
-  brainstorm: "You are a creative brainstorming partner. Generate ideas freely, suggest alternatives, explore possibilities. The WRITER writes. You ASSIST and ADVISE.",
-}
 
 const chatService = new TldwChatService()
 
@@ -37,6 +33,44 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const epochRef = useRef(0)
+  const controllerRef = useRef<AbortController | null>(null)
+  const historyScopeRef = useRef<string | null>(null)
+  const releaseHistoryRef = useRef<(() => void) | null>(null)
+
+  const cancelWork = useCallback(() => {
+    epochRef.current += 1
+    controllerRef.current?.abort()
+    controllerRef.current = null
+    releaseHistoryRef.current?.()
+    releaseHistoryRef.current = null
+    historyScopeRef.current = null
+  }, [])
+
+  const resetConversation = useCallback(() => {
+    cancelWork()
+    setMessages([])
+    setInput("")
+    setLoading(false)
+  }, [cancelWork])
+
+  useLayoutEffect(() => {
+    resetConversation()
+    return cancelWork
+  }, [activeProjectId, mode, resetConversation, cancelWork])
+
+  useEffect(() => {
+    // A failed first lookup has no lease to clear its error on account changes.
+    const clearUnboundState = () => {
+      if (!historyScopeRef.current && !controllerRef.current) resetConversation()
+    }
+    const unsubscribe = subscribeToServicePromptConfigChanges(clearUnboundState)
+    window.addEventListener("tldw:auth-credentials-changed", clearUnboundState)
+    return () => {
+      unsubscribe()
+      window.removeEventListener("tldw:auth-credentials-changed", clearUnboundState)
+    }
+  }, [resetConversation])
 
   useEffect(() => {
     if (typeof messagesEndRef.current?.scrollIntoView === "function") {
@@ -44,11 +78,13 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
     }
   }, [messages])
 
-  const buildContextSnippet = useCallback(async (): Promise<string> => {
+  const buildContextSnippet = useCallback(async (snapshot: ServicePromptSnapshot): Promise<string> => {
     const parts: string[] = []
+    const options = { signal: snapshot.scopeSignal, requestScope: snapshot.requestScope }
     try {
       if (activeNodeId) {
-        const scene: ManuscriptSceneResponse = await getManuscriptScene(activeNodeId)
+        const scene: ManuscriptSceneResponse = await getManuscriptScene(activeNodeId, options)
+        snapshot.scopeSignal.throwIfAborted()
         const sceneContent = scene.content_plain || ""
         if (sceneContent) {
           const snippet = sceneContent.length > 2000
@@ -57,11 +93,13 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
           parts.push(`[Current Scene: ${scene.title || "Untitled"}]\n${snippet}`)
         }
       }
+      snapshot.scopeSignal.throwIfAborted()
       if (activeProjectId) {
         const [charsResp, worldResp] = await Promise.all([
-          listManuscriptCharacters(activeProjectId),
-          listManuscriptWorldInfo(activeProjectId),
+          listManuscriptCharacters(activeProjectId, undefined, options),
+          listManuscriptWorldInfo(activeProjectId, undefined, options),
         ])
+        snapshot.scopeSignal.throwIfAborted()
         const chars = charsResp.characters || []
         if (chars.length > 0) {
           const charList = chars.slice(0, 10).map((c: ManuscriptCharacter) =>
@@ -77,27 +115,58 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
           parts.push(`[World Info]\n${worldList}`)
         }
       }
-    } catch {
-      // Context is best-effort; ignore errors
+    } catch (error) {
+      snapshot.scopeSignal.throwIfAborted()
+      if (isRequestConfigScopeChangedError(error)) throw error
+      // Ordinary context failures remain best-effort; scope failures never do.
     }
     return parts.length > 0 ? "\n\n--- Manuscript Context ---\n" + parts.join("\n\n") : ""
   }, [activeProjectId, activeNodeId])
 
   const handleSend = async () => {
     const text = input.trim()
-    if (!text || loading) return
+    if (!text || loading || controllerRef.current) return
+    const controller = new AbortController()
+    controllerRef.current = controller
+    const epoch = epochRef.current
+    const isCurrent = () => epoch === epochRef.current && !controller.signal.aborted
+    const history = historyScopeRef.current ? messages : []
 
     const userMsg: AgentMessage = { role: "user", content: text }
-    setMessages((prev) => [...prev, userMsg])
+    setMessages([...history, userMsg])
     setInput("")
     setLoading(true)
 
     try {
-      const context = await buildContextSnippet()
-      const systemPrompt = SYSTEM_PROMPTS[mode] + context
+      const id = `writing.agent.${mode}` as const
+      const snapshot = await loadServicePromptSnapshot([id], { signal: controller.signal })
+      if (!isCurrent() || snapshot.scopeInvalidatedSignal.aborted || snapshot.scopeSignal.aborted) {
+        snapshot.release()
+        if (isCurrent()) resetConversation()
+        return
+      }
+      if (historyScopeRef.current && historyScopeRef.current !== snapshot.scopeKey) {
+        snapshot.release()
+        resetConversation()
+        return
+      }
+      releaseHistoryRef.current?.()
+      historyScopeRef.current = snapshot.scopeKey
+      snapshot.scopeInvalidatedSignal.addEventListener("abort", resetConversation, { once: true })
+      // Keep the lease while history is visible, including between requests.
+      releaseHistoryRef.current = () => {
+        snapshot.scopeInvalidatedSignal.removeEventListener("abort", resetConversation)
+        snapshot.release()
+        controller.abort()
+      }
+      const system = snapshot.definitions[id]?.parts.system
+      if (typeof system !== "string" || !system.trim()) throw new Error("Writing Agent prompt is unavailable.")
+      const context = await buildContextSnippet(snapshot)
+      if (!isCurrent()) return
+      const systemPrompt = system + context
 
       const chatMessages = [
-        ...messages.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
+        ...history.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
         { role: "user" as const, content: text },
       ]
 
@@ -109,21 +178,31 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
           apiProvider: apiProvider || undefined,
           temperature: mode === "brainstorm" ? 0.9 : mode === "quick" ? 0.3 : 0.6,
           maxTokens: mode === "quick" ? 256 : 1024,
+          signal: snapshot.scopeSignal,
+          requestScope: snapshot.requestScope,
         }
       )
 
-      setMessages((prev) => [...prev, { role: "assistant", content: response }])
+      if (isCurrent()) setMessages((prev) => [...prev, { role: "assistant", content: response }])
     } catch (err: unknown) {
+      if (!isCurrent()) return
+      if (isRequestConfigScopeChangedError(err)) {
+        resetConversation()
+        return
+      }
       const message =
         err instanceof Error && err.message.trim().length > 0
           ? err.message
           : "Failed to get response"
       setMessages((prev) => [
-        ...prev,
+        ...(historyScopeRef.current ? prev : []),
         { role: "assistant", content: `Error: ${message}` },
       ])
     } finally {
-      setLoading(false)
+      if (isCurrent()) {
+        controllerRef.current = null
+        setLoading(false)
+      }
     }
   }
 
@@ -146,7 +225,6 @@ export function AIAgentTab({ isOnline }: AIAgentTabProps) {
         value={mode}
         onChange={(v) => {
           setMode(v as AgentMode)
-          setMessages([])
         }}
         options={[
           { value: "quick", label: "Quick" },

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/AIAgentTab.service-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/AIAgentTab.service-prompts.test.tsx
@@ -1,0 +1,268 @@
+import React from "react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  state: { activeProjectId: "project-a", activeNodeId: "scene-a" },
+  load: vi.fn(),
+  send: vi.fn(),
+  request: vi.fn(),
+  configListeners: new Set<() => void>(),
+}))
+vi.mock("@/store/writing-playground", () => ({
+  useWritingPlaygroundStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+}))
+vi.mock("@/store/model", () => ({
+  useStoreChatModelSettings: (selector: (state: { apiProvider: string }) => unknown) => selector({ apiProvider: "openai" }),
+}))
+vi.mock("@plasmohq/storage/hook", () => ({ useStorage: () => ["test-model"] }))
+vi.mock("@/services/tldw/TldwChat", () => ({
+  TldwChatService: class { sendMessage = mocks.send },
+}))
+vi.mock("@/services/background-proxy", () => ({ bgRequest: (...args: unknown[]) => mocks.request(...args) }))
+vi.mock("@/services/service-prompts", async () => ({
+  ...await vi.importActual<typeof import("@/services/service-prompts")>("@/services/service-prompts"),
+  loadServicePromptSnapshot: (...args: unknown[]) => mocks.load(...args),
+  subscribeToServicePromptConfigChanges: (listener: () => void) => {
+    mocks.configListeners.add(listener)
+    return () => mocks.configListeners.delete(listener)
+  },
+}))
+
+import { AIAgentTab } from "../AIAgentTab"
+import type { ServicePromptSnapshot } from "@/services/service-prompts"
+
+const requestScope = {
+  config: { serverUrl: "https://server-a.test", authMode: "multi-user" as const },
+  userId: "owner-a",
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+
+let scope: AbortController
+let snapshots: ServicePromptSnapshot[]
+
+function send(text = "Help my story") {
+  const input = screen.getByPlaceholderText("Type a message...")
+  fireEvent.change(input, { target: { value: text } })
+  fireEvent.keyDown(input, { key: "Enter" })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.state = { activeProjectId: "project-a", activeNodeId: "scene-a" }
+  scope = new AbortController()
+  snapshots = []
+  mocks.load.mockImplementation(async ([id]: string[], options: { signal?: AbortSignal } = {}) => {
+    const snapshot: ServicePromptSnapshot = {
+      scopeKey: "scope-a", requestScope, capability: "supported",
+      definitions: { [id]: {
+        definition: { id, parts: [{ key: "system", mode: "literal", required_variables: [] }] },
+        parts: { system: `Custom ${id} {literal}` }, source: "user", revision: "revision-a",
+      } },
+      scopeSignal: options.signal ?? scope.signal,
+      scopeInvalidatedSignal: scope.signal,
+      release: vi.fn(),
+    }
+    snapshots.push(snapshot)
+    return snapshot
+  })
+  mocks.request.mockImplementation(async ({ path }: { path: string }) => {
+    if (path.includes("/scenes/")) return { title: "Opening", content_plain: "Scene text" }
+    if (path.endsWith("/characters")) return { characters: [{ name: "Ari", role: "hero" }] }
+    if (path.endsWith("/world-info")) return { items: [{ name: "Harbor", kind: "location" }] }
+    throw new Error(`Unexpected request ${path}`)
+  })
+  mocks.send.mockResolvedValue("A useful answer")
+})
+afterEach(cleanup)
+
+describe("Writing Agent service prompts", () => {
+  it.each([
+    ["Quick", "quick", 0.3, 256],
+    ["Planning", "planning", 0.6, 1024],
+    ["Brainstorm", "brainstorm", 0.9, 1024],
+  ] as const)("uses the captured %s instruction with unchanged context and provider settings", async (label, mode, temperature, maxTokens) => {
+    render(<AIAgentTab isOnline />)
+    fireEvent.click(screen.getByText(label))
+    send()
+    await screen.findByText("A useful answer")
+    expect(mocks.load).toHaveBeenCalledWith([`writing.agent.${mode}`], { signal: expect.any(AbortSignal) })
+    expect(mocks.send).toHaveBeenCalledWith([{ role: "user", content: "Help my story" }], expect.objectContaining({
+      systemPrompt: `Custom writing.agent.${mode} {literal}\n\n--- Manuscript Context ---\n[Current Scene: Opening]\nScene text\n\n[Characters]\n- Ari (hero)\n\n[World Info]\n- Harbor (location)`,
+      model: "test-model", apiProvider: "openai", temperature, maxTokens,
+      requestScope, signal: expect.any(AbortSignal),
+    }))
+    for (const [request] of mocks.request.mock.calls) {
+      expect(request).toMatchObject({
+        servicePromptConfig: { ...requestScope.config, expectedUserId: "owner-a" },
+        headers: { "X-TLDW-Expected-User-ID": "owner-a" },
+        abortSignal: expect.any(AbortSignal),
+      })
+    }
+  })
+
+  it("retains bounded manuscript snippets", async () => {
+    mocks.request.mockImplementation(async ({ path }: { path: string }) => path.includes("/scenes/")
+      ? { title: "Long scene", content_plain: "x".repeat(2001) }
+      : path.endsWith("/characters")
+        ? { characters: Array.from({ length: 11 }, (_, i) => ({ name: `Person${i}`, role: "hero" })) }
+        : { items: Array.from({ length: 11 }, (_, i) => ({ name: `Place${i}`, kind: "location" })) })
+    render(<AIAgentTab isOnline />)
+    send()
+    await screen.findByText("A useful answer")
+    const prompt = mocks.send.mock.calls[0][1].systemPrompt
+    expect(prompt).toContain("x".repeat(2000) + "...")
+    expect(prompt).not.toContain("Person10")
+    expect(prompt).not.toContain("Place10")
+  })
+
+  it.each(["mode", "project", "scope"] as const)("discards pending replies after a %s change and clears old history", async (boundary) => {
+    const response = deferred<string>()
+    mocks.send.mockReturnValue(response.promise)
+    const view = render(<AIAgentTab isOnline />)
+    send("Old owner question")
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(1))
+    if (boundary === "mode") fireEvent.click(screen.getByText("Planning"))
+    if (boundary === "project") {
+      mocks.state = { activeProjectId: "project-b", activeNodeId: "scene-b" }
+      view.rerender(<AIAgentTab isOnline />)
+    }
+    if (boundary === "scope") act(() => scope.abort())
+    await act(async () => response.resolve("Old owner answer"))
+    expect(screen.queryByText("Old owner answer")).not.toBeInTheDocument()
+    expect(screen.queryByText("Old owner question")).not.toBeInTheDocument()
+  })
+
+  it("does not dispatch generation after scope changes during context loading", async () => {
+    const scene = deferred<unknown>()
+    mocks.request.mockReturnValueOnce(scene.promise)
+    render(<AIAgentTab isOnline />)
+    send()
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledTimes(1))
+    act(() => scope.abort())
+    await act(async () => scene.resolve({ title: "Old", content_plain: "Old private scene" }))
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.request).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText("Help my story")).not.toBeInTheDocument()
+  })
+
+  it("invalidates completed history when the account changes between requests", async () => {
+    render(<AIAgentTab isOnline />)
+    send()
+    await screen.findByText("A useful answer")
+    act(() => scope.abort())
+    expect(screen.queryByText("A useful answer")).not.toBeInTheDocument()
+    expect(screen.queryByText("Help my story")).not.toBeInTheDocument()
+  })
+
+  it("preserves ordinary context-error fallback but stops invalid prompt loads", async () => {
+    mocks.request.mockRejectedValue(new Error("Scene unavailable"))
+    const view = render(<AIAgentTab isOnline />)
+    send()
+    await screen.findByText("A useful answer")
+    expect(mocks.send.mock.calls[0][1].systemPrompt).toBe("Custom writing.agent.quick {literal}")
+    view.unmount()
+    mocks.send.mockClear()
+    mocks.request.mockClear()
+    mocks.load.mockRejectedValue(new Error("Invalid saved prompt"))
+    render(<AIAgentTab isOnline />)
+    send()
+    await screen.findByText("Error: Invalid saved prompt")
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it("does not publish stale errors or let an old request clear a newer loading state", async () => {
+    const old = deferred<string>()
+    const next = deferred<string>()
+    mocks.send.mockReturnValueOnce(old.promise).mockReturnValueOnce(next.promise)
+    render(<AIAgentTab isOnline />)
+    send()
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByText("Planning"))
+    send("New question")
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(2))
+    await act(async () => old.reject(new Error("Old private error")))
+    expect(screen.queryByText("Error: Old private error")).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText("Type a message...")).toBeDisabled()
+    await act(async () => next.resolve("New answer"))
+    expect(screen.getByText("New answer")).toBeVisible()
+  })
+
+  it("releases its retained scope and aborts pending work on unmount", async () => {
+    const response = deferred<string>()
+    mocks.send.mockReturnValue(response.promise)
+    const view = render(<AIAgentTab isOnline />)
+    send()
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(1))
+    view.unmount()
+    expect(mocks.send.mock.calls[0][1].signal.aborted).toBe(true)
+    expect(snapshots[0].release).toHaveBeenCalled()
+    await act(async () => response.resolve("Too late"))
+  })
+
+  it("does not carry a question from an unverified failed prompt load into another account", async () => {
+    mocks.load.mockRejectedValueOnce(new Error("Prompt server unavailable"))
+    render(<AIAgentTab isOnline />)
+    send("Private question before identity was resolved")
+    await screen.findByText("Error: Prompt server unavailable")
+    send("New account question")
+    await screen.findByText("A useful answer")
+    expect(mocks.send.mock.calls[0][0]).toEqual([{ role: "user", content: "New account question" }])
+  })
+
+  it.each(["config", "credentials"])("clears an unbound lookup error on a %s boundary", async (boundary) => {
+    mocks.load.mockRejectedValueOnce(new Error("Old account lookup error"))
+    render(<AIAgentTab isOnline />)
+    send()
+    await screen.findByText("Error: Old account lookup error")
+    act(() => {
+      if (boundary === "config") mocks.configListeners.forEach((listener) => listener())
+      else window.dispatchEvent(new Event("tldw:auth-credentials-changed"))
+    })
+    expect(screen.queryByText("Error: Old account lookup error")).not.toBeInTheDocument()
+  })
+
+  it("releases a late prompt snapshot without requesting context after a project change", async () => {
+    const snapshot = await mocks.load(["writing.agent.quick"])
+    const pending = deferred<ServicePromptSnapshot>()
+    mocks.load.mockReturnValueOnce(pending.promise)
+    const view = render(<AIAgentTab isOnline />)
+    send()
+    mocks.state = { activeProjectId: "project-b", activeNodeId: "scene-b" }
+    view.rerender(<AIAgentTab isOnline />)
+    await act(async () => pending.resolve(snapshot))
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(snapshot.release).toHaveBeenCalled()
+  })
+
+  it("captures edits only for the next send while retaining same-scope history", async () => {
+    const scene = deferred<unknown>()
+    mocks.request.mockReturnValueOnce(scene.promise)
+    render(<AIAgentTab isOnline />)
+    send("First question")
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledTimes(1))
+    const next = await mocks.load(["writing.agent.quick"])
+    mocks.load.mockResolvedValueOnce({ ...next, definitions: {
+      ...next.definitions,
+      "writing.agent.quick": { ...next.definitions["writing.agent.quick"]!, parts: { system: "Edited instructions" } },
+    } })
+    await act(async () => scene.resolve({ title: "Opening", content_plain: "Scene text" }))
+    await screen.findByText("A useful answer")
+    expect(mocks.send.mock.calls[0][1].systemPrompt).toMatch(/^Custom writing.agent.quick/)
+    send("Second question")
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(2))
+    expect(mocks.send.mock.calls[1][1].systemPrompt).toMatch(/^Edited instructions/)
+    expect(mocks.send.mock.calls[1][0]).toEqual([
+      { role: "user", content: "First question" },
+      { role: "assistant", content: "A useful answer" },
+      { role: "user", content: "Second question" },
+    ])
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/AIAgentTab.service-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/AIAgentTab.service-prompts.test.tsx
@@ -74,8 +74,8 @@ beforeEach(() => {
   })
   mocks.request.mockImplementation(async ({ path }: { path: string }) => {
     if (path.includes("/scenes/")) return { title: "Opening", content_plain: "Scene text" }
-    if (path.endsWith("/characters")) return { characters: [{ name: "Ari", role: "hero" }] }
-    if (path.endsWith("/world-info")) return { items: [{ name: "Harbor", kind: "location" }] }
+    if (path.endsWith("/characters")) return [{ name: "Ari", role: "hero" }]
+    if (path.endsWith("/world-info")) return [{ name: "Harbor", kind: "location" }]
     throw new Error(`Unexpected request ${path}`)
   })
   mocks.send.mockResolvedValue("A useful answer")
@@ -83,6 +83,19 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe("Writing Agent service prompts", () => {
+  it.each(["Quick", "Planning", "Brainstorm"])("identifies the invalid %s prompt without dispatching", async (label) => {
+    const id = `writing.agent.${label.toLowerCase()}`
+    const snapshot = await mocks.load([id])
+    snapshot.definitions[id].parts.system = " "
+    mocks.load.mockResolvedValueOnce(snapshot)
+    render(<AIAgentTab isOnline />)
+    fireEvent.click(screen.getByText(label))
+    send()
+    await screen.findByText(new RegExp(`Error:.*${id}`))
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
   it.each([
     ["Quick", "quick", 0.3, 256],
     ["Planning", "planning", 0.6, 1024],
@@ -111,8 +124,8 @@ describe("Writing Agent service prompts", () => {
     mocks.request.mockImplementation(async ({ path }: { path: string }) => path.includes("/scenes/")
       ? { title: "Long scene", content_plain: "x".repeat(2001) }
       : path.endsWith("/characters")
-        ? { characters: Array.from({ length: 11 }, (_, i) => ({ name: `Person${i}`, role: "hero" })) }
-        : { items: Array.from({ length: 11 }, (_, i) => ({ name: `Place${i}`, kind: "location" })) })
+        ? Array.from({ length: 11 }, (_, i) => ({ name: `Person${i}`, role: "hero" }))
+        : Array.from({ length: 11 }, (_, i) => ({ name: `Place${i}`, kind: "location" })))
     render(<AIAgentTab isOnline />)
     send()
     await screen.findByText("A useful answer")

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -6352,5 +6352,26 @@
   },
   "chatMacrosNav": {
     "message": "Chat Macros"
+  },
+  "servicePrompts_definitions_writingAgentQuick_label": {
+    "message": "Writing Agent: Quick"
+  },
+  "servicePrompts_definitions_writingAgentQuick_description": {
+    "message": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
+  "servicePrompts_definitions_writingAgentPlanning_label": {
+    "message": "Writing Agent: Planning"
+  },
+  "servicePrompts_definitions_writingAgentPlanning_description": {
+    "message": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
+  "servicePrompts_definitions_writingAgentBrainstorm_label": {
+    "message": "Writing Agent: Brainstorm"
+  },
+  "servicePrompts_definitions_writingAgentBrainstorm_description": {
+    "message": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
+  },
+  "servicePrompts_workflows_writingAgent": {
+    "message": "Writing Playground AI Agent"
   }
 }

--- a/apps/packages/ui/src/services/__tests__/background-proxy.web-refresh.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.web-refresh.test.ts
@@ -61,6 +61,30 @@ const jwtForUser = (userId: string | number): string =>
   `header.${btoa(JSON.stringify({ sub: String(userId) }))}.signature`
 
 describe("background proxy web token refresh", () => {
+  it.each([
+    "/api/v1/writing/manuscripts/scenes/scene-a",
+    "/api/v1/writing/manuscripts/projects/project-a/characters?role=protagonist",
+    "/api/v1/writing/manuscripts/projects/project-a/world-info?kind=location",
+  ])("dispatches the scoped manuscript read %s through the real transport", async (path) => {
+    mocks.store.tldwConfig = {
+      serverUrl: "https://api.example.com", authMode: "multi-user", accessToken: jwtForUser(42)
+    }
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(JSON.stringify({ context: "owner-42" }), {
+      status: 200, headers: { "content-type": "application/json" }
+    }))
+    vi.stubGlobal("fetch", fetchSpy)
+    const { bgRequest } = await importProxy()
+    await expect(bgRequest({
+      path: path as `/api/v1/writing/manuscripts/scenes/${string}`,
+      method: "GET",
+      headers: { "X-TLDW-Expected-User-ID": "42" },
+      servicePromptConfig: { serverUrl: "https://api.example.com", authMode: "multi-user", expectedUserId: 42 }
+    })).resolves.toEqual({ context: "owner-42" })
+    expect(fetchSpy.mock.calls[0][0]).toBe(`https://api.example.com${path}`)
+    expect(new Headers(fetchSpy.mock.calls[0][1].headers).get("X-TLDW-Expected-User-ID")).toBe("42")
+    expect(new Headers(fetchSpy.mock.calls[0][1].headers).get("Authorization")).toBe(`Bearer ${jwtForUser(42)}`)
+  })
+
   beforeEach(() => {
     vi.resetModules()
     vi.useRealTimers()

--- a/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
@@ -99,7 +99,10 @@ const definition = (
   affected_workflows: []
 })
 
-const definitions: Record<KnownServicePromptId, ServicePromptCatalogItem> = {
+const definitions: Partial<Record<KnownServicePromptId, ServicePromptCatalogItem>> = {
+  "writing.agent.quick": definition("writing.agent.quick", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
+  "writing.agent.planning": definition("writing.agent.planning", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
+  "writing.agent.brainstorm": definition("writing.agent.brainstorm", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
   "chat.rag.answer": definition("chat.rag.answer", [
     {
       key: "template",
@@ -177,6 +180,9 @@ const definitions: Record<KnownServicePromptId, ServicePromptCatalogItem> = {
 describe("Service Prompt validation and rendering", () => {
   it("keeps old-server defaults byte-equivalent to the shared fixture", () => {
     expect(LEGACY_SERVICE_PROMPT_DEFAULTS).toEqual({
+      "writing.agent.quick": fixture.defaults["writing.agent.quick"],
+      "writing.agent.planning": fixture.defaults["writing.agent.planning"],
+      "writing.agent.brainstorm": fixture.defaults["writing.agent.brainstorm"],
       "chat.rag.answer": fixture.defaults["chat.rag.answer"],
       "chat.rag.question_rewrite": fixture.defaults["chat.rag.question_rewrite"],
       "chat.web_search.answer": fixture.defaults["chat.web_search.answer"],
@@ -379,6 +385,24 @@ const renderDefinitionFor = (id: KnownServicePromptId) => ({
 })
 
 describe("Service Prompt migration and runtime snapshots", () => {
+  it.each(["quick", "planning", "brainstorm"] as const)("loads %s writing instructions with compatible defaults and no silent error fallback", async (mode) => {
+    const id = `writing.agent.${mode}` as const
+    for (const fallback of ["catalog-404", "omitted", "detail-404", "saved"]) {
+      mocks.listServicePrompts.mockResolvedValue(fallback === "omitted" ? [] : catalog)
+      if (fallback === "catalog-404") mocks.listServicePrompts.mockRejectedValueOnce(new ServicePromptApiError("Not found", { status: 404 }))
+      mocks.getServicePrompt.mockResolvedValue(detailFor(id, { effective_parts: { system: "Custom {literal}" }, source: "user" }))
+      if (fallback === "detail-404") mocks.getServicePrompt.mockRejectedValueOnce(new ServicePromptApiError("Not found", { status: 404 }))
+      const snapshot = await loadServicePromptSnapshot([id])
+      expect(snapshot.definitions[id]?.parts).toEqual(fallback === "saved" ? { system: "Custom {literal}" } : fixture.defaults[id])
+      snapshot.release()
+    }
+    for (const status of [401, 403, 409, 422, 500]) {
+      const error = new ServicePromptApiError("Failed", { status })
+      mocks.getServicePrompt.mockRejectedValueOnce(error)
+      await expect(loadServicePromptSnapshot([id])).rejects.toBe(error)
+    }
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.localGet.mockResolvedValue(undefined)

--- a/apps/packages/ui/src/services/__tests__/writing-playground.snapshot.test.ts
+++ b/apps/packages/ui/src/services/__tests__/writing-playground.snapshot.test.ts
@@ -13,12 +13,27 @@ vi.mock("@/services/background-proxy", () => ({
 import {
   exportWritingSnapshot,
   getWritingDefaults,
-  importWritingSnapshot
+  importWritingSnapshot,
+  listManuscriptCharacters,
+  listManuscriptWorldInfo
 } from "@/services/writing-playground"
 
 describe("writing-playground snapshot service wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it.each([
+    [listManuscriptCharacters, "characters", { id: "character-1", project_id: "project-1", name: "Ari", role: "hero" }],
+    [listManuscriptWorldInfo, "items", { id: "world-1", project_id: "project-1", name: "Harbor", kind: "location" }]
+  ] as const)("normalizes manuscript list payloads for %s", async (list, key, item) => {
+    mocks.bgRequest.mockResolvedValueOnce([item])
+    expect(await list("project-1")).toEqual({ [key]: [item], total: 1 })
+    mocks.bgRequest.mockResolvedValueOnce([])
+    expect(await list("project-1")).toEqual({ [key]: [], total: 0 })
+    const wrapped = { [key]: [item], total: 4 }
+    mocks.bgRequest.mockResolvedValueOnce(wrapped)
+    expect(await list("project-1")).toEqual(wrapped)
   })
 
   it("calls snapshot export endpoint", async () => {

--- a/apps/packages/ui/src/services/service-prompts.ts
+++ b/apps/packages/ui/src/services/service-prompts.ts
@@ -290,6 +290,18 @@ const freezeRenderDefinition = (
 })
 
 const LEGACY_RENDER_DEFINITIONS = Object.freeze({
+  "writing.agent.quick": freezeRenderDefinition({
+    id: "writing.agent.quick",
+    parts: [{ key: "system", mode: "literal", required_variables: [] }]
+  }),
+  "writing.agent.planning": freezeRenderDefinition({
+    id: "writing.agent.planning",
+    parts: [{ key: "system", mode: "literal", required_variables: [] }]
+  }),
+  "writing.agent.brainstorm": freezeRenderDefinition({
+    id: "writing.agent.brainstorm",
+    parts: [{ key: "system", mode: "literal", required_variables: [] }]
+  }),
   "chat.rag.answer": freezeRenderDefinition({
     id: "chat.rag.answer",
     parts: [{
@@ -337,6 +349,24 @@ const LEGACY_RENDER_DEFINITIONS = Object.freeze({
       }
     ]
   })
+})
+
+// These features shipped before their Service Prompts definitions.
+const PACKAGED_FALLBACK_IDS = [
+  "image.prompt.refinement",
+  "writing.agent.quick",
+  "writing.agent.planning",
+  "writing.agent.brainstorm"
+] as const
+type PackagedFallbackId = typeof PACKAGED_FALLBACK_IDS[number]
+const hasPackagedFallback = (id: KnownServicePromptId): id is PackagedFallbackId =>
+  PACKAGED_FALLBACK_IDS.some((candidate) => candidate === id)
+
+const packagedFallback = (id: PackagedFallbackId): SnapshotDefinition => ({
+  definition: LEGACY_RENDER_DEFINITIONS[id],
+  parts: { ...LEGACY_SERVICE_PROMPT_DEFAULTS[id] },
+  source: "packaged",
+  revision: null
 })
 
 const legacyLocalStorage = createSafeStorage({ area: "local" })
@@ -706,20 +736,8 @@ const legacySnapshot = async (
     }
   }
 
-  if (requested.has("image.prompt.refinement")) {
-    definitions["image.prompt.refinement"] = {
-      definition: LEGACY_RENDER_DEFINITIONS["image.prompt.refinement"],
-      parts: {
-        system_semantics:
-          LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
-            .system_semantics,
-        rewrite_semantics:
-          LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
-            .rewrite_semantics
-      },
-      source: "packaged",
-      revision: null
-    }
+  for (const id of PACKAGED_FALLBACK_IDS) {
+    if (requested.has(id)) definitions[id] = packagedFallback(id)
   }
 
   throwIfAborted(lease.signal)
@@ -776,11 +794,9 @@ export const loadServicePromptSnapshot = async (
     }
 
     const advertisedIds = new Set(catalog.map((definition) => definition.id))
-    const catalogOmitsImageRefinement =
-      requested.includes("image.prompt.refinement") &&
-      !advertisedIds.has("image.prompt.refinement")
+    const fallbackIds = new Set(requested.filter((id) => hasPackagedFallback(id) && !advertisedIds.has(id)))
     const requestedFromServer = requested.filter(
-      (id) => id !== "image.prompt.refinement" || !catalogOmitsImageRefinement
+      (id) => !fallbackIds.has(id)
     )
     const candidates = requestedFromServer.length > 0
       ? await readLegacyServicePromptCandidates({ signal: lease.signal })
@@ -807,18 +823,17 @@ export const loadServicePromptSnapshot = async (
         })
       } catch (error) {
         if (
-          id === "image.prompt.refinement" &&
+          hasPackagedFallback(id) &&
           error instanceof ServicePromptApiError &&
           error.status === 404
         ) {
+          fallbackIds.add(id)
           return null
         }
         throw error
       }
     }))
     throwIfAborted(lease.signal)
-    const usePackagedImageRefinement =
-      catalogOmitsImageRefinement || details.some((detail) => detail === null)
     const definitions: Partial<Record<KnownServicePromptId, SnapshotDefinition>> = {}
     for (const detail of details) {
       if (!detail) continue
@@ -829,20 +844,8 @@ export const loadServicePromptSnapshot = async (
         revision: detail.revision
       }
     }
-    if (usePackagedImageRefinement) {
-      definitions["image.prompt.refinement"] = {
-        definition: LEGACY_RENDER_DEFINITIONS["image.prompt.refinement"],
-        parts: {
-          system_semantics:
-            LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
-              .system_semantics,
-          rewrite_semantics:
-            LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
-              .rewrite_semantics
-        },
-        source: "packaged",
-        revision: null
-      }
+    for (const id of fallbackIds) {
+      if (hasPackagedFallback(id)) definitions[id] = packagedFallback(id)
     }
     return freezeSnapshot(scope, "supported", definitions, lease)
   } catch (error) {

--- a/apps/packages/ui/src/services/tldw-server.ts
+++ b/apps/packages/ui/src/services/tldw-server.ts
@@ -514,6 +514,9 @@ Shakespeare Analyse Literarische
 
 Response:`
   }),
+  "writing.agent.quick": Object.freeze({ system: "You are a writing assistant. Give brief, direct answers (3 sentences max). The WRITER writes. You ASSIST and ADVISE." }),
+  "writing.agent.planning": Object.freeze({ system: "You are a story planning assistant. Help with plot structure, character arcs, and world-building. Provide structured suggestions. The WRITER writes. You ASSIST and ADVISE." }),
+  "writing.agent.brainstorm": Object.freeze({ system: "You are a creative brainstorming partner. Generate ideas freely, suggest alternatives, explore possibilities. The WRITER writes. You ASSIST and ADVISE." }),
   "image.prompt.refinement": Object.freeze({
     system_semantics:
       "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition.",

--- a/apps/packages/ui/src/services/tldw/__tests__/service-prompt-scope-error.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/service-prompt-scope-error.test.ts
@@ -12,6 +12,29 @@ import {
 } from "@/services/chat-surface-scope"
 
 describe("Service Prompt scope policy", () => {
+  it.each([
+    "/api/v1/writing/manuscripts/scenes/scene-a",
+    "/api/v1/writing/manuscripts/projects/project-a/characters?role=protagonist",
+    "/api/v1/writing/manuscripts/projects/project-a/world-info?kind=location",
+  ])("allows only GET for the bounded context read %s", (path) => {
+    expect(isServicePromptRequestPath(path, "GET")).toBe(true)
+    for (const method of ["POST", "PATCH", "DELETE", "PUT"]) {
+      expect(isServicePromptRequestPath(path, method)).toBe(false)
+    }
+  })
+
+  it.each([
+    "/api/v1/writing/manuscripts/projects/project-a",
+    "/api/v1/writing/manuscripts/scenes/scene-a/annotations",
+    "/api/v1/writing/manuscripts/projects/project-a/characters/relationships",
+    "/api/v1/writing/manuscripts/projects/%2e%2e/characters",
+    "/api/v1/writing/manuscripts/scenes/a%2fb",
+    "/api/v1/writing/manuscripts/scenes/a%5cb",
+    "/api/v1/writing/manuscripts/scenes/",
+  ])("does not widen scoped access to %s", (path) => {
+    expect(isServicePromptRequestPath(path, "GET")).toBe(false)
+  })
+
   it("compares only the frozen target keys", () => {
     const current = {
       serverUrl: "https://api.example.test",

--- a/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
+++ b/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
@@ -5,6 +5,9 @@ import type {
 } from "@/services/tldw/TldwApiClient"
 
 export type KnownServicePromptId =
+  | "writing.agent.quick"
+  | "writing.agent.planning"
+  | "writing.agent.brainstorm"
   | "study.assistant.explain"
   | "study.assistant.mnemonic"
   | "study.assistant.followup"

--- a/apps/packages/ui/src/services/tldw/service-prompt-scope-error.ts
+++ b/apps/packages/ui/src/services/tldw/service-prompt-scope-error.ts
@@ -104,6 +104,9 @@ export const isServicePromptRequestPath = (
   if (/^\/api\/v1\/service-prompts\/[^/]+$/.test(pathname)) {
     return ["GET", "PUT", "DELETE"].includes(requestMethod)
   }
+  if (requestMethod === "GET") {
+    return /^\/api\/v1\/writing\/manuscripts\/(?:scenes\/[^/]+|projects\/[^/]+\/(?:characters|world-info))$/.test(pathname)
+  }
   if (requestMethod !== "POST") return false
   if (pathname === "/api/v1/chats/") return true
   return /^\/api\/v1\/(?:auth\/refresh|chat\/completions|media\/add|rag\/search|research\/websearch)$/.test(pathname) ||

--- a/apps/packages/ui/src/services/writing-playground.ts
+++ b/apps/packages/ui/src/services/writing-playground.ts
@@ -1157,12 +1157,13 @@ export async function listManuscriptCharacters(
   if (params?.cast_group) query.set("cast_group", params.cast_group)
   const qs = query.toString()
   const path = `/api/v1/writing/manuscripts/projects/${encodeURIComponent(projectId)}/characters${qs ? `?${qs}` : ""}`
-  return await bgRequest<ManuscriptCharacterListResponse>({
+  const response = await bgRequest<ManuscriptCharacter[] | ManuscriptCharacterListResponse>({
     path: path as AllowedPath,
     method: "GET",
     abortSignal: options?.signal,
     ...requestScopeFields(options?.requestScope),
   })
+  return Array.isArray(response) ? { characters: response, total: response.length } : response
 }
 
 export async function createManuscriptCharacter(
@@ -1219,12 +1220,13 @@ export async function listManuscriptWorldInfo(
   if (params?.kind) query.set("kind", params.kind)
   const qs = query.toString()
   const path = `/api/v1/writing/manuscripts/projects/${encodeURIComponent(projectId)}/world-info${qs ? `?${qs}` : ""}`
-  return await bgRequest<ManuscriptWorldInfoListResponse>({
+  const response = await bgRequest<ManuscriptWorldInfoItem[] | ManuscriptWorldInfoListResponse>({
     path: path as AllowedPath,
     method: "GET",
     abortSignal: options?.signal,
     ...requestScopeFields(options?.requestScope),
   })
+  return Array.isArray(response) ? { items: response, total: response.length } : response
 }
 
 export async function createManuscriptWorldInfo(

--- a/apps/packages/ui/src/services/writing-playground.ts
+++ b/apps/packages/ui/src/services/writing-playground.ts
@@ -1,6 +1,12 @@
 import { bgRequest } from "@/services/background-proxy"
 import { buildQuery, createResourceClient } from "@/services/resource-client"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
+import { requestScopeFields, type ServicePromptRequestScope } from "@/services/tldw/domains/service-prompts"
+
+type ManuscriptReadOptions = {
+  signal?: AbortSignal
+  requestScope?: ServicePromptRequestScope
+}
 
 export type ManuscriptProjectResponse = {
   id: string
@@ -1114,10 +1120,12 @@ export async function createManuscriptScene(
   })
 }
 
-export async function getManuscriptScene(sceneId: string): Promise<ManuscriptSceneResponse> {
+export async function getManuscriptScene(sceneId: string, options?: ManuscriptReadOptions): Promise<ManuscriptSceneResponse> {
   return await bgRequest<ManuscriptSceneResponse>({
     path: `/api/v1/writing/manuscripts/scenes/${encodeURIComponent(sceneId)}` as AllowedPath,
     method: "GET",
+    abortSignal: options?.signal,
+    ...requestScopeFields(options?.requestScope),
   })
 }
 
@@ -1142,6 +1150,7 @@ export async function updateManuscriptScene(
 export async function listManuscriptCharacters(
   projectId: string,
   params?: { role?: string; cast_group?: string },
+  options?: ManuscriptReadOptions,
 ): Promise<ManuscriptCharacterListResponse> {
   const query = new URLSearchParams()
   if (params?.role) query.set("role", params.role)
@@ -1151,6 +1160,8 @@ export async function listManuscriptCharacters(
   return await bgRequest<ManuscriptCharacterListResponse>({
     path: path as AllowedPath,
     method: "GET",
+    abortSignal: options?.signal,
+    ...requestScopeFields(options?.requestScope),
   })
 }
 
@@ -1202,6 +1213,7 @@ export async function createManuscriptRelationship(
 export async function listManuscriptWorldInfo(
   projectId: string,
   params?: { kind?: string },
+  options?: ManuscriptReadOptions,
 ): Promise<ManuscriptWorldInfoListResponse> {
   const query = new URLSearchParams()
   if (params?.kind) query.set("kind", params.kind)
@@ -1210,6 +1222,8 @@ export async function listManuscriptWorldInfo(
   return await bgRequest<ManuscriptWorldInfoListResponse>({
     path: path as AllowedPath,
     method: "GET",
+    abortSignal: options?.signal,
+    ...requestScopeFields(options?.requestScope),
   })
 }
 

--- a/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
+++ b/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
@@ -1,5 +1,14 @@
 {
   "defaults": {
+    "writing.agent.quick": {
+      "system": "You are a writing assistant. Give brief, direct answers (3 sentences max). The WRITER writes. You ASSIST and ADVISE."
+    },
+    "writing.agent.planning": {
+      "system": "You are a story planning assistant. Help with plot structure, character arcs, and world-building. Provide structured suggestions. The WRITER writes. You ASSIST and ADVISE."
+    },
+    "writing.agent.brainstorm": {
+      "system": "You are a creative brainstorming partner. Generate ideas freely, suggest alternatives, explore possibilities. The WRITER writes. You ASSIST and ADVISE."
+    },
     "study.assistant.explain": {
       "guidance": "Explain the material clearly and stay anchored to the provided study context only."
     },

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2073,
   "schema_count": 3142,
-  "sha256": "5c815e778af28b517b73f608b3b458f98c9751313590432e625ea81afe91792c"
+  "sha256": "e72e58af304408bc1b44bb380d7d4b3a34f126fc87b2c0bc01c9611147d597da"
 }

--- a/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Writing Agent mode prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-06 15:38'
-updated_date: '2026-09-06 16:19'
+updated_date: '2026-09-06 16:43'
 labels: []
 dependencies: []
 references:
@@ -49,6 +49,10 @@ Published PR #2926 against dev from codex/writing-agent-service-prompts. Impleme
 Qodo review on implementation head reported three actionable items: contextual missing-prompt errors, grouped authentication imports, and bare-array manuscript character/world-info responses being treated as empty. Verified server list response models and all three client consumers expect wrappers; plan minimal normalization in the two shared helpers with real-payload regression coverage, plus error context and import cleanup. Backend-required failed OpenAPI fingerprint drift after optional header dependencies; requested approval for contract artifact refresh separately.
 
 Qodo fixes verified: 8 RED failures then 191 shared UI tests GREEN; WebUI 25 passed; nine optional expected-user endpoint regressions passed. Bandit zero findings and py_compile pass. Scoped ESLint from repo root with WebUI config has no code findings (only known pages-directory config warning). Independent read-only fix review approved. Shared list helpers normalize arrays once while preserving existing wrappers and totals; tests feed bare arrays through real helpers into Agent context. Missing prompt errors identify each mode ID; auth imports grouped. OpenAPI regeneration still awaits approval; diagnostic export currently needs repository-local tldw_profile_core on PYTHONPATH.
+
+User approved the OpenAPI fingerprint and generated-type refresh. Regenerate with the canonical exporter, verify the schema change is restricted to the three optional expected-user manuscript headers, regenerate TypeScript declarations, and rerun the drift gate before pushing.
+
+Approved contract refresh complete. Canonical exporter succeeded with PYTHONPATH including packages/tldw_profile_core/src. Fingerprint now e72e58af304408bc1b44bb380d7d4b3a34f126fc87b2c0bc01c9611147d597da, matching the CI-computed value. Removed exactly the three optional X-TLDW-Expected-User-ID parameters from the exported schema in a diagnostic copy; canonical hashing reproduced the original 5c815e778af28b517b73f608b3b458f98c9751313590432e625ea81afe91792c hash. This proves no unrelated contract drift. Counts unchanged: 2073 paths, 3142 schemas. openapi-typescript 7.13.0 generated the ignored schema.d.ts successfully. Fresh export_openapi_schema.py --check passes; git diff --check passes. Only the fingerprint and tracking record are committed; no runtime code changed, so no additional Bandit run needed for this artifact-only fix.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
@@ -1,0 +1,60 @@
+---
+id: TASK-13209
+title: Expose Writing Agent mode prompts through Service Prompts
+status: In Progress
+assignee: []
+created_date: '2026-09-06 15:38'
+updated_date: '2026-09-06 16:05'
+labels: []
+dependencies: []
+documentation:
+  - Docs/Design/writing-agent-service-prompts.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Approved bounded slice: make Quick, Planning, and Brainstorm Writing Playground AI Agent instructions editable in shared WebUI/extension Settings using existing owner-scoped Service Prompts. Preserve defaults, model settings, manuscript bounds and older-server compatibility; prevent cross-scope context and stale replies after account/server, project, or mode changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Three mode-specific prompts support existing Settings save/reset and preserve packaged defaults.
+- [x] #2 Each send captures one owner-scoped prompt configuration and uses that scope for manuscript reads and model dispatch.
+- [x] #3 Stale context, replies and errors are discarded after scope, project or mode changes; unscoped service callers remain compatible.
+- [x] #4 Affected frontend/backend tests, lint, Bandit and code review pass with known skips documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish baseline and add regression tests. 2. Register three prompts and wire scoped context/generation using existing helpers. 3. Verify Settings, old-server fallback, request lifecycle, and review the bounded diff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline: 90 registry/API and 91 frontend checks passed. RED: component 11 failures/1 pass, snapshot compatibility 4 failures/79 passes, Settings 3 expected failures, backend registry 2 expected failures. Implemented 3 literal mode definitions, shared Settings labels, explicit packaged fallback allowlist, optional scoped manuscript reads, and retained history scope lease. Additional regression reproduced unverified failed-load text leaking into later request history; now excluded. Backend registry/API: 93 passed. Broad frontend, WebUI shim, lint/typecheck and independent read-only review in progress. Bandit on touched Python runtime and Ruff on touched Python runtime/tests pass.
+
+Independent review found and verified two issues: first-load errors without a retained lease could remain visible across account changes; scoped manuscript GETs were rejected by the existing transport allowlist. Both addressed test-first. Unbound config/auth cleanup regressions: 2 RED then 17 component tests GREEN. Scoped transport regressions: 6 RED then 70 real-transport/guard tests GREEN. HTTP expected-user regressions: 3 RED, 6 compatible cases passed; now adding the existing expected-user dependency only to those three GET endpoints. Follow-up review approved with no actionable findings. Broader scope suite: 286 passed. Shared Settings/save-reset regression and other affected suites passed, with final totals pending. WebUI Settings 87 passed and component rerun underway. Bandit on both Python runtime files reports zero findings. Five Ruff findings in preexisting manuscript endpoint/test code were verified against HEAD; other touched Python files pass. Frontend ESLint has no errors; 10 existing any warnings in tldw-server.ts. Full shared TypeScript check reports 158 existing diagnostics outside changed runtime code; corrected a preexisting over-broad fixture Record annotation. Locale generator run, retaining only this slice’s seven generated keys to avoid unrelated prior locale drift.
+
+Final backend verification: 132 passed (manuscript HTTP integration plus Service Prompts registry/API), including all nine optional expected-user cases. Current frontend coverage: 438 shared UI tests and 104 WebUI-harness tests pass across focused runs; consolidated shared UI rerun pending. Bandit: zero findings on both touched runtime files. Independent follow-up review approved, no remaining actionable findings. Full repository suite, production frontend builds and live-browser smoke were not run; focused suites match the approved design. Existing TypeScript diagnostics (158; none on changed lines), five preexisting Ruff findings in manuscript files, and existing frontend lint warnings are not newly introduced. No PR exists yet; branch is ready for integration choice after commit.
+
+Consolidated final shared frontend run completed: 438 passed across 12 files (65.78 seconds), zero failures. Final backend run: 132 passed, zero failures. WebUI harness: Settings 87 and current component 17 passed. Fresh Bandit and Python compilation also pass. Temporary dependency symlinks removed before staging; no dependency changes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Quick, Planning and Brainstorm prompt customization through existing shared Service Prompts Settings. Preserved exact defaults and generation settings, added narrow scoped manuscript GET support and optional server-side identity assertions, and retained a scope lease to clear stale requests/history. Older-server fallback remains explicit and auth/non-404 errors propagate. Verified actionable review findings with failing regressions before minimal fixes. Implementation and review complete; awaiting PR/integration choice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Writing Agent mode prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-06 15:38'
-updated_date: '2026-09-06 16:07'
+updated_date: '2026-09-06 16:19'
 labels: []
 dependencies: []
 references:
@@ -45,6 +45,10 @@ Final backend verification: 132 passed (manuscript HTTP integration plus Service
 Consolidated final shared frontend run completed: 438 passed across 12 files (65.78 seconds), zero failures. Final backend run: 132 passed, zero failures. WebUI harness: Settings 87 and current component 17 passed. Fresh Bandit and Python compilation also pass. Temporary dependency symlinks removed before staging; no dependency changes.
 
 Published PR #2926 against dev from codex/writing-agent-service-prompts. Implementation commit 1381222da64540e0a93bf17c96812c0a6bc91ab5. Remote dev matched the branch base at publication; no rebase needed. Awaiting CI and PR review; worktree preserved.
+
+Qodo review on implementation head reported three actionable items: contextual missing-prompt errors, grouped authentication imports, and bare-array manuscript character/world-info responses being treated as empty. Verified server list response models and all three client consumers expect wrappers; plan minimal normalization in the two shared helpers with real-payload regression coverage, plus error context and import cleanup. Backend-required failed OpenAPI fingerprint drift after optional header dependencies; requested approval for contract artifact refresh separately.
+
+Qodo fixes verified: 8 RED failures then 191 shared UI tests GREEN; WebUI 25 passed; nine optional expected-user endpoint regressions passed. Bandit zero findings and py_compile pass. Scoped ESLint from repo root with WebUI config has no code findings (only known pages-directory config warning). Independent read-only fix review approved. Shared list helpers normalize arrays once while preserving existing wrappers and totals; tests feed bare arrays through real helpers into Agent context. Missing prompt errors identify each mode ID; auth imports grouped. OpenAPI regeneration still awaits approval; diagnostic export currently needs repository-local tldw_profile_core on PYTHONPATH.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Writing Agent mode prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-06 15:38'
-updated_date: '2026-09-06 16:43'
+updated_date: '2026-09-06 18:09'
 labels: []
 dependencies: []
 references:
@@ -53,6 +53,10 @@ Qodo fixes verified: 8 RED failures then 191 shared UI tests GREEN; WebUI 25 pas
 User approved the OpenAPI fingerprint and generated-type refresh. Regenerate with the canonical exporter, verify the schema change is restricted to the three optional expected-user manuscript headers, regenerate TypeScript declarations, and rerun the drift gate before pushing.
 
 Approved contract refresh complete. Canonical exporter succeeded with PYTHONPATH including packages/tldw_profile_core/src. Fingerprint now e72e58af304408bc1b44bb380d7d4b3a34f126fc87b2c0bc01c9611147d597da, matching the CI-computed value. Removed exactly the three optional X-TLDW-Expected-User-ID parameters from the exported schema in a diagnostic copy; canonical hashing reproduced the original 5c815e778af28b517b73f608b3b458f98c9751313590432e625ea81afe91792c hash. This proves no unrelated contract drift. Counts unchanged: 2073 paths, 3142 schemas. openapi-typescript 7.13.0 generated the ignored schema.d.ts successfully. Fresh export_openapi_schema.py --check passes; git diff --check passes. Only the fingerprint and tracking record are committed; no runtime code changed, so no additional Bandit run needed for this artifact-only fix.
+
+User approved rebase and force-with-lease update. Rebased four commits onto origin/dev c5b777e9ba7f2ef755185fdb0d350fa1c0d2ce2e without conflicts. git range-diff reports all four patches unchanged. Current rebased implementation/fixes: 0ff1a07b37, d3e2e31f46, 6396c88d2f, 20ab6669ff. Fresh affected backend/shared UI/WebUI tests, Bandit and OpenAPI drift verification running before publication.
+
+Post-rebase verification complete: 132 backend tests, 443 shared UI tests across 12 files, and 25 WebUI-harness checks passed. Bandit on both touched runtime Python files reports no findings; OpenAPI drift check passes on latest dev; scoped ESLint has no code findings (existing pages-path configuration warning only). Temporary dependency symlinks removed. Remote dev remains c5b777e9ba7f2ef755185fdb0d350fa1c0d2ce2e and remote PR head remains 01036a690ca5b60881c0d8394dda9bcaa9e668db; publishing with an explicit expected-head lease.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13209 - Expose-Writing-Agent-mode-prompts-through-Service-Prompts.md
@@ -4,9 +4,11 @@ title: Expose Writing Agent mode prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-06 15:38'
-updated_date: '2026-09-06 16:05'
+updated_date: '2026-09-06 16:07'
 labels: []
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2926'
 documentation:
   - Docs/Design/writing-agent-service-prompts.md
 ---
@@ -41,12 +43,16 @@ Independent review found and verified two issues: first-load errors without a re
 Final backend verification: 132 passed (manuscript HTTP integration plus Service Prompts registry/API), including all nine optional expected-user cases. Current frontend coverage: 438 shared UI tests and 104 WebUI-harness tests pass across focused runs; consolidated shared UI rerun pending. Bandit: zero findings on both touched runtime files. Independent follow-up review approved, no remaining actionable findings. Full repository suite, production frontend builds and live-browser smoke were not run; focused suites match the approved design. Existing TypeScript diagnostics (158; none on changed lines), five preexisting Ruff findings in manuscript files, and existing frontend lint warnings are not newly introduced. No PR exists yet; branch is ready for integration choice after commit.
 
 Consolidated final shared frontend run completed: 438 passed across 12 files (65.78 seconds), zero failures. Final backend run: 132 passed, zero failures. WebUI harness: Settings 87 and current component 17 passed. Fresh Bandit and Python compilation also pass. Temporary dependency symlinks removed before staging; no dependency changes.
+
+Published PR #2926 against dev from codex/writing-agent-service-prompts. Implementation commit 1381222da64540e0a93bf17c96812c0a6bc91ab5. Remote dev matched the branch base at publication; no rebase needed. Awaiting CI and PR review; worktree preserved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented Quick, Planning and Brainstorm prompt customization through existing shared Service Prompts Settings. Preserved exact defaults and generation settings, added narrow scoped manuscript GET support and optional server-side identity assertions, and retained a scope lease to clear stale requests/history. Older-server fallback remains explicit and auth/non-404 errors propagate. Verified actionable review findings with failing regressions before minimal fixes. Implementation and review complete; awaiting PR/integration choice.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2926 (base dev). Awaiting CI/review and merge readiness.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
@@ -6,8 +6,14 @@ from typing import Any, Literal, NoReturn
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_expected_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RateLimiter,
+    User,
+    get_rate_limiter_dep,
+    get_request_user,
+    rbac_rate_limit,
+    require_expected_user,
+)
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager

--- a/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, NoReturn
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_expected_user
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
@@ -972,6 +973,7 @@ async def list_scenes(
     "/scenes/{scene_id}",
     response_model=ManuscriptSceneResponse,
     summary="Get a manuscript scene",
+    dependencies=[Depends(require_expected_user)],
     tags=["manuscripts"],
 )
 async def get_scene(
@@ -1133,6 +1135,7 @@ async def create_character(
     "/projects/{project_id}/characters",
     response_model=list[ManuscriptCharacterResponse],
     summary="List characters in a project",
+    dependencies=[Depends(require_expected_user)],
     tags=["manuscripts"],
 )
 async def list_characters(
@@ -1391,6 +1394,7 @@ async def create_world_info(
     "/projects/{project_id}/world-info",
     response_model=list[ManuscriptWorldInfoResponse],
     summary="List world-info entries in a project",
+    dependencies=[Depends(require_expected_user)],
     tags=["manuscripts"],
 )
 async def list_world_info(

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -158,6 +158,21 @@ Based on the content between backticks create comprehensive bulleted notes.
 _DEFINITION_SEQUENCE = (
     *(
         ServicePromptDefinition(
+            id=f"writing.agent.{mode}",
+            label=label,
+            description="Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+            parts=(ServicePromptPart(key="system", label="System instructions", mode="literal", required_variables=()),),
+            default_parts=MappingProxyType({"system": system}),
+            affected_workflows=(ServicePromptWorkflow(id="writing.agent", label="Writing Playground AI Agent"),),
+        )
+        for mode, label, system in (
+            ("quick", "Writing Agent: Quick", "You are a writing assistant. Give brief, direct answers (3 sentences max). The WRITER writes. You ASSIST and ADVISE."),
+            ("planning", "Writing Agent: Planning", "You are a story planning assistant. Help with plot structure, character arcs, and world-building. Provide structured suggestions. The WRITER writes. You ASSIST and ADVISE."),
+            ("brainstorm", "Writing Agent: Brainstorm", "You are a creative brainstorming partner. Generate ideas freely, suggest alternatives, explore possibilities. The WRITER writes. You ASSIST and ADVISE."),
+        )
+    ),
+    *(
+        ServicePromptDefinition(
             id=f"study.assistant.{action}",
             label=label,
             description="Controls study response guidance. Grounding instructions, study context and provider settings remain fixed.",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -29,6 +29,24 @@ FIXTURE_PATH = (
 FIXTURE = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 EXPECTED_REGISTRY = {
+    "writing.agent.quick": {
+        "label": "Writing Agent: Quick",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+        "parts": (("system", "System instructions", "literal", ()),),
+        "workflows": (("writing.agent", "Writing Playground AI Agent"),),
+    },
+    "writing.agent.planning": {
+        "label": "Writing Agent: Planning",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+        "parts": (("system", "System instructions", "literal", ()),),
+        "workflows": (("writing.agent", "Writing Playground AI Agent"),),
+    },
+    "writing.agent.brainstorm": {
+        "label": "Writing Agent: Brainstorm",
+        "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+        "parts": (("system", "System instructions", "literal", ()),),
+        "workflows": (("writing.agent", "Writing Playground AI Agent"),),
+    },
     "study.assistant.explain": {
         "label": "Study explanation",
         "description": "Controls study response guidance. Grounding instructions, study context and provider settings remain fixed.",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -88,6 +88,27 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
     assert response.headers["cache-control"] == "no-store"
     assert response.json() == [
         {
+            "id": "writing.agent.quick",
+            "label": "Writing Agent: Quick",
+            "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+            "parts": [{"key": "system", "label": "System instructions", "mode": "literal", "required_variables": []}],
+            "affected_workflows": [{"id": "writing.agent", "label": "Writing Playground AI Agent"}],
+        },
+        {
+            "id": "writing.agent.planning",
+            "label": "Writing Agent: Planning",
+            "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+            "parts": [{"key": "system", "label": "System instructions", "mode": "literal", "required_variables": []}],
+            "affected_workflows": [{"id": "writing.agent", "label": "Writing Playground AI Agent"}],
+        },
+        {
+            "id": "writing.agent.brainstorm",
+            "label": "Writing Agent: Brainstorm",
+            "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
+            "parts": [{"key": "system", "label": "System instructions", "mode": "literal", "required_variables": []}],
+            "affected_workflows": [{"id": "writing.agent", "label": "Writing Playground AI Agent"}],
+        },
+        {
             "id": "study.assistant.explain",
             "label": "Study explanation",
             "description": "Controls study response guidance. Grounding instructions, study context and provider settings remain fixed.",
@@ -480,6 +501,24 @@ def test_summary_settings_uses_deployment_default_for_detail_and_reset(
     assert reset.status_code == 200
     assert reset.json()["effective_parts"] == {"system": "Deployment summary guidance."}
     assert reset.json()["saved_parts"] is None
+
+
+@pytest.mark.parametrize("mode", ["quick", "planning", "brainstorm"])
+def test_writing_agent_prompt_save_reset_and_mode_isolation(api_context: SimpleNamespace, mode: str) -> None:
+    """A writing-mode override stays literal and does not affect another mode."""
+    path = f"/api/v1/service-prompts/writing.agent.{mode}"
+    defaults = api_context.client.get(path).json()["default_parts"]
+    other_mode = "planning" if mode == "quick" else "quick"
+    other_path = f"/api/v1/service-prompts/writing.agent.{other_mode}"
+    other_defaults = api_context.client.get(other_path).json()["effective_parts"]
+    custom = {"system": "Advise in French {literally}."}
+    saved = api_context.client.put(path, json={"parts": custom, "expected_revision": None})
+    assert saved.status_code == 200
+    assert api_context.client.get(path).json()["effective_parts"] == custom
+    assert api_context.client.get(other_path).json()["effective_parts"] == other_defaults
+    reset = api_context.client.delete(path, params={"expected_revision": saved.json()["revision"]})
+    assert reset.status_code == 200
+    assert reset.json()["effective_parts"] == defaults
 
 
 def test_title_prompt_can_be_saved_and_reset_through_generic_api(api_context) -> None:

--- a/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
+++ b/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
@@ -49,6 +49,24 @@ def client(tmp_path, monkeypatch):
 PREFIX = "/api/v1/writing/manuscripts"
 
 
+@pytest.mark.parametrize("path,expected_status", [
+    ("/scenes/missing-scene", 404),
+    ("/projects/missing-project/characters", 200),
+    ("/projects/missing-project/world-info", 200),
+])
+@pytest.mark.parametrize("expected_user", [None, "1", "999"])
+def test_agent_context_reads_enforce_optional_expected_user(
+    client: TestClient, path: str, expected_status: int, expected_user: str | None
+) -> None:
+    """Reject stale identity before reading manuscript data, preserving unscoped callers."""
+    headers = {} if expected_user is None else {"X-TLDW-Expected-User-ID": expected_user}
+    response = client.get(f"{PREFIX}{path}", headers=headers)
+    assert response.status_code == (412 if expected_user == "999" else expected_status), response.text
+    if expected_user == "999":
+        assert response.json()["detail"]["code"] == "request_config_scope_changed"
+        assert response.headers["cache-control"] == "no-store"
+
+
 def test_full_manuscript_crud(client: TestClient):
     """Full lifecycle: create project -> part -> chapter -> scene -> structure -> update -> search -> delete."""
 


### PR DESCRIPTION
## Summary

- What changed: expose Writing Playground AI Agent Quick, Planning, and Brainstorm instructions through the existing shared Service Prompts Settings in the WebUI and browser extension.
- Why: reuse the established owner-scoped storage, editor, and snapshot lifecycle while preserving exact default instructions, provider/model settings, token limits, and manuscript context bounds.
- Each send captures one prompt configuration for manuscript reads and model dispatch. Retained scope leases clear stale requests and visible history after account/server changes; project and mode changes also cancel stale work.
- Permit only the three required manuscript GET paths in scoped transport and enforce the existing optional expected-user assertion on those endpoints. Existing unscoped callers remain compatible.
- Keep explicit packaged defaults for older servers; authentication, validation, and non-404 failures do not silently fall back.

Tracking: TASK-13209. Design: `Docs/Design/writing-agent-service-prompts.md`.

## Validation

- [x] Tests added/updated for behavior changes, with failing regressions before fixes
- [x] Relevant unit/integration tests pass locally: 132 backend, 438 shared UI, and 104 WebUI-harness checks
- [x] Docs updated
- [x] Bandit reports zero findings on both touched Python runtime files; Python compilation and diff checks pass
- [x] Independent code review approved after fixing scoped transport and stale first-load error findings

Known limitations: full repository tests, production frontend builds, and live-browser smoke were not run. The shared TypeScript check reports 158 existing diagnostics, none on changed lines. Five existing Ruff findings in the manuscript endpoint/test files and existing frontend lint warnings remain documented in TASK-13209; other touched Python files and scoped frontend lint checks pass.

## UX Audit Checklist (v2 Stage 5)

- [ ] Stage 5 and all-pages browser smoke tests (not run; focused component/transport coverage used)
- [x] WebUI/extension shared UI parity covered by shared UI and WebUI-harness Settings and Agent tests
- Flashcards and Watchlists checklists: not applicable; no changes to those features.

## Risk & Rollback

- Risk level: Medium, primarily asynchronous scope lifecycle and older-server compatibility; regression tests cover both.
- Rollback: revert this PR. No database migration or new storage is introduced.

## Change summary

The repository owner explicitly waived the human-authored Change summary requirement for PR #2926: "waiver given". [Waiver record](https://github.com/rmusser01/tldw_server/pull/2926#issuecomment-5561342127). Technical summaries remain AI-authored; required CI and review gates still apply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Writing Playground AI Agent Quick, Planning, and Brainstorm instructions editable in Settings via the existing owner-scoped Service Prompts, replacing hardcoded defaults.

- Registers three literal `writing.agent.*` definitions in the server registry and shared UI Settings; older servers fall back to packaged defaults.
- Manuscript context reads now carry the captured scope and optional expected-user header; auth, validation, and non-404 failures still error.
- Character and world-info list responses are normalized to their existing wrapper contracts, and missing prompt errors identify the specific mode.
- Stale context, replies, and errors are discarded on account, project, or mode changes; history clears on scope boundaries.
- Tracks TASK-13209, refreshes the OpenAPI fingerprint for the expected-user headers, and tests cover mode selection, save/reset, scope transport, and asynchronous boundaries.

<sup>Written for commit b48cc4485d7efcfddf815ee1d07de617f41ca3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

