### PR TITLE
fix(persona): honor configured speech providers and document Buddy setup

### DIFF
--- a/Docs/Published/User_Guides/Server/Personas_User_Guide.md
+++ b/Docs/Published/User_Guides/Server/Personas_User_Guide.md
@@ -256,8 +256,17 @@ then **Start listening**. Preparation checks the configured Chat target and
 prepares the selected STT and TTS services before the browser requests microphone
 access. Under **Profiles**, choose **TTS provider**, optionally set **TTS model**
 and **TTS voice**, and choose **Save assistant defaults**. Blank model and voice
-fields use the selected provider's applicable defaults. The Live STT/TTS summaries
-show the effective settings; change saved selections under Profiles.
+fields use the selected provider's applicable defaults. A blank voice uses the
+server's configured voice only when the selected provider is its default provider;
+otherwise the selected adapter resolves its default. Browser-wide voice preferences
+do not override a blank Persona voice. The **browser** provider uses its native
+default voice when this field is blank.
+
+After saving changes, choose **Disconnect → Connect** if Live was connected.
+Connected sessions keep their original voice settings until reconnect; returning
+from Profiles or retrying Start does not refresh them. Live shows the provider,
+model selection and voice for the current connection. A “default model” or
+“default voice” label leaves that value for the provider to resolve.
 
 The provider list includes **browser**, registered server providers, and configured
 speech gateways. Browser speech uses the browser's speech synthesis and available

--- a/Docs/Published/User_Guides/Server/Personas_User_Guide.md
+++ b/Docs/Published/User_Guides/Server/Personas_User_Guide.md
@@ -1,6 +1,8 @@
 # Personas User Guide
 
-Last Updated: 2026-06-01
+For a step-by-step browser walkthrough, see the [Persona Buddy guide](../WebUI_Extension/Persona_Buddy_Guide.md): setup, Migu, dragging, live voice, approvals, and troubleshooting.
+
+Last Updated: 2026-09-07
 
 ## Overview
 
@@ -247,23 +249,44 @@ Common server events include:
 The stream enforces feature flags, authentication, policy checks, tool
 confirmation, audio limits, and rate limits.
 
-### Preparing local voice
+### Preparing voice with the selected provider
 
-Open the exact Buddy session in Full Live and choose Start. Preparation checks
-the configured Chat provider and initializes the selected STT and TTS models
-before the browser requests microphone access. The initial qualified speech path
-uses local Whisper and Kokoro. Other selections return setup feedback when they
-cannot be prepared; no substitute transcript or audio is generated.
+Open the exact Buddy session in Full Live, choose **Connect** if needed, and
+then **Start listening**. Preparation checks the configured Chat target and
+prepares the selected STT and TTS services before the browser requests microphone
+access. Under **Profiles**, choose **TTS provider**, optionally set **TTS model**
+and **TTS voice**, and choose **Save assistant defaults**. Blank model and voice
+fields use the selected provider's applicable defaults. The Live STT/TTS summaries
+show the effective settings; change saved selections under Profiles.
+
+The provider list includes **browser**, registered server providers, and configured
+speech gateways. Browser speech uses the browser's speech synthesis and available
+voices. Local server providers need their models, voice assets, and dependencies;
+remote providers and gateways need the appropriate configuration and credentials.
+The legacy Persona **tldw** value remains an alias for **kokoro**. Kokoro is an
+available provider, not a prerequisite for every Persona voice session.
+**Use browser fallback** inherits the browser-wide provider preference rather than
+forcing browser speech. Persona Live does not silently switch providers on
+preparation or synthesis failure. See [TTS setup](../WebUI_Extension/TTS-SETUP-GUIDE.md).
+
+Recorded physical tests used Parakeet ONNX and Kokoro; Whisper was also tested.
+These are historical test choices, not qualification of every provider or browser
+voice. A failed preparation returns setup feedback; no substitute transcript or
+audio is generated. Browser speech support and audible playback must be checked
+in the browser itself.
 
 WebSocket clients send `voice_config`, then `voice_prepare` with a unique
-`client_message_id`. Wait for the matching `voice_readiness` event. Supply a
-supported Whisper model size (for example `tiny.en`) and `tts.provider` set to
-`kokoro` (or its `tldw` alias). The server must have the selected models and a
-usable default Chat provider with server-configured credentials. This preparation
-check does not yet qualify user/team/organization BYOK credentials for voice.
-A failed preparation does not authorize
-capture. The WebUI cancels a preparation that exceeds its 30-second wait and
-offers retry guidance.
+`client_message_id`. Wait for the matching `voice_readiness` event. For STT,
+use a supported selected model such as `tiny.en` for Whisper or `parakeet-onnx`
+for Parakeet ONNX. Set `tts.provider` to `browser`, a registered server provider,
+or a configured speech gateway ID; optional `tts.model` and `tts.voice` select
+provider-supported values. The server must have the selected local models and a
+configured default Chat provider/model. Preparation resolves the Chat target;
+it does not require a server-static Chat key or certify Chat admission. Each
+submitted turn enters the authenticated Chat route, which resolves effective
+credentials (including applicable BYOK) and enforces access policy, moderation,
+and budget. A failed preparation does not authorize capture. The WebUI cancels
+a preparation that exceeds its 30-second wait and offers retry guidance.
 
 Voice readiness belongs to the connection and session. Session summaries report
 `capabilities.voice=true` only while an owned runtime is prepared. Stop, changes
@@ -473,4 +496,4 @@ until cleanup completes. Stop always discards its late transcript.
 
 Changing Persona through setup or Live ends the former connection and clears its resume selection, transcript and pending approvals. Use **Connect** to begin a session for the newly selected Persona. Previously saved setup and voice defaults remain available.
 
-Use **Refresh catalog** to reload bundled Buddy choices. If loading fails, **Retry catalog** repeats the read without copying, activating, or replacing the current pack. The button is disabled during the request. Voice preparation currently requires server-configured credentials for the default Chat provider; user/team/organization BYOK-only credentials are not qualified by this voice preflight.
+Use **Refresh catalog** to reload bundled Buddy choices. If loading fails, **Retry catalog** repeats the read without copying, activating, or replacing the current pack. The button is disabled during the request. If voice prepares but a submitted turn fails, read the Chat error and check authenticated access, effective credentials, and budget; preparation alone does not certify Chat admission.

--- a/Docs/Published/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
@@ -1,0 +1,198 @@
+# Persona Buddy — setup, live voice, approvals, and troubleshooting
+
+Persona Buddy is the floating companion on supported Persona-aware WebUI and
+extension surfaces. It displays a Persona's active visual pack and provides a
+small entry point for text sessions, feedback, and navigation to the full Live
+session. The full Live view owns microphone capture, playback, and plan review.
+
+This guide covers the **server-backed browser experience**. For the terminal
+application, see the [Chatbook user guide](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/index.md).
+The two apps have different selection and voice controls.
+
+## Before you start
+
+- Run the server and WebUI, connect the WebUI to that server, and authenticate.
+  Follow [Quickstart](../../Getting_Started/QUICKSTART.md) or your deployment's
+  existing setup instructions.
+- Make sure the server exposes Persona features and you can open **Persona
+  Garden** at `/persona`.
+- For conversation, configure the server's default Chat provider and model.
+  Voice preparation checks that target; each submitted turn then uses the
+  authenticated Chat route, which checks effective credentials (including
+  applicable BYOK), access policy, moderation, and budget. Preparation alone
+  does not certify that a Chat request will succeed.
+- For voice, install the selected speech-to-text model and choose a TTS provider
+  under **Profiles**. Use browser speech, a registered server provider, or a
+  configured speech gateway. Local providers need their model assets and
+  dependencies; remote providers and gateways need their endpoint and credentials.
+- In **Settings → UI customization**, enable **Enable persona buddy shell**.
+  Use a desktop-width WebUI window: the full WebUI hides the floating shell at
+  narrow widths. The extension sidepanel has its own supported layout.
+
+Art selection alone does not start a microphone, configure a provider, or grant
+tool permission. Keep using the authenticated WebUI for protected visual assets;
+a copied asset URL may require the same authentication.
+
+## Choose Migu or another visual pack
+
+1. Open **Persona Garden** and select or create the Persona you want to use.
+2. Open the **Visuals** tab. In **Buddy builder**, select **Bundled Buddy**.
+3. Find **pixel-migu** and click **Copy as draft** on that entry.
+   **pixel-migu** and **Migu Marker Basic** are separate choices; availability
+   depends on your server's catalog.
+4. Check **Review draft readiness** and **Draft preview**. Resolve any listed
+   blockers, then choose **Continue to activation**.
+5. Choose **Activate** under **Validation and activation** when you want the
+   copied pack to become the Persona's active visual pack.
+6. Return to the supported Persona surface and check the floating image.
+
+You can also import a portable pack through the preview/review flow. Copying,
+previewing, and importing are separate from activation; do not assume the active
+art has changed until activation succeeds. **Refresh catalog** reloads the
+starter choices. If it fails, **Retry catalog** retries that read without copying
+or activating a pack.
+
+The server's Migu UAT used a selected Persona and activated Migu pack. It does
+not establish that every existing account already contains that Persona. Your
+catalog, saved names, and active pack can differ.
+
+## Open, move, and send a text message
+
+Click the floating Buddy to expand or collapse its controls. Use **Drag Buddy**
+to move the floating panel; dragging the image is not the documented drag handle.
+The shell keeps position preferences for its surface and constrains placement to
+the viewport. Do not apply Chatbook's terminal resize keys to this browser shell.
+
+| Control or feedback | What it does |
+|---|---|
+| **Start** | Starts a text session for the selected Persona. This is not microphone Start. |
+| Session selection | Chooses the Live session shown in the shell. Check the session before sending or stopping. |
+| **Message your buddy** → **Send** | Sends text to the current session, starting an eligible text session when needed. |
+| Feedback area | Shows message outcomes, replies, errors, or a need for review. |
+| **Stop** | Stops the selected session's work. Already-dispatched provider work may finish remotely, but stopped output must not restart local playback. |
+| **Open Full Live View** | Opens the corresponding Persona/session for the transcript, voice, and review controls. |
+| **Set up voice**, **Listen**, or **Stop listening** | Opens that session's Live view. The label reflects availability/activity; microphone control happens in Live. |
+
+For a first text test, send a short request such as “Reply with: the blue notebook
+is ready.” Check the actual reply in the feedback area or full transcript. An
+idle or speaking image alone is not evidence that the provider returned an answer.
+
+## Make one voice turn
+
+Before recording, open **Profiles**, set **STT model** and **TTS provider**, then
+choose **Save assistant defaults**. **TTS model** and **TTS voice** are optional
+overrides: leave them blank to use the selected provider's applicable defaults,
+or enter values that provider supports. Return to the intended Live session and
+check its displayed settings before starting.
+
+Choose **browser** for the browser's speech synthesis, or choose a server TTS
+provider or configured speech gateway from the provider list. A listed provider
+still needs its required setup. For example, **kokoro** needs local model and
+voice assets; it is one option, not a requirement. The legacy Persona value
+**tldw** continues to select Kokoro. **Use browser fallback** inherits the
+browser-wide TTS preference; it does not force browser speech. Check the effective
+provider shown in Live. See [TTS setup](TTS-SETUP-GUIDE.md) for provider setup.
+
+Persona Live uses the selected route and does not silently switch providers when
+preparation or synthesis fails. Fix the reported setup problem or explicitly
+select another provider. Browser speech requires browser support and an available
+voice; server readiness cannot prove that browser playback will work.
+
+Start with manual control so you decide when recognized speech is submitted:
+
+1. From Buddy, open **Open Full Live View** for the intended session. If the
+   session is disconnected, choose **Connect**.
+2. Check the displayed **STT** model/language and **TTS** provider/voice. These
+   are read-only summaries; correct them under **Profiles** and save the assistant
+   defaults if they are wrong.
+3. Leave **Auto-commit**, **Auto-resume**, and **Barge-in** off for the initial
+   test. Pause background narration or other audio.
+4. Choose **Start listening**. Wait for preparation and the **listening** state,
+   and allow browser microphone access when requested. Do not speak while the
+   runtime is still preparing.
+5. Say one short phrase. Watch **Last heard**: these are provisional words and
+   may change as recognition receives more audio.
+6. While the turn is still listening and recognized speech is present, choose
+   **Send now**. This submits the transcript currently shown, once.
+7. Read the committed transcript and reply, listen for playback, and check that
+   Live returns to **idle**. With Auto-resume off, a new recording requires a
+   fresh **Start listening**. Choose **Disconnect** when finished.
+
+**Send now submits; Stop voice cancels.** Do not click **Stop voice** and then
+expect **Send now** to submit the cancelled recording. Last heard can remain
+visible after Stop, completion, or disconnect while Send now is disabled. If
+recognition is wrong, cancel and retry, or type the intended message in the text
+composer. Last heard is not an editable draft like Chatbook dictation.
+
+Keep a Persona voice turn within **30 seconds, including silence**. Whisper and
+Parakeet ONNX revise the complete bounded turn rather than appending stale chunk
+guesses. This reduces repeated fragments; it does not guarantee correct speech
+recognition. Automatic turn detection, when enabled, waits for recognition through
+the detected speech boundary. Manual Send now uses the currently displayed text.
+
+Stop invalidates late recognition and playback. A native decoder can still be
+finishing in the background; a quick retry may report busy until cleanup completes.
+Known Parakeet decoder error statuses produce speech failure feedback instead of
+being presented as words.
+
+The September 6 physical tests used normal server Parakeet ONNX configuration,
+DeepSeek conversation, and local Kokoro output. Whisper was also tested for the
+responsiveness repair. These are historical test choices, not required providers
+or universal defaults. They do not qualify every TTS provider, gateway, browser
+voice, or a separate realtime provider connection.
+
+## Review approvals in the exact session
+
+When Buddy shows **Needs approval** or review feedback, open **Open Full Live
+View** and inspect the pending plan or tool request in that session. Check the
+proposed actions and inputs, then explicitly confirm the intended steps or cancel.
+Opening Live, sending a message, choosing art, or enabling voice does not approve
+tools. Tool execution remains subject to the server's authentication, policy,
+moderation, and budget checks.
+
+Changing Persona through setup or Live ends the former connection and clears its
+resume selection, transcript, and pending approval view. Choose **Connect** for
+the newly selected Persona. Do not review a different session on the assumption
+that it is the one shown by Buddy.
+
+## Troubleshooting
+
+| Symptom | What to do |
+|---|---|
+| Buddy is absent | Check **Enable persona buddy shell**, desktop width, the selected Persona, active pack, and whether the current surface supports Buddy. |
+| Starter catalog fails | Use **Retry catalog** after checking connectivity and authentication. A retry does not activate anything. |
+| Image fails while text works | Check the visual diagnostic and authenticated pack loading. Confirm the pack is active. Do not make protected assets public as a workaround. |
+| “Visual pack did not load — rate_limited” | Stop repeated reloads and let the limit window recover, then reconnect. Record the session and reproduction steps if it recurs. Reconnection restored the image in UAT, but the repeated-request trigger remains unresolved (TASK-13211). |
+| **Start listening** is unavailable | Connect the intended session and check preparation feedback, the configured Chat target, selected STT/TTS setup, and browser microphone permission. |
+| **Send now** is unavailable | It needs recognized speech in the current listening turn. If you already stopped, sent, or disconnected, start a fresh turn or use text. |
+| Wrong or repeated words | Wait for the provisional text to settle before sending; pause background audio. If wrong, cancel and retry. A successful previous phrase does not guarantee the next one. |
+| No reply or no sound | Read the provider/TTS error and committed transcript. Check browser audio permission, output device, volume, and the selected voice. An audio-chunk notice or animated sprite alone does not prove audible playback. |
+| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
+| Voice prepares but Chat fails | Check the actual Chat error, authenticated access, effective credentials, and budget. Preparation checks the target; Chat admission happens when the turn is submitted. |
+| Shorter-turn or busy notice | Keep the retry under 30 seconds; after Stop, allow the previous decoder's cleanup to finish. |
+| Audio rate limit | The browser stops capture. Wait one minute before retrying **Start listening**, as directed by the notice. Operators should review configured limits rather than bypass them. |
+| Approval appears stuck | Open the exact session in Full Live, inspect the pending request, and confirm or cancel there. |
+
+## Validation status
+
+The guide's initial source check used server `dev` **83af7e5dcf** on
+**2026-09-07**; provider-selection instructions also reflect the TASK-13214
+implementation. This guide consolidates current controls and recorded UAT; it
+does not claim a new physical microphone test or all-provider playback test for
+this documentation update.
+
+- Human UAT verified real provider replies, clear Kokoro output, and stopped
+  recording/playback afterward. Exact recognition varied between attempts.
+- PR #2927 repaired decoding responsiveness, whole-turn revisions, and error
+  handling; 202 targeted Python tests passed and Qodo's findings were resolved.
+- Full request-correlated floating **listening → thinking → speaking → idle**
+  validation remains open under TASK-13202. Repeated visual-pack/session requests
+  reached rate limits in one observation; TASK-13211 tracks the unresolved trigger.
+  A stable idle image after reconnect is not proof that this defect is fixed.
+
+## Related documentation
+
+- [Personas: profiles, sessions, APIs, and voice configuration](../Server/Personas_User_Guide.md)
+- [Persona Live wake phrases](Persona_Live_Wake_Phrases.md)
+- [Persona Visual Packs](../../Code_Documentation/Persona_Visual_Packs.md)
+- [Detailed Migu voice UAT and review evidence](https://github.com/rmusser01/tldw_server/blob/dev/Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md)

--- a/Docs/Published/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
@@ -82,8 +82,16 @@ idle or speaking image alone is not evidence that the provider returned an answe
 Before recording, open **Profiles**, set **STT model** and **TTS provider**, then
 choose **Save assistant defaults**. **TTS model** and **TTS voice** are optional
 overrides: leave them blank to use the selected provider's applicable defaults,
-or enter values that provider supports. Return to the intended Live session and
-check its displayed settings before starting.
+or enter values that provider supports. A blank voice uses the server's configured
+voice when this is its default provider; otherwise the selected adapter supplies
+its own default. Browser-wide voice preferences do not override a blank Persona
+voice. For **browser**, blank selects the browser's native default voice.
+
+If Live is already connected, choose **Disconnect**, then **Connect** after saving.
+A connected session keeps the settings captured when it connected. Returning from
+Profiles or choosing Start again does not apply saved changes. Check Live's TTS
+provider, model selection and voice before starting; “default model” or “default
+voice” means the provider will resolve that omitted value.
 
 Choose **browser** for the browser's speech synthesis, or choose a server TTS
 provider or configured speech gateway from the provider list. A listed provider
@@ -95,14 +103,14 @@ provider shown in Live. See [TTS setup](TTS-SETUP-GUIDE.md) for provider setup.
 
 Persona Live uses the selected route and does not silently switch providers when
 preparation or synthesis fails. Fix the reported setup problem or explicitly
-select another provider. Browser speech requires browser support and an available
+select another provider, save defaults, and reconnect Live. Browser speech requires browser support and an available
 voice; server readiness cannot prove that browser playback will work.
 
 Start with manual control so you decide when recognized speech is submitted:
 
 1. From Buddy, open **Open Full Live View** for the intended session. If the
    session is disconnected, choose **Connect**.
-2. Check the displayed **STT** model/language and **TTS** provider/voice. These
+2. Check the displayed **STT** model/language and **TTS** provider/model/voice. These
    are read-only summaries; correct them under **Profiles** and save the assistant
    defaults if they are wrong.
 3. Leave **Auto-commit**, **Auto-resume**, and **Barge-in** off for the initial
@@ -167,7 +175,7 @@ that it is the one shown by Buddy.
 | **Send now** is unavailable | It needs recognized speech in the current listening turn. If you already stopped, sent, or disconnected, start a fresh turn or use text. |
 | Wrong or repeated words | Wait for the provisional text to settle before sending; pause background audio. If wrong, cancel and retry. A successful previous phrase does not guarantee the next one. |
 | No reply or no sound | Read the provider/TTS error and committed transcript. Check browser audio permission, output device, volume, and the selected voice. An audio-chunk notice or animated sprite alone does not prove audible playback. |
-| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
+| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. After changing saved defaults, choose **Disconnect → Connect** in Live. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
 | Voice prepares but Chat fails | Check the actual Chat error, authenticated access, effective credentials, and budget. Preparation checks the target; Chat admission happens when the turn is submitted. |
 | Shorter-turn or busy notice | Keep the retry under 30 seconds; after Stop, allow the previous decoder's cleanup to finish. |
 | Audio rate limit | The browser stops capture. Wait one minute before retrying **Start listening**, as directed by the notice. Operators should review configured limits rather than bypass them. |

--- a/Docs/Published/User_Guides/WebUI_Extension/User_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/User_Guide.md
@@ -1,5 +1,7 @@
 # tldw_server User Guide
 
+- [Persona Buddy: setup, voice, approvals, and troubleshooting](Persona_Buddy_Guide.md).
+
 This guide shows how to use the Next.js WebUI and API to ingest media, search and retrieve, chat with LLMs, generate embeddings, and run evaluations.
 
 ## Quick Start

--- a/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
+++ b/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
@@ -79,3 +79,39 @@ The broader audio defaults resolver has its own `tldw` alias/default policy;
 Persona deliberately preserves its existing alias instead of silently adopting
 a different provider default. This correction does not redefine other audio
 surfaces or claim a common alias across the server and Chatbook.
+
+## Follow-up review corrections
+
+A second review found four gaps after the initial commit. All four are corrected:
+
+- Blank Persona voices now stay unset in the browser. The server uses the global
+  configured voice only for its configured default provider; other providers
+  retain their own defaults. Explicit voices are preserved. The global `tldw`
+  audio alias does not cause a Kitten voice to cross into legacy Persona Kokoro.
+- Kitten preparation resolves the voice against the loaded runtime. Invalid or
+  stale voices fail before recording, without generating speech.
+- Speech generators close before their credential scope exits, including an
+  error after partial audio. Such errors discard the incomplete output.
+- Both guides and Live itself explain Disconnect → Connect after saving voice
+  defaults. Live displays its current provider, model selection and voice; the
+  Profiles preview labels an omitted voice as Provider default.
+
+The failure-first run reproduced five backend and seven frontend failures. After
+correction, 278 focused Python tests and 116 frontend tests passed. The regressions
+exercise configured/default/explicit voice precedence, cross-provider isolation,
+real Kitten voice resolution with model I/O controlled, generator cleanup order,
+partial-output rejection and cancellation. Bandit found no issues in the changed
+production Python module; targeted Ruff and Black passed. Frontend ESLint found
+zero errors and two existing warnings in unchanged hook dependency code.
+
+Two scoped independent re-reviews reported no residual findings. Both Published
+mirrors match their canonical guides, local links resolve, and MkDocs built with
+the same local serial-plugin workaround. The running browser visibly showed the
+new reconnect guidance and `browser · default model · default voice` summary.
+This follow-up did not open a microphone or repeat physical speech playback.
+
+Logs: `/private/tmp/persona-review-fixes-final-python.log`,
+`/private/tmp/persona-review-fixes-final-frontend.log`,
+`/private/tmp/persona-review-fixes-bandit.json`, and
+`/private/tmp/persona-review-fixes-docs-build.log`. The restarted isolated backend's
+source manifest is under `/private/tmp/persona-review-fixes-20260907/`.

--- a/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
+++ b/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
@@ -115,3 +115,53 @@ Logs: `/private/tmp/persona-review-fixes-final-python.log`,
 `/private/tmp/persona-review-fixes-bandit.json`, and
 `/private/tmp/persona-review-fixes-docs-build.log`. The restarted isolated backend's
 source manifest is under `/private/tmp/persona-review-fixes-20260907/`.
+
+## PR #2928 review and CI corrections
+
+Qodo identified six issues that were corrected:
+
+- Kitten model loads no longer overwrite the cached adapter's configured default
+  model or revision. Later model-less requests retain the configured selection.
+- Public audio health distinguishes an unprepared or failed Kitten runtime from
+  one loaded successfully, while lazy registry initialization remains routable
+  for selected-model preparation without requiring default-model assets.
+- Native browser callbacks carry an utterance generation invalidated before
+  cancellation. Synchronous and delayed callbacks from replaced utterances
+  cannot cancel their replacement or finish its turn.
+- Provider catalog failures are visible and retryable, preserving the selected
+  provider and unsaved form edits. Stale requests cannot replace newer results.
+- The normalization helper and endpoint wrappers have docstrings.
+- Kitten preparation fixtures and tests have explicit parameter and return types.
+
+The seventh finding claimed missing test category markers. The existing
+module-level `pytestmark = pytest.mark.unit` already classifies the file;
+`pytest --collect-only -m unit` selected all 14 current preparation cases.
+
+CI also exposed two integration omissions. The documentation checker treated
+external Chatbook URL paths as local server paths; URL exclusion now preserves
+missing-local-path detection, including repeated local slash separators. The
+OpenAPI fingerprint was regenerated and frontend types rebuilt. Removing only
+the optional `PersonaVoiceDefaults.tts_model` property from the export reproduces
+the old fingerprint, confirming that it is the sole schema change.
+
+Failure-first evidence reproduced six backend and five frontend review failures,
+five initial documentation failures, and one additional repeated-slash local-path
+failure found during independent review. That review found no remaining
+actionable issues after the correction. These tests use controlled runtime/model
+I/O and native speech API doubles; physical microphone/playback UAT was not
+repeated for this review pass.
+
+Final combined checks passed 284 Persona/TTS Python tests and 124 frontend tests.
+Additional scoped adapter/health coverage passed 66 tests (overlapping the
+combined run), and the corrected documentation checker passed all six cases.
+The wider Docs run passed 210 cases; its strict-build subprocess encountered the
+existing local macOS semaphore limit. A separate strict MkDocs build passed using
+the date plugin's supported serial mode. CI remains the check of the unmodified
+parallel build path. Bandit found zero issues across all five production Python
+files changed in this review pass. Scoped lint checks found no new diagnostics.
+OpenAPI drift validation and frontend schema generation passed.
+
+Logs: `/private/tmp/pr2928-final-python.log`,
+`/private/tmp/pr2928-final-frontend.log`, `/private/tmp/pr2928-final-bandit.json`,
+`/private/tmp/pr2928-docs-edge-green.log`, `/private/tmp/pr2928-docs-build.log`,
+and `/private/tmp/pr2928-openapi-check.log`.

--- a/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
+++ b/Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md
@@ -1,0 +1,81 @@
+# Persona TTS provider choice correction — 2026-09-07
+
+Task: TASK-13214. Decision: [preserve provider selection](../../backlog/decisions/004-persona-live-tts-provider-selection.md).
+
+The Migu UAT preparation path incorrectly required Kokoro while Persona offered
+other speech providers. This correction preserves configured provider, optional
+model and voice, uses existing effective audio credential/policy resolution,
+and disables cross-provider fallback. The legacy Persona `tldw` alias remains
+Kokoro for saved-profile compatibility. Browser speech uses native synthesis.
+
+Preparation validates the selected provider request and loads local assets where
+its adapter supports readiness checks. Kitten's cached loader warms the selected
+model without first requiring default-model assets. Preparation does not generate
+speech. Provider clients created for credential overrides are closed on completion,
+validation/init failure, Stop and cancellation; cached local models remain owned
+by the registry. Chat credentials, moderation and budgets remain enforced at the
+existing authenticated Chat dispatch boundary. Preparation checks the Chat target,
+not the availability of a static server API key.
+
+## Verification
+
+- 265 focused Python tests passed: Persona routing/model/voice/readiness/WS,
+  real authenticated Chat admission boundary, credential runtime, Kitten adapter
+  selection and request-adapter lifecycle.
+- 111 focused frontend tests passed: defaults, provider catalog, model transport,
+  browser exceptions and unavailable explicit voices, ownership/Stop and Persona panel localization guards.
+- Initial provider regressions failed on the original restriction; subsequent
+  invalid model/voice and credential-override tests failed before their fixes.
+  Four real-registry Kitten model regressions failed before selected-model loading.
+- Bandit: zero findings across all seven changed production Python files.
+- New Python modules/tests pass targeted Ruff and Black checks. Existing large
+  production files retain baseline formatting/lint debt; no broad reformat was
+  applied. Frontend ESLint: zero errors, 58 pre-existing warnings, matching HEAD.
+- MkDocs build passed with the existing date plugin's parallel processing disabled
+  only for this local build. Canonical/Published guide mirrors match; guide links
+  were checked.
+
+## Real runtime checks
+
+Used isolated source worktree `/private/tmp/tldw-server-migu-buddy-uat`, backend
+on `127.0.0.1:9101`, WebUI on `127.0.0.1:18384`. The backend was restarted from
+the corrected code; its launcher recorded revision, diff and application source
+hashes. Existing normal STT selection was Parakeet ONNX. No configuration secrets
+are included in this record.
+
+1. Real Persona Profiles UI loaded the server provider catalog, selected `browser`,
+   cleared the previous Kokoro voice, and saved assistant defaults successfully.
+2. A real authenticated Persona WebSocket session prepared Parakeet with browser
+   TTS in 0.06 seconds. A controlled committed transcript entered the existing
+   DeepSeek Chat route and returned “Browser speech is working. The blue notebook
+   is ready.” Voice Stop was acknowledged and session Stop returned HTTP 200.
+   No server audio bytes were emitted for the browser provider.
+3. A separate browser harness bundled the production voice controller and used
+   **real native SpeechSynthesis**. Its input/WS boundary was controlled, with no
+   microphone access or Chat call. Native `start` then `end` occurred; controller
+   states were idle → listening → thinking → speaking → idle, with active/ready,
+   native speaking and pending all false afterward. Stop interrupted a second
+   long reply, produced native `error:interrupted`, and left no warning or queued
+   speech. Native synthesis was observed, not replaced with a mock.
+
+Raw local artifacts, harness source and server identity are under
+`/private/tmp/persona-provider-uat-20260907/`. Test logs are
+`/private/tmp/persona-provider-final-python.log`,
+`/private/tmp/persona-provider-final-frontend.log` and
+`/private/tmp/persona-provider-i18n.log`.
+
+## Limits and remaining work
+
+These checks do not establish human audibility, microphone transcription accuracy,
+or a single physical end-to-end voice turn for every provider. OpenAI/ElevenLabs
+and gateway contracts were verified with controlled adapters/credentials, not paid
+remote synthesis calls. Remote provider readiness may still fail at actual
+synthesis. A configured native browser voice that is not in the current voice
+list fails clearly instead of substituting another voice; retry after browser
+voices load or choose an installed voice. Floating Buddy animation qualification and previously tracked voice
+responsiveness follow-ups remain separate.
+
+The broader audio defaults resolver has its own `tldw` alias/default policy;
+Persona deliberately preserves its existing alias instead of silently adopting
+a different provider default. This correction does not redefine other audio
+surfaces or claim a common alias across the server and Chatbook.

--- a/Docs/User_Guides/Server/Personas_User_Guide.md
+++ b/Docs/User_Guides/Server/Personas_User_Guide.md
@@ -256,8 +256,17 @@ then **Start listening**. Preparation checks the configured Chat target and
 prepares the selected STT and TTS services before the browser requests microphone
 access. Under **Profiles**, choose **TTS provider**, optionally set **TTS model**
 and **TTS voice**, and choose **Save assistant defaults**. Blank model and voice
-fields use the selected provider's applicable defaults. The Live STT/TTS summaries
-show the effective settings; change saved selections under Profiles.
+fields use the selected provider's applicable defaults. A blank voice uses the
+server's configured voice only when the selected provider is its default provider;
+otherwise the selected adapter resolves its default. Browser-wide voice preferences
+do not override a blank Persona voice. The **browser** provider uses its native
+default voice when this field is blank.
+
+After saving changes, choose **Disconnect → Connect** if Live was connected.
+Connected sessions keep their original voice settings until reconnect; returning
+from Profiles or retrying Start does not refresh them. Live shows the provider,
+model selection and voice for the current connection. A “default model” or
+“default voice” label leaves that value for the provider to resolve.
 
 The provider list includes **browser**, registered server providers, and configured
 speech gateways. Browser speech uses the browser's speech synthesis and available

--- a/Docs/User_Guides/Server/Personas_User_Guide.md
+++ b/Docs/User_Guides/Server/Personas_User_Guide.md
@@ -1,6 +1,8 @@
 # Personas User Guide
 
-Last Updated: 2026-06-01
+For a step-by-step browser walkthrough, see the [Persona Buddy guide](../WebUI_Extension/Persona_Buddy_Guide.md): setup, Migu, dragging, live voice, approvals, and troubleshooting.
+
+Last Updated: 2026-09-07
 
 ## Overview
 
@@ -247,23 +249,44 @@ Common server events include:
 The stream enforces feature flags, authentication, policy checks, tool
 confirmation, audio limits, and rate limits.
 
-### Preparing local voice
+### Preparing voice with the selected provider
 
-Open the exact Buddy session in Full Live and choose Start. Preparation checks
-the configured Chat provider and initializes the selected STT and TTS models
-before the browser requests microphone access. The initial qualified speech path
-uses local Whisper and Kokoro. Other selections return setup feedback when they
-cannot be prepared; no substitute transcript or audio is generated.
+Open the exact Buddy session in Full Live, choose **Connect** if needed, and
+then **Start listening**. Preparation checks the configured Chat target and
+prepares the selected STT and TTS services before the browser requests microphone
+access. Under **Profiles**, choose **TTS provider**, optionally set **TTS model**
+and **TTS voice**, and choose **Save assistant defaults**. Blank model and voice
+fields use the selected provider's applicable defaults. The Live STT/TTS summaries
+show the effective settings; change saved selections under Profiles.
+
+The provider list includes **browser**, registered server providers, and configured
+speech gateways. Browser speech uses the browser's speech synthesis and available
+voices. Local server providers need their models, voice assets, and dependencies;
+remote providers and gateways need the appropriate configuration and credentials.
+The legacy Persona **tldw** value remains an alias for **kokoro**. Kokoro is an
+available provider, not a prerequisite for every Persona voice session.
+**Use browser fallback** inherits the browser-wide provider preference rather than
+forcing browser speech. Persona Live does not silently switch providers on
+preparation or synthesis failure. See [TTS setup](../WebUI_Extension/TTS-SETUP-GUIDE.md).
+
+Recorded physical tests used Parakeet ONNX and Kokoro; Whisper was also tested.
+These are historical test choices, not qualification of every provider or browser
+voice. A failed preparation returns setup feedback; no substitute transcript or
+audio is generated. Browser speech support and audible playback must be checked
+in the browser itself.
 
 WebSocket clients send `voice_config`, then `voice_prepare` with a unique
-`client_message_id`. Wait for the matching `voice_readiness` event. Supply a
-supported Whisper model size (for example `tiny.en`) and `tts.provider` set to
-`kokoro` (or its `tldw` alias). The server must have the selected models and a
-usable default Chat provider with server-configured credentials. This preparation
-check does not yet qualify user/team/organization BYOK credentials for voice.
-A failed preparation does not authorize
-capture. The WebUI cancels a preparation that exceeds its 30-second wait and
-offers retry guidance.
+`client_message_id`. Wait for the matching `voice_readiness` event. For STT,
+use a supported selected model such as `tiny.en` for Whisper or `parakeet-onnx`
+for Parakeet ONNX. Set `tts.provider` to `browser`, a registered server provider,
+or a configured speech gateway ID; optional `tts.model` and `tts.voice` select
+provider-supported values. The server must have the selected local models and a
+configured default Chat provider/model. Preparation resolves the Chat target;
+it does not require a server-static Chat key or certify Chat admission. Each
+submitted turn enters the authenticated Chat route, which resolves effective
+credentials (including applicable BYOK) and enforces access policy, moderation,
+and budget. A failed preparation does not authorize capture. The WebUI cancels
+a preparation that exceeds its 30-second wait and offers retry guidance.
 
 Voice readiness belongs to the connection and session. Session summaries report
 `capabilities.voice=true` only while an owned runtime is prepared. Stop, changes
@@ -473,4 +496,4 @@ until cleanup completes. Stop always discards its late transcript.
 
 Changing Persona through setup or Live ends the former connection and clears its resume selection, transcript and pending approvals. Use **Connect** to begin a session for the newly selected Persona. Previously saved setup and voice defaults remain available.
 
-Use **Refresh catalog** to reload bundled Buddy choices. If loading fails, **Retry catalog** repeats the read without copying, activating, or replacing the current pack. The button is disabled during the request. Voice preparation currently requires server-configured credentials for the default Chat provider; user/team/organization BYOK-only credentials are not qualified by this voice preflight.
+Use **Refresh catalog** to reload bundled Buddy choices. If loading fails, **Retry catalog** repeats the read without copying, activating, or replacing the current pack. The button is disabled during the request. If voice prepares but a submitted turn fails, read the Chat error and check authenticated access, effective credentials, and budget; preparation alone does not certify Chat admission.

--- a/Docs/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
@@ -1,0 +1,198 @@
+# Persona Buddy — setup, live voice, approvals, and troubleshooting
+
+Persona Buddy is the floating companion on supported Persona-aware WebUI and
+extension surfaces. It displays a Persona's active visual pack and provides a
+small entry point for text sessions, feedback, and navigation to the full Live
+session. The full Live view owns microphone capture, playback, and plan review.
+
+This guide covers the **server-backed browser experience**. For the terminal
+application, see the [Chatbook user guide](https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/User_Guide/index.md).
+The two apps have different selection and voice controls.
+
+## Before you start
+
+- Run the server and WebUI, connect the WebUI to that server, and authenticate.
+  Follow [Quickstart](../../Getting_Started/QUICKSTART.md) or your deployment's
+  existing setup instructions.
+- Make sure the server exposes Persona features and you can open **Persona
+  Garden** at `/persona`.
+- For conversation, configure the server's default Chat provider and model.
+  Voice preparation checks that target; each submitted turn then uses the
+  authenticated Chat route, which checks effective credentials (including
+  applicable BYOK), access policy, moderation, and budget. Preparation alone
+  does not certify that a Chat request will succeed.
+- For voice, install the selected speech-to-text model and choose a TTS provider
+  under **Profiles**. Use browser speech, a registered server provider, or a
+  configured speech gateway. Local providers need their model assets and
+  dependencies; remote providers and gateways need their endpoint and credentials.
+- In **Settings → UI customization**, enable **Enable persona buddy shell**.
+  Use a desktop-width WebUI window: the full WebUI hides the floating shell at
+  narrow widths. The extension sidepanel has its own supported layout.
+
+Art selection alone does not start a microphone, configure a provider, or grant
+tool permission. Keep using the authenticated WebUI for protected visual assets;
+a copied asset URL may require the same authentication.
+
+## Choose Migu or another visual pack
+
+1. Open **Persona Garden** and select or create the Persona you want to use.
+2. Open the **Visuals** tab. In **Buddy builder**, select **Bundled Buddy**.
+3. Find **pixel-migu** and click **Copy as draft** on that entry.
+   **pixel-migu** and **Migu Marker Basic** are separate choices; availability
+   depends on your server's catalog.
+4. Check **Review draft readiness** and **Draft preview**. Resolve any listed
+   blockers, then choose **Continue to activation**.
+5. Choose **Activate** under **Validation and activation** when you want the
+   copied pack to become the Persona's active visual pack.
+6. Return to the supported Persona surface and check the floating image.
+
+You can also import a portable pack through the preview/review flow. Copying,
+previewing, and importing are separate from activation; do not assume the active
+art has changed until activation succeeds. **Refresh catalog** reloads the
+starter choices. If it fails, **Retry catalog** retries that read without copying
+or activating a pack.
+
+The server's Migu UAT used a selected Persona and activated Migu pack. It does
+not establish that every existing account already contains that Persona. Your
+catalog, saved names, and active pack can differ.
+
+## Open, move, and send a text message
+
+Click the floating Buddy to expand or collapse its controls. Use **Drag Buddy**
+to move the floating panel; dragging the image is not the documented drag handle.
+The shell keeps position preferences for its surface and constrains placement to
+the viewport. Do not apply Chatbook's terminal resize keys to this browser shell.
+
+| Control or feedback | What it does |
+|---|---|
+| **Start** | Starts a text session for the selected Persona. This is not microphone Start. |
+| Session selection | Chooses the Live session shown in the shell. Check the session before sending or stopping. |
+| **Message your buddy** → **Send** | Sends text to the current session, starting an eligible text session when needed. |
+| Feedback area | Shows message outcomes, replies, errors, or a need for review. |
+| **Stop** | Stops the selected session's work. Already-dispatched provider work may finish remotely, but stopped output must not restart local playback. |
+| **Open Full Live View** | Opens the corresponding Persona/session for the transcript, voice, and review controls. |
+| **Set up voice**, **Listen**, or **Stop listening** | Opens that session's Live view. The label reflects availability/activity; microphone control happens in Live. |
+
+For a first text test, send a short request such as “Reply with: the blue notebook
+is ready.” Check the actual reply in the feedback area or full transcript. An
+idle or speaking image alone is not evidence that the provider returned an answer.
+
+## Make one voice turn
+
+Before recording, open **Profiles**, set **STT model** and **TTS provider**, then
+choose **Save assistant defaults**. **TTS model** and **TTS voice** are optional
+overrides: leave them blank to use the selected provider's applicable defaults,
+or enter values that provider supports. Return to the intended Live session and
+check its displayed settings before starting.
+
+Choose **browser** for the browser's speech synthesis, or choose a server TTS
+provider or configured speech gateway from the provider list. A listed provider
+still needs its required setup. For example, **kokoro** needs local model and
+voice assets; it is one option, not a requirement. The legacy Persona value
+**tldw** continues to select Kokoro. **Use browser fallback** inherits the
+browser-wide TTS preference; it does not force browser speech. Check the effective
+provider shown in Live. See [TTS setup](TTS-SETUP-GUIDE.md) for provider setup.
+
+Persona Live uses the selected route and does not silently switch providers when
+preparation or synthesis fails. Fix the reported setup problem or explicitly
+select another provider. Browser speech requires browser support and an available
+voice; server readiness cannot prove that browser playback will work.
+
+Start with manual control so you decide when recognized speech is submitted:
+
+1. From Buddy, open **Open Full Live View** for the intended session. If the
+   session is disconnected, choose **Connect**.
+2. Check the displayed **STT** model/language and **TTS** provider/voice. These
+   are read-only summaries; correct them under **Profiles** and save the assistant
+   defaults if they are wrong.
+3. Leave **Auto-commit**, **Auto-resume**, and **Barge-in** off for the initial
+   test. Pause background narration or other audio.
+4. Choose **Start listening**. Wait for preparation and the **listening** state,
+   and allow browser microphone access when requested. Do not speak while the
+   runtime is still preparing.
+5. Say one short phrase. Watch **Last heard**: these are provisional words and
+   may change as recognition receives more audio.
+6. While the turn is still listening and recognized speech is present, choose
+   **Send now**. This submits the transcript currently shown, once.
+7. Read the committed transcript and reply, listen for playback, and check that
+   Live returns to **idle**. With Auto-resume off, a new recording requires a
+   fresh **Start listening**. Choose **Disconnect** when finished.
+
+**Send now submits; Stop voice cancels.** Do not click **Stop voice** and then
+expect **Send now** to submit the cancelled recording. Last heard can remain
+visible after Stop, completion, or disconnect while Send now is disabled. If
+recognition is wrong, cancel and retry, or type the intended message in the text
+composer. Last heard is not an editable draft like Chatbook dictation.
+
+Keep a Persona voice turn within **30 seconds, including silence**. Whisper and
+Parakeet ONNX revise the complete bounded turn rather than appending stale chunk
+guesses. This reduces repeated fragments; it does not guarantee correct speech
+recognition. Automatic turn detection, when enabled, waits for recognition through
+the detected speech boundary. Manual Send now uses the currently displayed text.
+
+Stop invalidates late recognition and playback. A native decoder can still be
+finishing in the background; a quick retry may report busy until cleanup completes.
+Known Parakeet decoder error statuses produce speech failure feedback instead of
+being presented as words.
+
+The September 6 physical tests used normal server Parakeet ONNX configuration,
+DeepSeek conversation, and local Kokoro output. Whisper was also tested for the
+responsiveness repair. These are historical test choices, not required providers
+or universal defaults. They do not qualify every TTS provider, gateway, browser
+voice, or a separate realtime provider connection.
+
+## Review approvals in the exact session
+
+When Buddy shows **Needs approval** or review feedback, open **Open Full Live
+View** and inspect the pending plan or tool request in that session. Check the
+proposed actions and inputs, then explicitly confirm the intended steps or cancel.
+Opening Live, sending a message, choosing art, or enabling voice does not approve
+tools. Tool execution remains subject to the server's authentication, policy,
+moderation, and budget checks.
+
+Changing Persona through setup or Live ends the former connection and clears its
+resume selection, transcript, and pending approval view. Choose **Connect** for
+the newly selected Persona. Do not review a different session on the assumption
+that it is the one shown by Buddy.
+
+## Troubleshooting
+
+| Symptom | What to do |
+|---|---|
+| Buddy is absent | Check **Enable persona buddy shell**, desktop width, the selected Persona, active pack, and whether the current surface supports Buddy. |
+| Starter catalog fails | Use **Retry catalog** after checking connectivity and authentication. A retry does not activate anything. |
+| Image fails while text works | Check the visual diagnostic and authenticated pack loading. Confirm the pack is active. Do not make protected assets public as a workaround. |
+| “Visual pack did not load — rate_limited” | Stop repeated reloads and let the limit window recover, then reconnect. Record the session and reproduction steps if it recurs. Reconnection restored the image in UAT, but the repeated-request trigger remains unresolved (TASK-13211). |
+| **Start listening** is unavailable | Connect the intended session and check preparation feedback, the configured Chat target, selected STT/TTS setup, and browser microphone permission. |
+| **Send now** is unavailable | It needs recognized speech in the current listening turn. If you already stopped, sent, or disconnected, start a fresh turn or use text. |
+| Wrong or repeated words | Wait for the provisional text to settle before sending; pause background audio. If wrong, cancel and retry. A successful previous phrase does not guarantee the next one. |
+| No reply or no sound | Read the provider/TTS error and committed transcript. Check browser audio permission, output device, volume, and the selected voice. An audio-chunk notice or animated sprite alone does not prove audible playback. |
+| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
+| Voice prepares but Chat fails | Check the actual Chat error, authenticated access, effective credentials, and budget. Preparation checks the target; Chat admission happens when the turn is submitted. |
+| Shorter-turn or busy notice | Keep the retry under 30 seconds; after Stop, allow the previous decoder's cleanup to finish. |
+| Audio rate limit | The browser stops capture. Wait one minute before retrying **Start listening**, as directed by the notice. Operators should review configured limits rather than bypass them. |
+| Approval appears stuck | Open the exact session in Full Live, inspect the pending request, and confirm or cancel there. |
+
+## Validation status
+
+The guide's initial source check used server `dev` **83af7e5dcf** on
+**2026-09-07**; provider-selection instructions also reflect the TASK-13214
+implementation. This guide consolidates current controls and recorded UAT; it
+does not claim a new physical microphone test or all-provider playback test for
+this documentation update.
+
+- Human UAT verified real provider replies, clear Kokoro output, and stopped
+  recording/playback afterward. Exact recognition varied between attempts.
+- PR #2927 repaired decoding responsiveness, whole-turn revisions, and error
+  handling; 202 targeted Python tests passed and Qodo's findings were resolved.
+- Full request-correlated floating **listening → thinking → speaking → idle**
+  validation remains open under TASK-13202. Repeated visual-pack/session requests
+  reached rate limits in one observation; TASK-13211 tracks the unresolved trigger.
+  A stable idle image after reconnect is not proof that this defect is fixed.
+
+## Related documentation
+
+- [Personas: profiles, sessions, APIs, and voice configuration](../Server/Personas_User_Guide.md)
+- [Persona Live wake phrases](Persona_Live_Wake_Phrases.md)
+- [Persona Visual Packs](../../Code_Documentation/Persona_Visual_Packs.md)
+- [Detailed Migu voice UAT and review evidence](https://github.com/rmusser01/tldw_server/blob/dev/Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md)

--- a/Docs/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
@@ -82,8 +82,16 @@ idle or speaking image alone is not evidence that the provider returned an answe
 Before recording, open **Profiles**, set **STT model** and **TTS provider**, then
 choose **Save assistant defaults**. **TTS model** and **TTS voice** are optional
 overrides: leave them blank to use the selected provider's applicable defaults,
-or enter values that provider supports. Return to the intended Live session and
-check its displayed settings before starting.
+or enter values that provider supports. A blank voice uses the server's configured
+voice when this is its default provider; otherwise the selected adapter supplies
+its own default. Browser-wide voice preferences do not override a blank Persona
+voice. For **browser**, blank selects the browser's native default voice.
+
+If Live is already connected, choose **Disconnect**, then **Connect** after saving.
+A connected session keeps the settings captured when it connected. Returning from
+Profiles or choosing Start again does not apply saved changes. Check Live's TTS
+provider, model selection and voice before starting; “default model” or “default
+voice” means the provider will resolve that omitted value.
 
 Choose **browser** for the browser's speech synthesis, or choose a server TTS
 provider or configured speech gateway from the provider list. A listed provider
@@ -95,14 +103,14 @@ provider shown in Live. See [TTS setup](TTS-SETUP-GUIDE.md) for provider setup.
 
 Persona Live uses the selected route and does not silently switch providers when
 preparation or synthesis fails. Fix the reported setup problem or explicitly
-select another provider. Browser speech requires browser support and an available
+select another provider, save defaults, and reconnect Live. Browser speech requires browser support and an available
 voice; server readiness cannot prove that browser playback will work.
 
 Start with manual control so you decide when recognized speech is submitted:
 
 1. From Buddy, open **Open Full Live View** for the intended session. If the
    session is disconnected, choose **Connect**.
-2. Check the displayed **STT** model/language and **TTS** provider/voice. These
+2. Check the displayed **STT** model/language and **TTS** provider/model/voice. These
    are read-only summaries; correct them under **Profiles** and save the assistant
    defaults if they are wrong.
 3. Leave **Auto-commit**, **Auto-resume**, and **Barge-in** off for the initial
@@ -167,7 +175,7 @@ that it is the one shown by Buddy.
 | **Send now** is unavailable | It needs recognized speech in the current listening turn. If you already stopped, sent, or disconnected, start a fresh turn or use text. |
 | Wrong or repeated words | Wait for the provisional text to settle before sending; pause background audio. If wrong, cancel and retry. A successful previous phrase does not guarantee the next one. |
 | No reply or no sound | Read the provider/TTS error and committed transcript. Check browser audio permission, output device, volume, and the selected voice. An audio-chunk notice or animated sprite alone does not prove audible playback. |
-| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
+| Selected TTS provider fails | Check that provider's model, voice, dependencies or credentials. After changing saved defaults, choose **Disconnect → Connect** in Live. For a gateway, check its configured route. Persona Live does not silently substitute Kokoro or another provider. |
 | Voice prepares but Chat fails | Check the actual Chat error, authenticated access, effective credentials, and budget. Preparation checks the target; Chat admission happens when the turn is submitted. |
 | Shorter-turn or busy notice | Keep the retry under 30 seconds; after Stop, allow the previous decoder's cleanup to finish. |
 | Audio rate limit | The browser stops capture. Wait one minute before retrying **Start listening**, as directed by the notice. Operators should review configured limits rather than bypass them. |

--- a/Docs/User_Guides/WebUI_Extension/User_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/User_Guide.md
@@ -1,5 +1,7 @@
 # tldw_server User Guide
 
+- [Persona Buddy: setup, voice, approvals, and troubleshooting](Persona_Buddy_Guide.md).
+
 This guide shows how to use the Next.js WebUI and API to ingest media, search and retrieve, chat with LLMs, generate embeddings, and run evaluations.
 
 ## Quick Start

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
           - Advanced Character Roleplay: User_Guides/WebUI_Extension/Advanced_Character_Roleplay_Guide.md
           - Character Cards: User_Guides/Server/Character_Cards_User_Guide.md
           - Personas: User_Guides/Server/Personas_User_Guide.md
+          - Persona Buddy: User_Guides/WebUI_Extension/Persona_Buddy_Guide.md
           - Prompt Engineering Notes: User_Guides/WebUI_Extension/Prompt_Engineering_Notes.md
       - Knowledge and Research:
           - Feature Map: User_Guides/Feature_Map.md

--- a/Helper_Scripts/docs/check_top_guides_docs_path_hygiene.py
+++ b/Helper_Scripts/docs/check_top_guides_docs_path_hygiene.py
@@ -30,9 +30,11 @@ GUIDE_FILES = (
     REPO_ROOT / "Docs/STT-TTS/QWEN3_TTS_SETUP.md",
 )
 DOC_PATH_PATTERN = re.compile(r"Docs/[A-Za-z0-9_./-]+")
+EXTERNAL_URL_PATTERN = re.compile(r"(?<![A-Za-z0-9_./-])(?:https?:)?//[^\s<>\[\]()`\"']+", re.IGNORECASE)
 
 
 def _collect_missing_paths() -> list[tuple[str, str]]:
+    """Collect missing local paths without treating remote URL paths as local."""
     missing: list[tuple[str, str]] = []
     markdown_files: list[Path] = []
     for root in GUIDE_DIRS:
@@ -44,7 +46,7 @@ def _collect_missing_paths() -> list[tuple[str, str]]:
             markdown_files.append(guide_file)
 
     for guide_file in markdown_files:
-        text = guide_file.read_text(encoding="utf-8")
+        text = EXTERNAL_URL_PATTERN.sub("", guide_file.read_text(encoding="utf-8"))
         for match in DOC_PATH_PATTERN.finditer(text):
             raw_path = match.group(0).rstrip("`),.:;")
             candidate = REPO_ROOT / raw_path
@@ -54,6 +56,7 @@ def _collect_missing_paths() -> list[tuple[str, str]]:
 
 
 def main() -> int:
+    """Report broken repository paths and return a failing exit code if any exist."""
     missing = _collect_missing_paths()
     if missing:
         print("Top guide docs reference missing paths:")

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/hooks/useResolvedPersonaVoiceDefaults"
 import type { PersonaProfileResponse } from "@/routes/personaTypes"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { fetchTtsProviders } from "@/services/tldw/audio-providers"
 import { toAllowedPath } from "@/services/tldw/path-utils"
 
 type AssistantDefaultsPanelProps = {
@@ -40,6 +41,7 @@ type AssistantDefaultsFormState = {
   sttLanguage: string
   sttModel: string
   ttsProvider: string
+  ttsModel: string
   ttsVoice: string
   confirmationMode: PersonaConfirmationMode
   wakeBehavior: PersonaWakeBehavior
@@ -57,6 +59,7 @@ const DEFAULT_FORM_STATE: AssistantDefaultsFormState = {
   sttLanguage: "",
   sttModel: "",
   ttsProvider: "",
+  ttsModel: "",
   ttsVoice: "",
   confirmationMode: "destructive_only",
   wakeBehavior: "one_shot",
@@ -92,6 +95,7 @@ const buildFormState = (
   sttLanguage: normalizeText(voiceDefaults?.stt_language),
   sttModel: normalizeText(voiceDefaults?.stt_model),
   ttsProvider: normalizeText(voiceDefaults?.tts_provider),
+  ttsModel: normalizeText(voiceDefaults?.tts_model),
   ttsVoice: normalizeText(voiceDefaults?.tts_voice),
   confirmationMode: voiceDefaults?.confirmation_mode || "destructive_only",
   wakeBehavior: voiceDefaults?.wake_behavior || "one_shot",
@@ -130,6 +134,7 @@ const buildPayload = (
   stt_language: normalizeText(formState.sttLanguage) || null,
   stt_model: normalizeText(formState.sttModel) || null,
   tts_provider: normalizeText(formState.ttsProvider) || null,
+  tts_model: normalizeText(formState.ttsModel) || null,
   tts_voice: normalizeText(formState.ttsVoice) || null,
   confirmation_mode: formState.confirmationMode,
   wake_behavior: formState.wakeBehavior,
@@ -176,6 +181,28 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
   const sttLanguageInputRef = React.useRef<HTMLInputElement | null>(null)
   const confirmationModeRef = React.useRef<HTMLSelectElement | null>(null)
   const lastHandledHandoffTokenRef = React.useRef<number | null>(null)
+
+  const [serverProviders, setServerProviders] = React.useState<string[]>([])
+  React.useEffect(() => {
+    if (!isActive || !selectedPersonaId) return
+    let cancelled = false
+    void fetchTtsProviders().then((catalog) => {
+      if (!cancelled) setServerProviders(Object.keys(catalog?.providers || {}))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isActive, selectedPersonaId])
+  const ttsProviderOptions = Array.from(
+    new Set([
+      "browser",
+      "tldw",
+      "openai",
+      "elevenlabs",
+      ...serverProviders,
+      ...(formState.ttsProvider ? [formState.ttsProvider] : [])
+    ])
+  )
 
   const saveGenerationRef = React.useRef(0)
 
@@ -438,11 +465,27 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
                 defaultValue: "Use browser fallback"
               })}
             </option>
-            <option value="browser">browser</option>
-            <option value="tldw">tldw</option>
-            <option value="openai">openai</option>
-            <option value="elevenlabs">elevenlabs</option>
+            {ttsProviderOptions.map((provider) => (
+              <option key={provider} value={provider}>
+                {provider}
+              </option>
+            ))}
           </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm text-text">
+          <span>
+            {t("sidepanel:personaGarden.profile.assistantDefaults.ttsModel", {
+              defaultValue: "TTS model"
+            })}
+          </span>
+          <input
+            id="persona-assistant-defaults-tts-model"
+            className="rounded-md border border-border bg-surface2 px-3 py-2 text-sm text-text"
+            value={formState.ttsModel}
+            onChange={(event) => updateField("ttsModel", event.target.value)}
+            disabled={!selectedPersonaId || loading || saving}
+          />
         </label>
 
         <label className="flex flex-col gap-1 text-sm text-text">
@@ -641,6 +684,10 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           <div>
             <dt className="text-xs text-text-muted">TTS provider</dt>
             <dd>{resolvedDefaults.ttsProvider || "unset"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-text-muted">TTS model</dt>
+            <dd>{resolvedDefaults.ttsModel || "Server default"}</dd>
           </div>
           <div>
             <dt className="text-xs text-text-muted">TTS voice</dt>

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -183,16 +183,34 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
   const lastHandledHandoffTokenRef = React.useRef<number | null>(null)
 
   const [serverProviders, setServerProviders] = React.useState<string[]>([])
+  const [providerCatalogFailed, setProviderCatalogFailed] = React.useState(false)
+  const [providerCatalogLoading, setProviderCatalogLoading] = React.useState(false)
+  const [providerCatalogRetry, setProviderCatalogRetry] = React.useState(0)
   React.useEffect(() => {
     if (!isActive || !selectedPersonaId) return
     let cancelled = false
-    void fetchTtsProviders().then((catalog) => {
-      if (!cancelled) setServerProviders(Object.keys(catalog?.providers || {}))
-    })
+    setProviderCatalogLoading(true)
+    const loadProviders = async () => {
+      try {
+        const catalog = await fetchTtsProviders({ throwOnError: true })
+        if (cancelled) return
+        if (!catalog) {
+          setProviderCatalogFailed(true)
+          return
+        }
+        setServerProviders(Object.keys(catalog.providers))
+        setProviderCatalogFailed(false)
+      } catch {
+        if (!cancelled) setProviderCatalogFailed(true)
+      } finally {
+        if (!cancelled) setProviderCatalogLoading(false)
+      }
+    }
+    void loadProviders()
     return () => {
       cancelled = true
     }
-  }, [isActive, selectedPersonaId])
+  }, [isActive, selectedPersonaId, providerCatalogRetry])
   const ttsProviderOptions = Array.from(
     new Set([
       "browser",
@@ -412,6 +430,24 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
       {success ? (
         <div className="mt-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
           {success}
+        </div>
+      ) : null}
+
+      {isActive && selectedPersonaId && providerCatalogFailed ? (
+        <div role="alert" className="mt-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-text">
+          <p>
+            {t("sidepanel:personaGarden.profile.assistantDefaults.providerCatalogError", {
+              defaultValue: "Unable to load server speech providers. Available options may be incomplete. Your selected provider is preserved."
+            })}
+          </p>
+          <button
+            type="button"
+            className="mt-2 rounded-md border border-border px-3 py-1 disabled:opacity-60"
+            disabled={providerCatalogLoading}
+            onClick={() => setProviderCatalogRetry((current) => current + 1)}
+          >
+            {t("common:retry", { defaultValue: "Retry" })}
+          </button>
         </div>
       ) : null}
 

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -691,7 +691,7 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           </div>
           <div>
             <dt className="text-xs text-text-muted">TTS voice</dt>
-            <dd>{resolvedDefaults.ttsVoice || "unset"}</dd>
+            <dd>{resolvedDefaults.ttsVoice || "Provider default"}</dd>
           </div>
           <div>
             <dt className="text-xs text-text-muted">Confirmation mode</dt>

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
@@ -168,8 +168,8 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
         <div>
           <Typography.Text strong>Assistant Voice</Typography.Text>
           <Typography.Text type="secondary" className="mt-1 block text-xs">
-            Saved defaults live under Profiles. The toggles here only affect this live
-            session.
+            Save voice defaults under Profiles, then disconnect and reconnect Live to apply changes.
+            The toggles here only affect this live session.
           </Typography.Text>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -207,7 +207,7 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
         </div>
         <div className="rounded border border-border bg-surface2 px-2 py-1.5">
           <div className="text-text-muted">TTS</div>
-          <div className="mt-1">{`${resolvedDefaults.ttsProvider} · ${resolvedDefaults.ttsVoice || "default voice"}`}</div>
+          <div className="mt-1">{`${resolvedDefaults.ttsProvider} · ${resolvedDefaults.ttsModel || "default model"} · ${resolvedDefaults.ttsVoice || "default voice"}`}</div>
         </div>
         <div className="rounded border border-border bg-surface2 px-2 py-1.5">
           <div className="text-text-muted">Live status</div>

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   fetchWithAuth: vi.fn(),
-  fetchTtsProviders: vi.fn(),
+  bgRequestClient: vi.fn(),
   resolvedDefaults: {
     sttLanguage: "en-US",
     sttModel: "parakeet",
@@ -23,8 +23,8 @@ const mocks = vi.hoisted(() => ({
   }
 }))
 
-vi.mock("@/services/tldw/audio-providers", () => ({
-  fetchTtsProviders: mocks.fetchTtsProviders
+vi.mock("@/services/background-proxy", () => ({
+  bgRequestClient: mocks.bgRequestClient
 }))
 
 vi.mock("react-i18next", () => ({
@@ -213,7 +213,7 @@ describe("AssistantDefaultsPanel", () => {
       configurable: true,
       value: vi.fn()
     })
-    mocks.fetchTtsProviders.mockResolvedValue({ providers: { piper: {} } })
+    mocks.bgRequestClient.mockReset().mockResolvedValue({ providers: { piper: {} } })
     mocks.fetchWithAuth.mockReset()
     mocks.resolvedDefaults = {
       sttLanguage: "en-US",
@@ -279,6 +279,64 @@ describe("AssistantDefaultsPanel", () => {
       })
     })
   })
+
+  it.each(["empty catalog", "request error"])(
+    "recovers from %s without resetting saved or edited defaults",
+    async (failure) => {
+      if (failure === "request error") {
+        mocks.bgRequestClient.mockRejectedValueOnce(new Error("network unavailable"))
+      } else {
+        mocks.bgRequestClient.mockResolvedValueOnce(null)
+      }
+      let resolveRetry!: (value: unknown) => void
+      mocks.bgRequestClient.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveRetry = resolve
+      }))
+      mocks.fetchWithAuth.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "persona-1",
+          voice_defaults: { tts_provider: "custom-server", tts_model: "saved-model" }
+        })
+      })
+      render(<AssistantDefaultsPanel selectedPersonaId="persona-1" selectedPersonaName="Helper" isActive />)
+      await waitFor(() => expect(screen.getByLabelText("TTS provider")).toHaveValue("custom-server"))
+      expect(screen.getByRole("alert")).toHaveTextContent(/unable to load.*speech providers/i)
+      fireEvent.change(screen.getByLabelText("TTS model"), { target: { value: "edited-model" } })
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }))
+      expect(screen.getByRole("button", { name: /retry/i })).toBeDisabled()
+      await act(async () => resolveRetry({ providers: { piper: {} } }))
+      expect(screen.getByRole("option", { name: "piper" })).toBeInTheDocument()
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+      expect(screen.getByLabelText("TTS provider")).toHaveValue("custom-server")
+      expect(screen.getByLabelText("TTS model")).toHaveValue("edited-model")
+    }
+  )
+
+  it.each(["success", "failure"])(
+    "ignores a stale catalog %s after the panel reopens",
+    async (completion) => {
+      let resolveOld!: (value: unknown) => void
+      let rejectOld!: (error: Error) => void
+      mocks.bgRequestClient.mockImplementationOnce(() => new Promise((resolve, reject) => {
+        resolveOld = resolve
+        rejectOld = reject
+      }))
+      const { rerender } = render(
+        <AssistantDefaultsPanel selectedPersonaId="persona-1" selectedPersonaName="Helper" isActive />
+      )
+      rerender(<AssistantDefaultsPanel selectedPersonaId="persona-1" selectedPersonaName="Helper" isActive={false} />)
+      rerender(<AssistantDefaultsPanel selectedPersonaId="persona-1" selectedPersonaName="Helper" isActive />)
+      await waitFor(() => expect(screen.getByRole("option", { name: "piper" })).toBeInTheDocument())
+      await act(async () => {
+        if (completion === "success") resolveOld({ providers: { "stale-provider": {} } })
+        else rejectOld(new Error("old request failed"))
+      })
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+      expect(screen.queryByRole("option", { name: "stale-provider" })).not.toBeInTheDocument()
+      expect(screen.getByRole("option", { name: "piper" })).toBeInTheDocument()
+    }
+  )
 
   it("offers server providers and preserves a saved provider absent from the catalog", async () => {
     mocks.fetchWithAuth.mockResolvedValueOnce({

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   fetchWithAuth: vi.fn(),
+  fetchTtsProviders: vi.fn(),
   resolvedDefaults: {
     sttLanguage: "en-US",
     sttModel: "parakeet",
@@ -20,6 +21,10 @@ const mocks = vi.hoisted(() => ({
     turnStopSecs: 0.2,
     minUtteranceSecs: 0.4
   }
+}))
+
+vi.mock("@/services/tldw/audio-providers", () => ({
+  fetchTtsProviders: mocks.fetchTtsProviders
 }))
 
 vi.mock("react-i18next", () => ({
@@ -208,6 +213,7 @@ describe("AssistantDefaultsPanel", () => {
       configurable: true,
       value: vi.fn()
     })
+    mocks.fetchTtsProviders.mockResolvedValue({ providers: { piper: {} } })
     mocks.fetchWithAuth.mockReset()
     mocks.resolvedDefaults = {
       sttLanguage: "en-US",
@@ -272,6 +278,54 @@ describe("AssistantDefaultsPanel", () => {
         json: async () => ({})
       })
     })
+  })
+
+  it("offers server providers and preserves a saved provider absent from the catalog", async () => {
+    mocks.fetchWithAuth.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "persona-1",
+        voice_defaults: {
+          tts_provider: "custom-server",
+          tts_model: "custom-model"
+        }
+      })
+    })
+    render(
+      <AssistantDefaultsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Helper"
+        isActive
+      />
+    )
+    await waitFor(() =>
+      expect(screen.getByLabelText("TTS provider")).toHaveValue("custom-server")
+    )
+    expect(screen.getByRole("option", { name: "piper" })).toBeInTheDocument()
+    expect(screen.getByLabelText("TTS model")).toHaveValue("custom-model")
+    fireEvent.change(screen.getByLabelText("TTS provider"), {
+      target: { value: "piper" }
+    })
+    fireEvent.change(screen.getByLabelText("TTS model"), {
+      target: { value: "en_US-lessac-medium" }
+    })
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save assistant defaults" })
+    )
+    await waitFor(() =>
+      expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+        "/api/v1/persona/profiles/persona-1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: expect.objectContaining({
+            voice_defaults: expect.objectContaining({
+              tts_provider: "piper",
+              tts_model: "en_US-lessac-medium"
+            })
+          })
+        })
+      )
+    )
   })
 
   it("loads persona defaults, explains fallback behavior, and saves edits", async () => {
@@ -365,6 +419,7 @@ describe("AssistantDefaultsPanel", () => {
               stt_language: "fr-FR",
               stt_model: "whisper-1",
               tts_provider: "openai",
+              tts_model: null,
               tts_voice: "nova",
               confirmation_mode: "destructive_only",
               voice_chat_trigger_phrases: [

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantVoiceCard.readiness.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantVoiceCard.readiness.test.tsx
@@ -39,6 +39,7 @@ it("offers Stop during preparation and generation without claiming speech is rea
       sttLanguage: "en",
       sttModel: "whisper",
       ttsProvider: "kokoro",
+      ttsModel: "selected-model",
       ttsVoice: "af_heart",
       confirmationMode: "destructive_only" as const,
       wakeBehavior: "one_shot" as const,
@@ -53,6 +54,7 @@ it("offers Stop during preparation and generation without claiming speech is rea
     }
   }
   const view = render(<AssistantVoiceCard {...props} />)
+  expect(screen.getByText("kokoro · selected-model · af_heart")).toBeInTheDocument()
   expect(screen.getByText(/Preparing the selected speech/)).toBeInTheDocument()
   fireEvent.click(screen.getByRole("button", { name: "Stop voice" }))
   expect(stop).toHaveBeenCalledOnce()

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -212,6 +212,167 @@ describe("usePersonaLiveVoiceController", () => {
     })
   })
 
+  it("forwards the selected server TTS model in voice configuration", () => {
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+    renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-voice",
+        personaId: "persona-1",
+        resolvedDefaults: {
+          ...resolvedDefaults,
+          ttsProvider: "piper",
+          ttsModel: "en_US-lessac-medium"
+        },
+        canUseServerStt: true
+      })
+    )
+    expect(ownerPayload(ws).tts).toEqual({
+      provider: "piper",
+      voice: "alloy",
+      model: "en_US-lessac-medium"
+    })
+  })
+
+  it.each(["construct", "getVoices", "speak", "cancel-event"])(
+    "finishes a browser voice turn after synchronous %s failure",
+    async (failure) => {
+      let activeUtterance: { onerror?: () => void } | undefined
+      const synthesis = {
+        cancel: vi.fn(() => {
+          const cancelled = activeUtterance
+          activeUtterance = undefined
+          cancelled?.onerror?.()
+        }),
+        getVoices: vi.fn(() => {
+          if (failure === "getVoices") throw new Error("unavailable")
+          return []
+        }),
+        speak: vi.fn((utterance) => {
+          if (failure === "cancel-event") activeUtterance = utterance
+          if (failure === "speak" || failure === "cancel-event")
+            throw new Error("unavailable")
+        })
+      }
+      vi.stubGlobal("speechSynthesis", synthesis)
+      vi.stubGlobal(
+        "SpeechSynthesisUtterance",
+        class {
+          constructor() {
+            if (failure === "construct") throw new Error("unavailable")
+          }
+        }
+      )
+      try {
+        const ws = {
+          readyState: WebSocket.OPEN,
+          send: vi.fn()
+        } as unknown as WebSocket
+        const { result } = renderHook(() =>
+          usePersonaLiveVoiceController({
+            ws,
+            connected: true,
+            sessionId: "sess-voice",
+            personaId: "persona-1",
+            resolvedDefaults: {
+              ...resolvedDefaults,
+              ttsProvider: "browser",
+              ttsVoice: "",
+              autoResume: false
+            },
+            canUseServerStt: true
+          })
+        )
+        await act(async () => {
+          await startPreparedVoice(result, ws)
+        })
+        const cancelsBeforeSpeech = synthesis.cancel.mock.calls.length
+        act(() => {
+          deliverPayload(result, ws, {
+            event: "assistant_delta",
+            text_delta: "Hello"
+          })
+        })
+        expect(synthesis.cancel.mock.calls.length - cancelsBeforeSpeech).toBe(2)
+        expect(result.current.textOnlyDueToTtsFailure).toBe(true)
+        expect(result.current.warningReasonCode).toBe(
+          "voice_tts_unavailable_text_only"
+        )
+        expect(result.current.state).not.toBe("speaking")
+        act(() => result.current.stopListening())
+        expect(result.current.state).toBe("idle")
+        expect(hookMocks.audioStart).not.toHaveBeenCalled()
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    }
+  )
+
+  it.each(["missing-voice", "voice-uri", "Known voice", ""])(
+    "honors browser voice selection %s without hidden substitution",
+    async (ttsVoice) => {
+      const voice = { voiceURI: "voice-uri", name: "Known voice" }
+      const synthesis = {
+        cancel: vi.fn(),
+        getVoices: vi.fn(() => [voice]),
+        speak: vi.fn()
+      }
+      vi.stubGlobal("speechSynthesis", synthesis)
+      vi.stubGlobal("SpeechSynthesisUtterance", class {})
+      try {
+        const ws = {
+          readyState: WebSocket.OPEN,
+          send: vi.fn()
+        } as unknown as WebSocket
+        const { result } = renderHook(() =>
+          usePersonaLiveVoiceController({
+            ws,
+            connected: true,
+            sessionId: "sess-voice",
+            personaId: "persona-1",
+            resolvedDefaults: {
+              ...resolvedDefaults,
+              ttsProvider: "browser",
+              ttsVoice,
+              autoResume: false
+            },
+            canUseServerStt: true
+          })
+        )
+        await act(async () => {
+          await startPreparedVoice(result, ws)
+        })
+        act(() => {
+          deliverPayload(result, ws, {
+            event: "assistant_delta",
+            text_delta: "Hello"
+          })
+        })
+        if (ttsVoice === "missing-voice") {
+          expect(synthesis.speak).not.toHaveBeenCalled()
+          expect(result.current.textOnlyDueToTtsFailure).toBe(true)
+          expect(result.current.warning).toContain("selected browser voice")
+          expect(result.current.state).toBe("idle")
+          expect(hookMocks.audioStart).not.toHaveBeenCalled()
+        } else {
+          expect(synthesis.speak).toHaveBeenCalledTimes(1)
+          expect(synthesis.speak.mock.calls[0][0].voice).toBe(
+            ttsVoice ? voice : undefined
+          )
+          expect(result.current.state).toBe("speaking")
+        }
+        act(() => result.current.stopListening())
+        expect(result.current.state).toBe("idle")
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    }
+  )
+
   it("initializes session turn detection to the balanced preset", () => {
     const ws = {
       readyState: WebSocket.OPEN,

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -312,6 +312,76 @@ describe("usePersonaLiveVoiceController", () => {
     }
   )
 
+  it.each([
+    ["synchronous", "onerror"],
+    ["synchronous", "onend"],
+    ["delayed", "onerror"],
+    ["delayed", "onend"]
+  ] as const)(
+    "ignores %s stale %s callbacks when replacing speech in the same turn",
+    async (timing, callback) => {
+      let activeUtterance: SpeechSynthesisUtterance | undefined
+      let staleCallback: (() => void) | undefined
+      const synthesis = {
+        cancel: vi.fn(() => {
+          const cancelled = activeUtterance
+          activeUtterance = undefined
+          if (!cancelled) return
+          const notify = () => cancelled[callback]?.call(cancelled, {} as SpeechSynthesisErrorEvent)
+          if (timing === "synchronous") notify()
+          else staleCallback = notify
+        }),
+        getVoices: vi.fn(() => []),
+        speak: vi.fn((utterance: SpeechSynthesisUtterance) => {
+          activeUtterance = utterance
+        })
+      }
+      vi.stubGlobal("speechSynthesis", synthesis)
+      vi.stubGlobal("SpeechSynthesisUtterance", class {})
+      try {
+        const ws = { readyState: WebSocket.OPEN, send: vi.fn() } as unknown as WebSocket
+        const { result } = renderHook(() =>
+          usePersonaLiveVoiceController({
+            ws,
+            connected: true,
+            sessionId: "sess-voice",
+            personaId: "persona-1",
+            resolvedDefaults: {
+              ...resolvedDefaults,
+              ttsProvider: "browser",
+              ttsVoice: "",
+              autoResume: false
+            },
+            canUseServerStt: true
+          })
+        )
+        await act(async () => { await startPreparedVoice(result, ws) })
+        act(() => deliverPayload(result, ws, { event: "assistant_delta", text_delta: "First" }))
+        expect(result.current.state).toBe("speaking")
+        act(() => deliverPayload(result, ws, { event: "assistant_delta", text_delta: "Replacement" }))
+        const replacement = activeUtterance
+        act(() => staleCallback?.())
+        expect(result.current.textOnlyDueToTtsFailure).toBe(false)
+        expect(result.current.warning).toBeNull()
+        expect(result.current.state).toBe("speaking")
+        expect(activeUtterance).toBe(replacement)
+        expect(replacement).toBeDefined()
+        act(() => replacement?.onend?.({} as SpeechSynthesisEvent))
+        expect(result.current.state).toBe("idle")
+        await act(async () => { await startPreparedVoice(result, ws) })
+        act(() => deliverPayload(result, ws, { event: "assistant_delta", text_delta: "Stop this speech" }))
+        expect(result.current.state).toBe("speaking")
+        act(() => result.current.stopListening())
+        expect(activeUtterance).toBeUndefined()
+        act(() => staleCallback?.())
+        expect(result.current.state).toBe("idle")
+        expect(result.current.textOnlyDueToTtsFailure).toBe(false)
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    }
+  )
+
   it.each(["missing-voice", "voice-uri", "Known voice", ""])(
     "honors browser voice selection %s without hidden substitution",
     async (ttsVoice) => {

--- a/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
@@ -140,6 +140,27 @@ describe("useResolvedPersonaVoiceDefaults", () => {
     expect(result.current.wakeBehavior).toBe("one_shot")
   })
 
+  it.each(["browser", "kokoro", "piper", "custom-server"])(
+    "does not borrow the tldw voice for %s",
+    (provider) => {
+      const { result } = renderHook(() =>
+        useResolvedPersonaVoiceDefaults({ tts_provider: provider })
+      )
+      expect(result.current.ttsVoice).toBe("")
+      expect(result.current.ttsProvider).toBe(provider)
+    }
+  )
+
+  it("resolves an optional persona TTS model without borrowing another provider model", () => {
+    const { result } = renderHook(() =>
+      useResolvedPersonaVoiceDefaults({
+        tts_provider: "piper",
+        tts_model: " en_US-lessac-medium "
+      })
+    )
+    expect(result.current.ttsModel).toBe("en_US-lessac-medium")
+  })
+
   it("resolves explicit persona wake behavior", () => {
     const { result } = renderHook(() =>
       useResolvedPersonaVoiceDefaults({

--- a/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
@@ -66,7 +66,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
     sttState.model = "parakeet"
   })
 
-  it("prefers persona defaults and falls back to browser values for missing fields", () => {
+  it("keeps explicit Persona provider voice unset while inheriting non-voice browser settings", () => {
     const { result } = renderHook(() =>
       useResolvedPersonaVoiceDefaults({
         stt_language: "fr-FR",
@@ -87,7 +87,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
       sttLanguage: "fr-FR",
       sttModel: "parakeet",
       ttsProvider: "openai",
-      ttsVoice: "alloy",
+      ttsVoice: "",
       confirmationMode: "always",
       voiceChatTriggerPhrases: ["bonjour helper"],
       wakeBehavior: "continuous",
@@ -101,7 +101,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
     })
   })
 
-  it("uses Kitten-backed defaults when persona values are absent", () => {
+  it("inherits the browser provider without overriding its server voice default", () => {
     storageState.values.ttsProvider = "elevenlabs"
     voiceChatState.voiceChatTriggerPhrases = ["okay helper", "status check"]
     voiceChatState.voiceChatAutoResume = false
@@ -114,7 +114,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
       sttLanguage: "en-US",
       sttModel: "whisper-1",
       ttsProvider: "elevenlabs",
-      ttsVoice: "voice-eleven",
+      ttsVoice: "",
       confirmationMode: "destructive_only",
       voiceChatTriggerPhrases: ["okay helper", "status check"],
       wakeBehavior: "one_shot",
@@ -128,7 +128,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
     })
   })
 
-  it("materializes the canonical fresh-profile Kitten baseline", () => {
+  it("leaves the fresh-profile voice to the selected provider", () => {
     storageState.values = {
       speechToTextLanguage: "en-US"
     }
@@ -136,7 +136,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
     const { result } = renderHook(() => useResolvedPersonaVoiceDefaults(null))
 
     expect(result.current.ttsProvider).toBe("tldw")
-    expect(result.current.ttsVoice).toBe("Bella")
+    expect(result.current.ttsVoice).toBe("")
     expect(result.current.wakeBehavior).toBe("one_shot")
   })
 
@@ -170,4 +170,15 @@ describe("useResolvedPersonaVoiceDefaults", () => {
 
     expect(result.current.wakeBehavior).toBe("push_to_talk_after_wake")
   })
+})
+
+
+it.each(["openai", "elevenlabs", "tldw"])("keeps a blank %s voice unset instead of injecting browser preferences", provider => {
+  const {result}=renderHook(()=>useResolvedPersonaVoiceDefaults({tts_provider:provider,tts_voice:"   "}))
+  expect(result.current.ttsVoice).toBe("")
+})
+
+it("preserves an explicit Persona voice",()=>{
+ const {result}=renderHook(()=>useResolvedPersonaVoiceDefaults({tts_provider:"openai",tts_voice:" nova "}))
+ expect(result.current.ttsVoice).toBe("nova")
 })

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -279,6 +279,7 @@ export const usePersonaLiveVoiceController = ({
   const pendingBinaryFinishRef = React.useRef(false)
   const pendingResumeRef = React.useRef(false)
   const browserUtteranceActiveRef = React.useRef(false)
+  const browserUtteranceGenerationRef = React.useRef(0)
   const listeningRecoveryTimeoutRef = React.useRef<number | null>(null)
   const thinkingRecoveryTimeoutRef = React.useRef<number | null>(null)
   const wakeDetectorRef = React.useRef<WakeDetector | null>(null)
@@ -469,6 +470,9 @@ export const usePersonaLiveVoiceController = ({
   } = useStreamingAudioPlayer()
 
   const stopBrowserSpeech = React.useCallback(() => {
+    // Native cancel may synchronously invoke callbacks from the old utterance.
+    browserUtteranceGenerationRef.current += 1
+    browserUtteranceActiveRef.current = false
     if (typeof window !== "undefined" && "speechSynthesis" in window) {
       try {
         window.speechSynthesis.cancel()
@@ -476,7 +480,6 @@ export const usePersonaLiveVoiceController = ({
         console.error("stopBrowserSpeech: speechSynthesis.cancel failed", error)
       }
     }
-    browserUtteranceActiveRef.current = false
   }, [])
 
   const stopCurrentPlayback = React.useCallback(() => {
@@ -1178,6 +1181,7 @@ export const usePersonaLiveVoiceController = ({
       }
 
       stopBrowserSpeech()
+      const utteranceGeneration = browserUtteranceGenerationRef.current
       const owner = voiceOwnerRef.current
       let completed = false
       const handleSpeechFailure = (
@@ -1185,6 +1189,7 @@ export const usePersonaLiveVoiceController = ({
       ) => {
         if (
           completed ||
+          utteranceGeneration !== browserUtteranceGenerationRef.current ||
           !owner ||
           voiceOwnerRef.current !== owner ||
           !voiceEnabledRef.current
@@ -1223,6 +1228,7 @@ export const usePersonaLiveVoiceController = ({
         utterance.onend = () => {
           if (
             completed ||
+            utteranceGeneration !== browserUtteranceGenerationRef.current ||
             !owner ||
             voiceOwnerRef.current !== owner ||
             !voiceEnabledRef.current

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -1178,40 +1178,66 @@ export const usePersonaLiveVoiceController = ({
       }
 
       stopBrowserSpeech()
-      const synthesis = window.speechSynthesis
-      const utterance = new SpeechSynthesisUtterance(spokenText)
-      if (resolvedDefaults.sttLanguage) {
-        utterance.lang = resolvedDefaults.sttLanguage
-      }
-      const availableVoices = synthesis.getVoices()
-      const matchedVoice = availableVoices.find(
-        (voice) =>
-          voice.voiceURI === resolvedDefaults.ttsVoice ||
-          voice.name === resolvedDefaults.ttsVoice
-      )
-      if (matchedVoice) {
-        utterance.voice = matchedVoice
-      }
-      browserUtteranceActiveRef.current = true
       const owner = voiceOwnerRef.current
-      utterance.onend = () => {
-        if (!owner || voiceOwnerRef.current !== owner || !voiceEnabledRef.current) return
-        browserUtteranceActiveRef.current = false
-        finishVoiceTurn()
-      }
-      utterance.onerror = () => {
-        if (!owner || voiceOwnerRef.current !== owner || !voiceEnabledRef.current) return
-        browserUtteranceActiveRef.current = false
+      let completed = false
+      const handleSpeechFailure = (
+        message = "Browser speech playback failed. Continuing in text-only mode."
+      ) => {
+        if (
+          completed ||
+          !owner ||
+          voiceOwnerRef.current !== owner ||
+          !voiceEnabledRef.current
+        )
+          return
+        completed = true
+        stopBrowserSpeech()
         textOnlyDueToTtsFailureRef.current = true
         setTextOnlyDueToTtsFailure(true)
         setVoiceWarning(
-          "Browser speech playback failed. Continuing in text-only mode.",
+          message,
           "voice_tts_unavailable_text_only"
         )
         finishVoiceTurn()
       }
-      setState("speaking")
-      synthesis.speak(utterance)
+      try {
+        const synthesis = window.speechSynthesis
+        const utterance = new SpeechSynthesisUtterance(spokenText)
+        if (resolvedDefaults.sttLanguage)
+          utterance.lang = resolvedDefaults.sttLanguage
+        const matchedVoice = synthesis
+          .getVoices()
+          .find(
+            (voice) =>
+              voice.voiceURI === resolvedDefaults.ttsVoice ||
+              voice.name === resolvedDefaults.ttsVoice
+          )
+        if (resolvedDefaults.ttsVoice && !matchedVoice) {
+          handleSpeechFailure(
+            "The selected browser voice is unavailable. Continuing in text-only mode. Retry after browser voices load or choose an available voice."
+          )
+          return
+        }
+        if (matchedVoice) utterance.voice = matchedVoice
+        browserUtteranceActiveRef.current = true
+        utterance.onend = () => {
+          if (
+            completed ||
+            !owner ||
+            voiceOwnerRef.current !== owner ||
+            !voiceEnabledRef.current
+          )
+            return
+          completed = true
+          browserUtteranceActiveRef.current = false
+          finishVoiceTurn()
+        }
+        utterance.onerror = () => handleSpeechFailure()
+        setState("speaking")
+        synthesis.speak(utterance)
+      } catch {
+        handleSpeechFailure()
+      }
     },
     [
       finishVoiceTurn,
@@ -1398,7 +1424,10 @@ export const usePersonaLiveVoiceController = ({
           },
           tts: {
             provider: resolvedDefaults.ttsProvider,
-            voice: resolvedDefaults.ttsVoice
+            voice: resolvedDefaults.ttsVoice,
+            ...(resolvedDefaults.ttsModel
+              ? { model: resolvedDefaults.ttsModel }
+              : {})
           }
         })
       )
@@ -1412,6 +1441,7 @@ export const usePersonaLiveVoiceController = ({
     stopCurrentPlayback,
     resolvedDefaults.sttLanguage,
     resolvedDefaults.sttModel,
+    resolvedDefaults.ttsModel,
     resolvedDefaults.ttsProvider,
     resolvedDefaults.ttsVoice,
     resolvedDefaults.voiceChatTriggerPhrases,

--- a/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
+++ b/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
@@ -22,6 +22,7 @@ export type PersonaVoiceDefaults = {
   stt_language?: string | null
   stt_model?: string | null
   tts_provider?: string | null
+  tts_model?: string | null
   tts_voice?: string | null
   confirmation_mode?: PersonaConfirmationMode | null
   wake_behavior?: PersonaWakeBehavior | null
@@ -39,6 +40,7 @@ export type ResolvedPersonaVoiceDefaults = {
   sttLanguage: string
   sttModel: string
   ttsProvider: string
+  ttsModel?: string
   ttsVoice: string
   confirmationMode: PersonaConfirmationMode
   wakeBehavior: PersonaWakeBehavior
@@ -103,7 +105,10 @@ const resolveDefaultTtsVoice = (
   if (normalizedProvider === "elevenlabs") {
     return normalizeText(elevenLabsVoice) || ""
   }
-  return normalizeText(tldwVoice) || DEFAULT_TLDW_TTS_VOICE
+  if (normalizedProvider === "tldw") {
+    return normalizeText(tldwVoice) || DEFAULT_TLDW_TTS_VOICE
+  }
+  return ""
 }
 
 export const useResolvedPersonaVoiceDefaults = (
@@ -144,6 +149,7 @@ export const useResolvedPersonaVoiceDefaults = (
         normalizeText(String(sttSettings.model || "")) ||
         "",
       ttsProvider: resolvedProvider,
+      ttsModel: normalizeText(personaVoiceDefaults?.tts_model) || undefined,
       ttsVoice:
         normalizeText(personaVoiceDefaults?.tts_voice) ||
         resolveDefaultTtsVoice(

--- a/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
+++ b/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
@@ -3,10 +3,7 @@ import { useStorage } from "@plasmohq/storage/hook"
 
 import { useSttSettings } from "@/hooks/useSttSettings"
 import { useVoiceChatSettings } from "@/hooks/useVoiceChatSettings"
-import {
-  DEFAULT_TLDW_TTS_VOICE,
-  DEFAULT_TTS_PROVIDER
-} from "@/services/tts"
+import { DEFAULT_TTS_PROVIDER } from "@/services/tts"
 
 export type PersonaConfirmationMode =
   | "always"
@@ -55,7 +52,6 @@ export type ResolvedPersonaVoiceDefaults = {
 }
 
 const DEFAULT_STT_LANGUAGE = "en-US"
-const DEFAULT_OPENAI_VOICE = "alloy"
 const DEFAULT_CONFIRMATION_MODE: PersonaConfirmationMode = "destructive_only"
 const DEFAULT_WAKE_BEHAVIOR: PersonaWakeBehavior = "one_shot"
 export const PERSONA_TURN_DETECTION_BALANCED_DEFAULTS = {
@@ -92,25 +88,6 @@ const normalizeWakeBehavior = (
     ? value
     : DEFAULT_WAKE_BEHAVIOR
 
-const resolveDefaultTtsVoice = (
-  provider: string,
-  tldwVoice: string,
-  openAiVoice: string,
-  elevenLabsVoice: string
-): string => {
-  const normalizedProvider = String(provider || "").trim().toLowerCase()
-  if (normalizedProvider === "openai") {
-    return normalizeText(openAiVoice) || DEFAULT_OPENAI_VOICE
-  }
-  if (normalizedProvider === "elevenlabs") {
-    return normalizeText(elevenLabsVoice) || ""
-  }
-  if (normalizedProvider === "tldw") {
-    return normalizeText(tldwVoice) || DEFAULT_TLDW_TTS_VOICE
-  }
-  return ""
-}
-
 export const useResolvedPersonaVoiceDefaults = (
   personaVoiceDefaults?: PersonaVoiceDefaults | null
 ): ResolvedPersonaVoiceDefaults => {
@@ -125,9 +102,6 @@ export const useResolvedPersonaVoiceDefaults = (
     DEFAULT_STT_LANGUAGE
   )
   const [ttsProvider] = useStorage("ttsProvider", DEFAULT_TTS_PROVIDER)
-  const [tldwTtsVoice] = useStorage("tldwTtsVoice", DEFAULT_TLDW_TTS_VOICE)
-  const [openAITTSVoice] = useStorage("openAITTSVoice", DEFAULT_OPENAI_VOICE)
-  const [elevenLabsVoiceId] = useStorage("elevenLabsVoiceId", "")
 
   return React.useMemo(() => {
     const resolvedProvider =
@@ -150,14 +124,9 @@ export const useResolvedPersonaVoiceDefaults = (
         "",
       ttsProvider: resolvedProvider,
       ttsModel: normalizeText(personaVoiceDefaults?.tts_model) || undefined,
-      ttsVoice:
-        normalizeText(personaVoiceDefaults?.tts_voice) ||
-        resolveDefaultTtsVoice(
-          resolvedProvider,
-          String(tldwTtsVoice || ""),
-          String(openAITTSVoice || ""),
-          String(elevenLabsVoiceId || "")
-        ),
+      // An unset voice belongs to the selected provider, not another
+      // browser surface's speech preference.
+      ttsVoice: normalizeText(personaVoiceDefaults?.tts_voice) || "",
       confirmationMode:
         personaVoiceDefaults?.confirmation_mode || DEFAULT_CONFIRMATION_MODE,
       wakeBehavior: normalizeWakeBehavior(personaVoiceDefaults?.wake_behavior),
@@ -195,12 +164,9 @@ export const useResolvedPersonaVoiceDefaults = (
           : PERSONA_TURN_DETECTION_BALANCED_DEFAULTS.minUtteranceSecs
     }
   }, [
-    elevenLabsVoiceId,
-    openAITTSVoice,
     personaVoiceDefaults,
     speechToTextLanguage,
     sttSettings.model,
-    tldwTtsVoice,
     ttsProvider,
     voiceChatAutoResume,
     voiceChatBargeIn,

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 2073,
   "schema_count": 3142,
-  "sha256": "e72e58af304408bc1b44bb380d7d4b3a34f126fc87b2c0bc01c9611147d597da"
+  "sha256": "8d934003bcd61b048f506fb978e257ba7dce61d8ede40badd343d8de2da7a3f2"
 }

--- a/backlog/decisions/004-persona-live-tts-provider-selection.md
+++ b/backlog/decisions/004-persona-live-tts-provider-selection.md
@@ -36,3 +36,15 @@ We reject both broad removal of all readiness checks and a second hard-coded
 provider allowlist. An installed/configured adapter is the runtime boundary;
 physical qualification of one provider does not establish support for only that
 provider or prove every other deployment works.
+
+A blank Persona voice is not an instruction to copy another browser surface's
+voice preference. The browser leaves it unset; the server uses its configured
+global voice only when the selected provider matches the configured default
+provider, otherwise the selected adapter supplies its own default. Global audio
+provider aliases retain their own meaning during that comparison (global `tldw`
+means Kitten; the legacy Persona alias remains Kokoro). Explicit Persona voices
+remain authoritative. Kitten readiness validates the voice against the loaded
+model without synthesizing, and speech streams close inside their credential
+scope even when an error arrives after partial audio. Connected Live settings
+remain fixed for that connection; saving defaults requires reconnecting, and
+Live displays the active model override to make this visible.

--- a/backlog/decisions/004-persona-live-tts-provider-selection.md
+++ b/backlog/decisions/004-persona-live-tts-provider-selection.md
@@ -48,3 +48,11 @@ model without synthesizing, and speech streams close inside their credential
 scope even when an error arrives after partial audio. Connected Live settings
 remain fixed for that connection; saving defaults requires reconnecting, and
 Live displays the active model override to make this visible.
+
+Kitten's cached runtime selection does not replace its configured default model
+or revision. Registry initialization makes the lazy adapter routable; public
+audio health separately reports an unprepared, failed, or loaded runtime. This
+keeps selected-model preparation independent of default-model assets without
+claiming that an untested runtime is healthy. Browser playback callbacks also
+belong to one utterance generation, invalidated before cancellation, so an old
+utterance cannot end replacement playback within the same voice turn.

--- a/backlog/decisions/004-persona-live-tts-provider-selection.md
+++ b/backlog/decisions/004-persona-live-tts-provider-selection.md
@@ -1,0 +1,38 @@
+# Persona Live preserves speech provider selection
+
+Date: 2026-09-07
+Status: Accepted
+Task: TASK-13214
+
+Persona Live preparation incorrectly restricted all users to the Kokoro setup used
+for UAT, while its synthesis route already used the shared TTS service. Generic
+voice and model defaults also crossed provider boundaries.
+
+Use one Persona TTS resolution path for preparation and synthesis. Preserve the
+selected registered provider, optional model and voice; use that adapter's own
+configured defaults when fields are omitted. Keep the existing Persona `tldw`
+alias for Kokoro to avoid silently changing saved profiles. Browser speech is
+prepared and played by the browser. Explicit configured gateways use existing
+server-owned gateway validation and credential resolution, never client URLs.
+
+Both preparation and synthesis enter the existing authenticated audio credential
+scope, applying effective BYOK and provider restrictions. Remote credentials are
+request-owned; their temporary adapters are closed on failure, completion and
+cancellation. Chat preparation validates the target only; actual Chat dispatch
+retains credential, moderation and budget enforcement.
+
+Preparation initializes the selected adapter without generating speech. Kitten
+initialization stays model-independent so preparation and synthesis load the
+selected model through its cached loader, without requiring default-model assets.
+OpenAI preparation disables optional synthetic key-verification speech. Kokoro's
+additional lazy model load remains a Kokoro-specific readiness step, not a
+provider allowlist. Synthesis continues through the shared TTS service with
+fallback disabled and the authenticated user context for owned voices/gateways.
+Runtime failures invalidate readiness and preserve text-only recovery and Stop
+ownership. Optional `tts_model` is stored in existing JSON defaults; no schema
+migration is needed.
+
+We reject both broad removal of all readiness checks and a second hard-coded
+provider allowlist. An installed/configured adapter is the runtime boundary;
+physical qualification of one provider does not establish support for only that
+provider or prove every other deployment works.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -294,3 +294,11 @@ provider and preserve its selected model/voice through preparation and output.
 Passing a user ID is not proof of BYOK enforcement: exercise the existing
 authenticated credential scope. Document the UAT configuration as evidence,
 not as an allowlist or prerequisite.
+
+The follow-up review on the same day found that mocked provider/config boundaries
+hid a global default-voice mismatch and a fake Kitten runtime never exercised
+voice-name validation. Tests now use the real TTSConfig schema and Kitten voice
+resolver while replacing only credential/network/model-weight I/O. A retained
+async-generator reference also exposed error cleanup running after credential
+disposal; asserting cleanup order before returning catches what eventual-GC
+checks miss.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -277,3 +277,20 @@ that the requester had not said.
 silence and chunk boundaries. Assert the final complete transcript, not whether
 any partial contains the expected substring. Preserve intermediate hypotheses in
 sanitized evidence so a corrected final does not hide earlier errors.
+
+## 2026-09-07: A UAT provider is not a product requirement
+
+During Migu Buddy UAT, a Kokoro preparation allowlist was introduced even though
+Persona advertised other TTS providers. Tests exercised only Kokoro, and the
+new guides then described the accidental restriction as mandatory. TASK-13214
+removed that restriction and added selected-provider/model/voice, credential,
+failure and cleanup checks. Native browser speech was exercised through the
+production controller with a controlled transcript; native start/end and Stop
+were observed, while microphone recognition and human audibility were explicitly
+outside that check.
+
+Before claiming a configurable provider feature works, test a non-default
+provider and preserve its selected model/voice through preparation and output.
+Passing a user ID is not proof of BYOK enforcement: exercise the existing
+authenticated credential scope. Document the UAT configuration as evidence,
+not as an allowlist or prerequisite.

--- a/backlog/tasks/task-13213 - Document-server-Buddy-setup-live-voice-approvals-and-troubleshooting.md
+++ b/backlog/tasks/task-13213 - Document-server-Buddy-setup-live-voice-approvals-and-troubleshooting.md
@@ -1,0 +1,56 @@
+---
+id: TASK-13213
+title: Document server Buddy setup live voice approvals and troubleshooting
+status: Done
+created_date: 2026-09-07 08:35
+labels:
+- documentation
+- buddy
+updated_date: 2026-09-07 16:45
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give users a single practical Buddy guide with setup, Migu selection, movement, voice, approvals and honest troubleshooting guidance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A discoverable user guide covers the current Buddy workflow and links related setup and voice documentation.
+- [x] #2 Instructions distinguish verified behavior from outstanding UAT limitations and use current control labels.
+- [x] #3 Relative documentation links and navigation resolve; published mirrors match where applicable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no. ADR path: N/A. Reason: user documentation of existing behavior, no runtime or contract change.
+1. Read current controls, existing guides and UAT records.
+2. Write a dedicated guide and link it from the documentation index and relevant feature pages.
+3. Validate links/navigation, inspect the rendered Markdown, and record source revision and evidence limitations.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added the canonical Persona_Buddy_Guide.md and byte-identical Published mirror, with links from both Persona and WebUI user guides and the MkDocs navigation. Documents configuration, pixel-migu Copy as draft then Activate, dragging, text/voice controls, Send now versus Stop voice, exact-session approvals, and troubleshooting. Explicitly preserves outstanding animation TASK-13202 and repeated-request TASK-13211 limitations. Independent source review found and resolved the missing Copy as draft instruction. Validation: case-sensitive relative links resolve, all three changed canonical/Published pairs match, Markdown layout inspected, git diff --check passes, full MkDocs build passed using the installed git revision plugin's supported serial mode after this machine could not allocate multiprocessing semaphores. Repository build configuration was unchanged. Documentation-only change; no runtime or security boundary change; no new physical microphone test claimed. ADR required: no, documentation of existing behavior.
+Bandit skipped: only Markdown and MkDocs navigation YAML changed, with no Python code touched. Known environment workaround (serial docs build) and remaining product UAT limitations are recorded above.
+User-requested second review: independently inspect setup and voice controls, reconcile contradictory voice setup guidance in linked Personas guide, and recheck publishing/link behavior. Changes remain within current documentation AC.
+Second independent review resolved two onboarding defects: replaced hidden legacy starter picker with Visuals → Buddy builder → Bundled Buddy → pixel-migu → Copy as draft → Continue to activation → Activate; explicitly require local Kokoro/TLDW TTS and document Profiles fields plus Save assistant defaults because Live STT/TTS summaries are read-only. Updated linked Personas guide's stale Start and Whisper-only preparation text to current Start listening and supported Whisper/Parakeet ONNX examples, distinguishing supported selections from physical UAT. Source verified in VisualPackEditor, BuddySourcePicker, BuddyDraftReviewPanel, AssistantDefaultsPanel, AssistantVoiceCard, persona.py and live_stt.py. Final Markdown rendered-link checks pass (4 relative targets per Buddy mirror), all three changed canonical/Published pairs match, and git diff --check passes. Previous full serial MkDocs build remains recorded; no runtime tests or physical microphone UAT repeated for prose changes.
+Correction after TASK-13214: the earlier Kokoro-mandatory guidance described an accidental UAT restriction, not the intended product requirement. That runtime restriction is now removed. Both canonical and Published guides document configured TTS provider/browser/gateway, optional model/voice, no silent substitution, and authenticated Chat credentials/policy/budget enforcement at dispatch. Historical Kokoro UAT remains evidence only. Provider-selection verification and remaining limits are in Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and linked the server Buddy guide, synchronized its published copy, and verified documentation rendering/build and source accuracy.
+<!-- SECTION:FINAL_SUMMARY:END -->
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13213 - Document-server-Buddy-setup-live-voice-approvals-and-troubleshooting.md
+++ b/backlog/tasks/task-13213 - Document-server-Buddy-setup-live-voice-approvals-and-troubleshooting.md
@@ -2,11 +2,13 @@
 id: TASK-13213
 title: Document server Buddy setup live voice approvals and troubleshooting
 status: Done
-created_date: 2026-09-07 08:35
+assignee: []
+created_date: '2026-09-07 08:35'
+updated_date: '2026-09-07 17:45'
 labels:
-- documentation
-- buddy
-updated_date: 2026-09-07 16:45
+  - documentation
+  - buddy
+dependencies: []
 ---
 
 ## Description
@@ -20,19 +22,18 @@ Give users a single practical Buddy guide with setup, Migu selection, movement, 
 - [x] #1 A discoverable user guide covers the current Buddy workflow and links related setup and voice documentation.
 - [x] #2 Instructions distinguish verified behavior from outstanding UAT limitations and use current control labels.
 - [x] #3 Relative documentation links and navigation resolve; published mirrors match where applicable.
+- [x] #4 Documentation path checker distinguishes external URLs from local repository paths and still detects missing local paths.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: no. ADR path: N/A. Reason: user documentation of existing behavior, no runtime or contract change.
-1. Read current controls, existing guides and UAT records.
-2. Write a dedicated guide and link it from the documentation index and relevant feature pages.
-3. Validate links/navigation, inspect the rendered Markdown, and record source revision and evidence limitations.
+ADR required: no. ADR path: N/A. Reason: routine documentation checker bug fix preserving its existing contract. 1. Reproduce external Chatbook URL false positive and retain missing-local-path coverage. 2. Exclude external URLs from local path scanning. 3. Run Docs suite and checks, record PR #2928 evidence.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Added the canonical Persona_Buddy_Guide.md and byte-identical Published mirror, with links from both Persona and WebUI user guides and the MkDocs navigation. Documents configuration, pixel-migu Copy as draft then Activate, dragging, text/voice controls, Send now versus Stop voice, exact-session approvals, and troubleshooting. Explicitly preserves outstanding animation TASK-13202 and repeated-request TASK-13211 limitations. Independent source review found and resolved the missing Copy as draft instruction. Validation: case-sensitive relative links resolve, all three changed canonical/Published pairs match, Markdown layout inspected, git diff --check passes, full MkDocs build passed using the installed git revision plugin's supported serial mode after this machine could not allocate multiprocessing semaphores. Repository build configuration was unchanged. Documentation-only change; no runtime or security boundary change; no new physical microphone test claimed. ADR required: no, documentation of existing behavior.
 Bandit skipped: only Markdown and MkDocs navigation YAML changed, with no Python code touched. Known environment workaround (serial docs build) and remaining product UAT limitations are recorded above.
@@ -40,11 +41,20 @@ User-requested second review: independently inspect setup and voice controls, re
 Second independent review resolved two onboarding defects: replaced hidden legacy starter picker with Visuals → Buddy builder → Bundled Buddy → pixel-migu → Copy as draft → Continue to activation → Activate; explicitly require local Kokoro/TLDW TTS and document Profiles fields plus Save assistant defaults because Live STT/TTS summaries are read-only. Updated linked Personas guide's stale Start and Whisper-only preparation text to current Start listening and supported Whisper/Parakeet ONNX examples, distinguishing supported selections from physical UAT. Source verified in VisualPackEditor, BuddySourcePicker, BuddyDraftReviewPanel, AssistantDefaultsPanel, AssistantVoiceCard, persona.py and live_stt.py. Final Markdown rendered-link checks pass (4 relative targets per Buddy mirror), all three changed canonical/Published pairs match, and git diff --check passes. Previous full serial MkDocs build remains recorded; no runtime tests or physical microphone UAT repeated for prose changes.
 Correction after TASK-13214: the earlier Kokoro-mandatory guidance described an accidental UAT restriction, not the intended product requirement. That runtime restriction is now removed. Both canonical and Published guides document configured TTS provider/browser/gateway, optional model/voice, no silent substitution, and authenticated Chat credentials/policy/budget enforcement at dispatch. Historical Kokoro UAT remains evidence only. Provider-selection verification and remaining limits are in Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+PR #2928 CI exposed a false positive: the top-guides checker interpreted the Chatbook GitHub URL as a missing server Docs path. Added four URL-form regressions that preserve detection of a missing local path on the same line, and exclude external URL targets from repository-path scanning. Red: five failures. Green: 210 Docs tests passed; only the existing strict-build subprocess hit this macOS semaphore limit (OSError 28). A separate strict MkDocs build with the plugin-supported serial date processing passed. Ruff/Black and Bandit passed for the checker; canonical guide links remain intact.
+
+Independent follow-up caught repeated local slash separators being mistaken for protocol-relative URLs. Added failure-first regression and token boundary; all six focused checker tests now pass. Scoped Ruff/Black and Bandit pass; reviewer confirmed both nested and root repeated-slash local references remain detectable.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Created and linked the server Buddy guide, synchronized its published copy, and verified documentation rendering/build and source accuracy.
+
+PR #2928 follow-up corrects external-URL path scanning with regression coverage; documentation CI can now retain the valid cross-repository Chatbook guide link.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
+++ b/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
@@ -2,13 +2,15 @@
 id: TASK-13214
 title: Honor configured Persona Live speech provider without Kokoro lock-in
 status: Done
-created_date: 2026-09-07 16:06
+assignee: []
+created_date: '2026-09-07 16:06'
+updated_date: '2026-09-07 17:45'
 labels:
-- buddy
-- voice
-- bug
+  - buddy
+  - voice
+  - bug
+dependencies: []
 priority: high
-updated_date: 2026-09-07 17:24
 ---
 
 ## Description
@@ -28,25 +30,34 @@ Remove the UAT-specific Kokoro restriction so Persona Live prepares and speaks t
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: no new ADR. Existing ADR: backlog/decisions/004-persona-live-tts-provider-selection.md; clarify blank-voice precedence and cleanup ownership within that boundary.
-1. Add failing tests for configured matching-provider voice/default and explicit override, unrelated provider isolation, Kitten invalid voice, and error-path cleanup ordering.
-2. Implement minimal resolution/preparation/cleanup fixes and show active TTS model; preserve connected-session baseline semantics.
-3. Update canonical/Published guides with Disconnect then Connect; recheck links and mirrors.
-4. Run focused backend/frontend tests, lint/Bandit, scoped independent review, and commit.
+ADR required: no new ADR; existing backlog/decisions/004-persona-live-tts-provider-selection.md applies. 1. Reproduce Qodo backend and frontend defects with focused regression tests. 2. Preserve configured Kitten defaults and truthful readiness; guard each native utterance identity; show catalog failure and retry. 3. Correct function contracts and validate existing category markers. 4. Run focused tests, lint/Bandit, review fixes, respond to all findings, and verify PR checks.
 <!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented provider/model/voice selection, shared authenticated TTS credential scope, browser playback recovery and temporary adapter cleanup. Kitten preparation warms the requested model through its cache; Chat preparation no longer requires a static server key. Guides corrected in both repositories. Final verification/evidence recording in progress.
 Verification complete: 265 focused Python and 111 frontend tests passed; Bandit found zero issues in all seven changed production Python files. Targeted new Python Ruff/Black checks pass. Frontend ESLint has zero errors and 58 confirmed baseline warnings; large legacy Python formatting/lint debt remains unchanged. Real restarted server prepared Parakeet + browser TTS, dispatched the authorized DeepSeek Persona reply, acknowledged voice Stop, and stopped the session with HTTP 200. Real native SpeechSynthesis through the production controller emitted start/end and stopped a long reply with no queued speech. The browser input/WS boundary was controlled; no microphone/human-audibility or paid remote-TTS claim. Independent review resolved credential-scope, selected Kitten model readiness, and browser explicit-voice substitution findings. Canonical/Published guide mirrors match and MkDocs build passed. ADR: backlog/decisions/004-persona-live-tts-provider-selection.md. Evidence and limitations: Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md. Added incident-based lesson; temporary browser harness removed from product public files.
 Reopened for four user-approved review corrections: consistent blank voice/default precedence, Kitten voice validation before readiness, speech generator cleanup inside credential scope, and documented reconnect with visible active model. Add failure-first regressions and scoped re-review before committing.
 All four second-review findings addressed. Blank voices remain unset in the frontend and resolve the configured global voice only for its provider; explicit voices remain authoritative. Kitten validates the selected voice with the loaded runtime. Speech generators close within the credential scope, including partial-audio errors. Live displays model selection and reconnect guidance; both guides and Published mirrors require Disconnect then Connect after saving connected-session voice defaults. Failure-first reproduction: five backend and seven frontend failures. Final checks: 278 Python tests, 116 frontend tests, Ruff/Black clean on changed Python, Bandit zero findings, ESLint zero errors/two existing warnings, MkDocs build and links/mirrors pass. Two scoped independent re-reviews found no residual issues. Live UI labels checked, isolated backend restarted from matching source manifest and /health returned 200. No microphone or physical audio UAT repeated. Evidence appended in Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md; ADR-004 clarified.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+PR #2928 Qodo review follow-up: validate all seven findings; fix Kitten shared model/revision state and readiness reporting, stale browser utterance callbacks, catalog error recovery, and missing annotations/docstrings. Module-level unit marker already exists; verify collection and respond with evidence. User authorizes all review fixes and merge.
+
+Backend CI also identified the stale OpenAPI fingerprint for the new optional tts_model schema field. Regenerate canonical schema/types and verify drift gate; no additional API contract change.
+
+PR #2928: resolved six confirmed Qodo findings (shared Kitten model/revision defaults, truthful public runtime health, stale native utterance callbacks, visible catalog failure/Retry, docstrings, annotations). Seventh marker claim rebutted: existing module pytestmark selects all 14 cases under -m unit. Six backend and five frontend red failures reproduced; final combined 284 Python/124 frontend tests passed, additional overlapping adapter/health suites 66 passed, Bandit zero, no new lint diagnostics, independent review clear. API fingerprint regenerated; sole schema delta is optional tts_model; drift check and frontend codegen pass. ADR-004 clarified lazy readiness versus routability and utterance ownership. Physical voice UAT not repeated. Details in Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Removed Kokoro lock-in and addressed all four follow-up findings: correct provider-owned default voice, pre-recording Kitten voice validation, deterministic speech cleanup before credential disposal, and actionable reconnect guidance with Live model display. Verified 278 Python and 116 frontend tests, zero Bandit findings, clean scoped re-review, built/synchronized guides and healthy restarted UAT server. Physical all-provider voice qualification remains outside this correction.
+
+PR #2928 Qodo findings and docs/OpenAPI CI integration issues addressed with failure-first tests and independent review; final combined 284 Python and 124 frontend tests pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
+++ b/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
@@ -1,0 +1,56 @@
+---
+id: TASK-13214
+title: Honor configured Persona Live speech provider without Kokoro lock-in
+status: Done
+created_date: 2026-09-07 16:06
+labels:
+- buddy
+- voice
+- bug
+priority: high
+updated_date: 2026-09-07 16:44
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the UAT-specific Kokoro restriction so Persona Live prepares and speaks through the configured TTS provider. Audit related UAT assumptions and retain explicit errors, provider choice, and Stop/cleanup behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Configured registered TTS providers prepare and synthesize without silently substituting Kokoro or its model/voice defaults.
+- [x] #2 Unsupported or unavailable configurations fail clearly before recording where detectable; preparation does not synthesize user content.
+- [x] #3 Regression coverage verifies a non-Kokoro provider through preparation, audio delivery and stop/cleanup, including provider failure and no fallback.
+- [x] #4 Audit related voice assumptions, correct relevant guides and record remaining limitations and actual UAT evidence.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes. ADR path: backlog/decisions/004-persona-live-tts-provider-selection.md. Reason: preserve selected TTS provider/model/voice through authenticated preparation and synthesis, including optional persisted model and lazy selected Kitten model readiness.
+1. Reproduce provider/default failures and audit voice paths.
+2. Restore shared TTS resolution, effective credentials and owned cleanup; retain browser speech and explicit model transport.
+3. Verify selected provider, failure, stop and actual native browser speech/server route.
+4. Review, update guides and evidence, run focused checks and commit.
+<!-- SECTION:PLAN:END -->
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented provider/model/voice selection, shared authenticated TTS credential scope, browser playback recovery and temporary adapter cleanup. Kitten preparation warms the requested model through its cache; Chat preparation no longer requires a static server key. Guides corrected in both repositories. Final verification/evidence recording in progress.
+Verification complete: 265 focused Python and 111 frontend tests passed; Bandit found zero issues in all seven changed production Python files. Targeted new Python Ruff/Black checks pass. Frontend ESLint has zero errors and 58 confirmed baseline warnings; large legacy Python formatting/lint debt remains unchanged. Real restarted server prepared Parakeet + browser TTS, dispatched the authorized DeepSeek Persona reply, acknowledged voice Stop, and stopped the session with HTTP 200. Real native SpeechSynthesis through the production controller emitted start/end and stopped a long reply with no queued speech. The browser input/WS boundary was controlled; no microphone/human-audibility or paid remote-TTS claim. Independent review resolved credential-scope, selected Kitten model readiness, and browser explicit-voice substitution findings. Canonical/Published guide mirrors match and MkDocs build passed. ADR: backlog/decisions/004-persona-live-tts-provider-selection.md. Evidence and limitations: Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md. Added incident-based lesson; temporary browser harness removed from product public files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed Kokoro-only Persona Live preparation, preserved configured provider/model/voice through effective credentials and cleanup, and corrected both Buddy guides. Verified 265 Python and 111 frontend tests, zero Bandit findings, actual browser synthesis/Stop, and real Parakeet/DeepSeek server route. Remaining physical voice, provider deployment and Buddy animation limits are explicitly recorded.
+<!-- SECTION:FINAL_SUMMARY:END -->
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
+++ b/backlog/tasks/task-13214 - Honor-configured-Persona-Live-speech-provider-without-Kokoro-lock-in.md
@@ -8,7 +8,7 @@ labels:
 - voice
 - bug
 priority: high
-updated_date: 2026-09-07 16:44
+updated_date: 2026-09-07 17:24
 ---
 
 ## Description
@@ -28,22 +28,24 @@ Remove the UAT-specific Kokoro restriction so Persona Live prepares and speaks t
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes. ADR path: backlog/decisions/004-persona-live-tts-provider-selection.md. Reason: preserve selected TTS provider/model/voice through authenticated preparation and synthesis, including optional persisted model and lazy selected Kitten model readiness.
-1. Reproduce provider/default failures and audit voice paths.
-2. Restore shared TTS resolution, effective credentials and owned cleanup; retain browser speech and explicit model transport.
-3. Verify selected provider, failure, stop and actual native browser speech/server route.
-4. Review, update guides and evidence, run focused checks and commit.
+ADR required: no new ADR. Existing ADR: backlog/decisions/004-persona-live-tts-provider-selection.md; clarify blank-voice precedence and cleanup ownership within that boundary.
+1. Add failing tests for configured matching-provider voice/default and explicit override, unrelated provider isolation, Kitten invalid voice, and error-path cleanup ordering.
+2. Implement minimal resolution/preparation/cleanup fixes and show active TTS model; preserve connected-session baseline semantics.
+3. Update canonical/Published guides with Disconnect then Connect; recheck links and mirrors.
+4. Run focused backend/frontend tests, lint/Bandit, scoped independent review, and commit.
 <!-- SECTION:PLAN:END -->
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented provider/model/voice selection, shared authenticated TTS credential scope, browser playback recovery and temporary adapter cleanup. Kitten preparation warms the requested model through its cache; Chat preparation no longer requires a static server key. Guides corrected in both repositories. Final verification/evidence recording in progress.
 Verification complete: 265 focused Python and 111 frontend tests passed; Bandit found zero issues in all seven changed production Python files. Targeted new Python Ruff/Black checks pass. Frontend ESLint has zero errors and 58 confirmed baseline warnings; large legacy Python formatting/lint debt remains unchanged. Real restarted server prepared Parakeet + browser TTS, dispatched the authorized DeepSeek Persona reply, acknowledged voice Stop, and stopped the session with HTTP 200. Real native SpeechSynthesis through the production controller emitted start/end and stopped a long reply with no queued speech. The browser input/WS boundary was controlled; no microphone/human-audibility or paid remote-TTS claim. Independent review resolved credential-scope, selected Kitten model readiness, and browser explicit-voice substitution findings. Canonical/Published guide mirrors match and MkDocs build passed. ADR: backlog/decisions/004-persona-live-tts-provider-selection.md. Evidence and limitations: Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md. Added incident-based lesson; temporary browser harness removed from product public files.
+Reopened for four user-approved review corrections: consistent blank voice/default precedence, Kitten voice validation before readiness, speech generator cleanup inside credential scope, and documented reconnect with visible active model. Add failure-first regressions and scoped re-review before committing.
+All four second-review findings addressed. Blank voices remain unset in the frontend and resolve the configured global voice only for its provider; explicit voices remain authoritative. Kitten validates the selected voice with the loaded runtime. Speech generators close within the credential scope, including partial-audio errors. Live displays model selection and reconnect guidance; both guides and Published mirrors require Disconnect then Connect after saving connected-session voice defaults. Failure-first reproduction: five backend and seven frontend failures. Final checks: 278 Python tests, 116 frontend tests, Ruff/Black clean on changed Python, Bandit zero findings, ESLint zero errors/two existing warnings, MkDocs build and links/mirrors pass. Two scoped independent re-reviews found no residual issues. Live UI labels checked, isolated backend restarted from matching source manifest and /health returned 200. No microphone or physical audio UAT repeated. Evidence appended in Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md; ADR-004 clarified.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Removed Kokoro-only Persona Live preparation, preserved configured provider/model/voice through effective credentials and cleanup, and corrected both Buddy guides. Verified 265 Python and 111 frontend tests, zero Bandit findings, actual browser synthesis/Stop, and real Parakeet/DeepSeek server route. Remaining physical voice, provider deployment and Buddy animation limits are explicitly recorded.
+Removed Kokoro lock-in and addressed all four follow-up findings: correct provider-owned default voice, pre-recording Kitten voice validation, deterministic speech cleanup before credential disposal, and actionable reconnect guidance with Live model display. Verified 278 Python and 116 frontend tests, zero Bandit findings, clean scoped re-review, built/synchronized guides and healthy restarted UAT server. Physical all-provider voice qualification remains outside this correction.
 <!-- SECTION:FINAL_SUMMARY:END -->
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
@@ -684,6 +684,27 @@ async def get_tts_health(request: Request, tts_service: TTSServiceV2 = Depends(g
         except Exception:
             logger.debug("Kokoro health enrichment failed")
 
+        # Kitten registry availability means its lazy adapter can accept requests;
+        # only a successful selected-model load proves assets and dependencies ready.
+        kitten_detail = provider_details.get("kitten_tts")
+        if isinstance(kitten_detail, dict):
+            registry = getattr(factory, "registry", None)
+            cached_adapters = getattr(registry, "_adapters", {})
+            kitten_adapter = cached_adapters.get("kitten_tts")
+            if kitten_adapter is not None:
+                runtime_info = kitten_adapter.get_runtime_readiness()
+                kitten_detail.update(runtime_info)
+                if not runtime_info["runtime_ready"]:
+                    failed = runtime_info["runtime_reason"] == "model_load_failed"
+                    availability = "unhealthy" if failed else "unprepared"
+                    kitten_detail.update(status=availability, availability=availability, failed=failed)
+                for entry in capability_envelopes:
+                    if entry.get("provider") == "kitten_tts":
+                        entry.update(runtime_info)
+                        if not runtime_info["runtime_ready"]:
+                            entry["availability"] = kitten_detail["availability"]
+                _recompute_health_rollup(health, provider_details, capability_envelopes)
+
         return health
     except Exception as e:
         logger.exception("Error getting TTS health")

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -3533,6 +3533,7 @@ async def _send_persona_live_audio_pair(
 
 
 async def _prepare_persona_live_tts(voice_runtime: dict[str, Any], *, user_id: int | None = None, auth_request: Any = None) -> None:
+    """Validate the authenticated Live speech selection before recording begins."""
     from tldw_Server_API.app.core.Persona.live_tts import prepare_persona_speech
 
     await prepare_persona_speech(voice_runtime, user_id=user_id, auth_request=auth_request)
@@ -3542,6 +3543,7 @@ async def _generate_persona_live_tts_audio(
     text: str, *, provider: str | None, voice: str | None, model: str | None = None,
     response_format: str = "mp3", user_id: int | None = None, auth_request: Any = None,
 ) -> tuple[bytes, str]:
+    """Return Live audio bytes and format through the selected authenticated provider."""
     from tldw_Server_API.app.core.Persona.live_tts import generate_persona_speech
 
     return await generate_persona_speech(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -3532,59 +3532,22 @@ async def _send_persona_live_audio_pair(
         return True
 
 
-async def _prepare_persona_live_tts(voice_runtime: dict[str, Any]) -> None:
-    """Load the supported local speech runtime without synthesizing or playing audio."""
-    provider = str(voice_runtime.get("tts_provider") or "").strip().lower()
-    if provider not in {"tldw", "kokoro"}:
-        raise ValueError("Select local Kokoro speech output in Persona Live voice settings.")
-    from tldw_Server_API.app.core.TTS.tts_service_v2 import get_tts_service_v2
+async def _prepare_persona_live_tts(voice_runtime: dict[str, Any], *, user_id: int | None = None, auth_request: Any = None) -> None:
+    from tldw_Server_API.app.core.Persona.live_tts import prepare_persona_speech
 
-    service = await get_tts_service_v2()
-    adapter = await service._get_adapter(model="kokoro", provider="kokoro")
-    if adapter is None or not await adapter.ensure_initialized():
-        raise RuntimeError("Kokoro speech output is unavailable.")
-    # Kokoro's lazy initialize reports AVAILABLE before loading model/voice assets.
-    if not await adapter._ensure_model_loaded():
-        raise RuntimeError("Kokoro model and voice assets could not be loaded.")
+    await prepare_persona_speech(voice_runtime, user_id=user_id, auth_request=auth_request)
 
 
 async def _generate_persona_live_tts_audio(
-    text: str,
-    *,
-    provider: str | None,
-    voice: str | None,
-    response_format: str = "mp3",
+    text: str, *, provider: str | None, voice: str | None, model: str | None = None,
+    response_format: str = "mp3", user_id: int | None = None, auth_request: Any = None,
 ) -> tuple[bytes, str]:
-    provider_norm = str(provider or "").strip().lower()
-    voice_norm = str(voice or "").strip()
-    if not provider_norm or provider_norm == "browser":
-        return b"", response_format
+    from tldw_Server_API.app.core.Persona.live_tts import generate_persona_speech
 
-    provider_norm = "kokoro" if provider_norm == "tldw" else provider_norm
-    model_name = "tts-1" if provider_norm == "openai" else provider_norm
-
-    from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
-    from tldw_Server_API.app.core.TTS.tts_service_v2 import get_tts_service_v2
-
-    tts_service = await get_tts_service_v2()
-    request = OpenAISpeechRequest(
-        model=model_name,
-        input=text,
-        voice=voice_norm or "af_heart",
-        response_format=response_format,
-        stream=False,
+    return await generate_persona_speech(
+        text, provider=provider, model=model, voice=voice,
+        response_format=response_format, user_id=user_id, auth_request=auth_request,
     )
-
-    audio_chunks: list[bytes] = []
-    async for chunk in tts_service.generate_speech(
-        request=request,
-        provider=provider_norm,
-        fallback=False,
-    ):
-        if chunk:
-            audio_chunks.append(chunk)
-
-    return b"".join(audio_chunks), response_format
 
 
 def _is_authnz_access_token(token: str) -> bool:
@@ -8432,7 +8395,10 @@ async def persona_stream(
                 audio_bytes, audio_format = await _generate_persona_live_tts_audio(
                     assistant_text,
                     provider=provider,
+                    model=voice_runtime.get("tts_model"),
                     voice=voice,
+                    user_id=int(authenticated_user_id),
+                    auth_request=ws,
                     response_format="mp3",
                 )
                 if not audio_bytes:
@@ -8450,7 +8416,7 @@ async def persona_stream(
                         user_id=connection_user_id,
                         preferences={"voice_runtime": updated_voice_runtime},
                     )
-                logger.debug(f"persona live TTS unavailable for session {session_id}: {exc}")
+                logger.debug("Persona Live TTS unavailable; error_type={}", type(exc).__name__)
                 _mark_persona_live_processing_progress(session_id)
                 _upsert_persona_live_session_summary_safe(
                     session_id=session_id,
@@ -8660,8 +8626,8 @@ async def persona_stream(
                 if not persona_live_voice_registry.is_preparing(**key, token=token):
                     return
                 reason_code = "VOICE_TTS_UNAVAILABLE"
-                message = "Select local Kokoro speech output and install its model and voice assets in server audio settings."
-                await _prepare_persona_live_tts(voice_runtime)
+                message = "The selected speech output could not prepare. Check its provider, model, voice, credentials and dependencies in audio settings."
+                await _prepare_persona_live_tts(voice_runtime, user_id=int(authenticated_user_id), auth_request=ws)
                 if not persona_live_voice_registry.is_preparing(**key, token=token):
                     return
                 turn_detector = None
@@ -10178,6 +10144,7 @@ async def persona_stream(
                 ),
                 "tts_provider": str(tts_payload.get("provider") or "").strip() or None,
                 "tts_voice": str(tts_payload.get("voice") or "").strip() or None,
+                "tts_model": str(tts_payload.get("model") or "").strip() or None,
                 "text_only_due_to_tts_failure": False,
             }
 

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -765,6 +765,7 @@ class PersonaVoiceDefaults(BaseModel):
     stt_language: str | None = None
     stt_model: str | None = None
     tts_provider: str | None = None
+    tts_model: str | None = None
     tts_voice: str | None = None
     confirmation_mode: PersonaConfirmationMode | None = None
     voice_chat_trigger_phrases: list[str] = Field(default_factory=list)
@@ -777,7 +778,7 @@ class PersonaVoiceDefaults(BaseModel):
     turn_stop_secs: float | None = None
     min_utterance_secs: float | None = None
 
-    @field_validator("stt_language", "stt_model", "tts_provider", "tts_voice", mode="before")
+    @field_validator("stt_language", "stt_model", "tts_provider", "tts_model", "tts_voice", mode="before")
     @classmethod
     def _strip_optional_text(cls, value: Any) -> Any:
         if not isinstance(value, str):

--- a/tldw_Server_API/app/core/Persona/live_conversation.py
+++ b/tldw_Server_API/app/core/Persona/live_conversation.py
@@ -27,30 +27,16 @@ def resolve_persona_conversation_target() -> Any:
 
 
 def require_persona_voice_conversation_credentials() -> Any:
-    """Conservatively qualify voice against server-configured Chat credentials.
+    """Validate the configured voice Chat target, retaining the legacy name.
 
-    User-scoped BYOK credentials remain supported by the normal text Chat route;
-    this local preparation check does not certify their availability for voice.
+    Preparation has no authenticated credential scope and cannot establish
+    readiness from server keys: the caller may use BYOK, and a configured key
+    does not guarantee admission. Each turn enters the ordinary authenticated
+    Chat HTTP route, which owns effective credentials, moderation and budgets.
+    This check performs no provider request and does not certify Chat access.
     """
-    from tldw_Server_API.app.core.Chat.chat_service import resolve_static_provider_fallback
-    from tldw_Server_API.app.core.LLM_Calls.adapter_utils import provider_auth_is_resolved
-    from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
-
     try:
-        target = resolve_persona_conversation_target()
-        credentials = resolve_static_provider_fallback(target.provider)
-        if provider_requires_api_key(target.provider) and not provider_auth_is_resolved(
-            target.provider,
-            api_key=credentials.api_key,
-            app_config=credentials.app_config,
-            credentials_resolved=True,
-        ):
-            raise PersonaConversationError(
-                "Voice preparation requires server-configured credentials for the default Chat provider."
-            )
-        return target
-    except PersonaConversationError:
-        raise
+        return resolve_persona_conversation_target()
     except (ValueError, TypeError, KeyError):
         raise PersonaConversationError(
             "Configure a supported default Chat provider and model in server settings."

--- a/tldw_Server_API/app/core/Persona/live_tts.py
+++ b/tldw_Server_API/app/core/Persona/live_tts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import aclosing, asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -86,7 +86,14 @@ async def resolve_persona_speech(
         "kitten_tts": "KittenML/kitten-tts-nano-0.8",
     }
     resolved_model = _text(model) or _text(config.get("model")) or model_defaults.get(selected, selected)
-    resolved_voice = _text(voice) or _text(config.get("default_voice"))
+    from tldw_Server_API.app.core.TTS.tts_config import get_tts_config
+    from tldw_Server_API.app.core.TTS.tts_request_resolution import normalize_tts_provider
+
+    resolved_voice = _text(voice)
+    if not resolved_voice:
+        tts_config = get_tts_config()
+        if normalize_tts_provider(tts_config.default_provider) == selected:
+            resolved_voice = _text(tts_config.default_voice)
     async with tts_provider_credential_scope(
         provider=selected,
         model=resolved_model,
@@ -148,7 +155,8 @@ async def prepare_persona_speech(
             # Kitten initialization is model-independent; warm the exact model
             # through its cached loader, which synthesis also uses.
             if selected == "kitten_tts":
-                await adapter._load_runtime_for_model(adapter._resolve_model_name(prepared.model))
+                runtime = await adapter._load_runtime_for_model(adapter._resolve_model_name(prepared.model))
+                runtime.resolve_voice(prepared.voice)
             # Kokoro loads assets lazily after initialization.
             if selected == "kokoro" and not await adapter._ensure_model_loaded():
                 raise RuntimeError("Kokoro model and voice assets could not be loaded.")
@@ -182,15 +190,18 @@ async def generate_persona_speech(
         auth_request=auth_request,
     ) as (service, selected, request, overrides):
         chunks: list[bytes] = []
-        async for chunk in service.generate_speech(
-            request=request,
-            provider=selected,
-            fallback=False,
-            user_id=user_id,
-            provider_overrides=overrides,
-        ):
-            if chunk:
-                if not chunks and chunk.startswith(b"ERROR:"):
-                    raise RuntimeError("The selected speech provider failed to generate audio.")
-                chunks.append(chunk)
+        async with aclosing(
+            service.generate_speech(
+                request=request,
+                provider=selected,
+                fallback=False,
+                user_id=user_id,
+                provider_overrides=overrides,
+            )
+        ) as speech:
+            async for chunk in speech:
+                if chunk:
+                    if chunk.startswith(b"ERROR:"):
+                        raise RuntimeError("The selected speech provider failed to generate audio.")
+                    chunks.append(chunk)
         return b"".join(chunks), response_format

--- a/tldw_Server_API/app/core/Persona/live_tts.py
+++ b/tldw_Server_API/app/core/Persona/live_tts.py
@@ -12,6 +12,7 @@ from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterRegistry
 
 
 def _text(value: Any) -> str:
+    """Trim string settings; treat missing or non-string values as unset."""
     return value.strip() if isinstance(value, str) else ""
 
 

--- a/tldw_Server_API/app/core/Persona/live_tts.py
+++ b/tldw_Server_API/app/core/Persona/live_tts.py
@@ -1,0 +1,196 @@
+"""Resolve Persona speech through the configured TTS adapters, without fallback."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterRegistry
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+@asynccontextmanager
+async def resolve_persona_speech(
+    *,
+    text: str,
+    provider: str | None,
+    model: str | None,
+    voice: str | None,
+    response_format: str = "mp3",
+    user_id: int | None = None,
+    auth_request: Any = None,
+) -> AsyncIterator[tuple[Any, str, OpenAISpeechRequest, Any]]:
+    """Resolve one selected route; never infer a different provider from a model."""
+    from tldw_Server_API.app.core.TTS.tts_service_v2 import get_tts_service_v2
+
+    selected = _text(provider).lower()
+    # Preserve the existing Persona alias; new profiles can select Kokoro directly.
+    selected = "kokoro" if selected == "tldw" else selected
+    if not selected or selected == "browser":
+        raise ValueError("Select a server speech provider for server audio output.")
+    service = await get_tts_service_v2()
+    registered = TTSAdapterRegistry.resolve_provider(selected)
+    if registered is None:
+        manager = getattr(service, "gateway_config_manager", None)
+        specs = manager.get_gateway_specs() if manager is not None else {}
+        spec = specs.get(selected)
+        if spec is None:
+            raise ValueError("The selected speech provider is not registered.")
+        from tldw_Server_API.app.core.TTS.gateway_preflight import preflight_gateway_speech
+
+        route = preflight_gateway_speech(
+            backend=selected,
+            model=_text(model) or spec.default_model or "",
+            voice=_text(voice) or None,
+            voice_supplied=bool(_text(voice)),
+            response_format=response_format,
+            allow_fallback=False,
+            supplied_fields={"voice"} if _text(voice) else set(),
+            gateway_specs=specs,
+            text_length=len(text),
+        )
+        resolver = getattr(service, "gateway_credential_resolver", None)
+        if resolver is None or getattr(service, "gateway_executor", None) is None:
+            raise ValueError("The selected speech gateway is unavailable.")
+        credential = await resolver(selected, user_id=user_id, gateway_spec=spec)
+        if not _text(credential.api_key):
+            raise ValueError("Configure credentials for the selected speech gateway.")
+        request = OpenAISpeechRequest(
+            backend=selected,
+            model=route.model,
+            voice=route.voice,
+            input=text,
+            response_format=response_format,
+            stream=False,
+            allow_fallback=False,
+        )
+        yield service, selected, request, None
+        return
+
+    from tldw_Server_API.app.core.Audio.tts_service import (
+        _capture_tts_provider_config,
+        tts_provider_credential_scope,
+    )
+
+    selected = registered.value
+    config = _capture_tts_provider_config(selected)
+    model_defaults = {
+        "openai": "tts-1",
+        "elevenlabs": "eleven_monolingual_v1",
+        "kitten_tts": "KittenML/kitten-tts-nano-0.8",
+    }
+    resolved_model = _text(model) or _text(config.get("model")) or model_defaults.get(selected, selected)
+    resolved_voice = _text(voice) or _text(config.get("default_voice"))
+    async with tts_provider_credential_scope(
+        provider=selected,
+        model=resolved_model,
+        request=auth_request,
+        current_user=SimpleNamespace(id=user_id),
+    ) as (owner, overrides, _, _):
+        # Local models have no credential/endpoint override to apply; retain the
+        # shared model cache. Policy was still enforced by the scope above.
+        effective_overrides = overrides if set(overrides) - {"credentials_resolved"} else None
+        if selected == "openai" and effective_overrides is not None:
+            effective_overrides = {**effective_overrides, "verify_api_key_on_init": False}
+        request = OpenAISpeechRequest(
+            model=resolved_model,
+            input=text,
+            voice=resolved_voice,
+            response_format=response_format,
+            stream=False,
+        )
+        yield service, selected, request, effective_overrides
+
+
+async def prepare_persona_speech(
+    voice_runtime: dict[str, Any],
+    *,
+    user_id: int | None = None,
+    auth_request: Any = None,
+) -> None:
+    """Validate selected speech without synthesis; browser owns browser readiness."""
+    if _text(voice_runtime.get("tts_provider")).lower() == "browser":
+        return
+    async with resolve_persona_speech(
+        text="Voice readiness check.",
+        provider=voice_runtime.get("tts_provider"),
+        model=voice_runtime.get("tts_model"),
+        voice=voice_runtime.get("tts_voice"),
+        user_id=user_id,
+        auth_request=auth_request,
+    ) as (service, selected, request, overrides):
+        if request.backend is not None:
+            return  # Gateway preflight above validates config and credentials only.
+        unified = service._convert_request(request)
+        prepared = None
+        adapter = None
+        try:
+            adapter, _, prepared = await service._prepare_generate_speech_request(
+                request=request,
+                tts_request=unified,
+                provider=selected,
+                provider_hint=selected,
+                provider_overrides=overrides,
+                fallback=False,
+                user_id=user_id,
+            )
+            if not await adapter.ensure_initialized():
+                raise RuntimeError("The selected speech provider could not initialize.")
+            result = await adapter.validate_request(prepared)
+            if isinstance(result, tuple) and not result[0]:
+                raise ValueError("The selected speech model, voice or output format is unavailable.")
+            # Kitten initialization is model-independent; warm the exact model
+            # through its cached loader, which synthesis also uses.
+            if selected == "kitten_tts":
+                await adapter._load_runtime_for_model(adapter._resolve_model_name(prepared.model))
+            # Kokoro loads assets lazily after initialization.
+            if selected == "kokoro" and not await adapter._ensure_model_loaded():
+                raise RuntimeError("Kokoro model and voice assets could not be loaded.")
+        finally:
+            try:
+                service._cleanup_transient_pocket_tts_cpp_voice_path(prepared or unified)
+            finally:
+                await service._close_request_adapter(adapter, overrides)
+
+
+async def generate_persona_speech(
+    text: str,
+    *,
+    provider: str | None,
+    voice: str | None,
+    model: str | None = None,
+    response_format: str = "mp3",
+    user_id: int | None = None,
+    auth_request: Any = None,
+) -> tuple[bytes, str]:
+    """Generate through the selected route and authenticated credential scope."""
+    if _text(provider).lower() == "browser":
+        return b"", response_format
+    async with resolve_persona_speech(
+        text=text,
+        provider=provider,
+        model=model,
+        voice=voice,
+        response_format=response_format,
+        user_id=user_id,
+        auth_request=auth_request,
+    ) as (service, selected, request, overrides):
+        chunks: list[bytes] = []
+        async for chunk in service.generate_speech(
+            request=request,
+            provider=selected,
+            fallback=False,
+            user_id=user_id,
+            provider_overrides=overrides,
+        ):
+            if chunk:
+                if not chunks and chunk.startswith(b"ERROR:"):
+                    raise RuntimeError("The selected speech provider failed to generate audio.")
+                chunks.append(chunk)
+        return b"".join(chunks), response_format

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -715,8 +715,13 @@ class TTSAdapterRegistry:
             provider_cfg.update(overrides)
 
         adapter = adapter_class(config=provider_cfg)
+        initialized = False
         try:
-            success = await adapter.ensure_initialized()
+            initialized = await adapter.ensure_initialized()
+            if not initialized:
+                logger.error(f"Failed to initialize {provider_key} adapter with overrides")
+                return None
+            return adapter
         except _TTS_REGISTRY_ADAPTER_EXCEPTIONS as exc:
             logger.error(
                 "Error initializing {} adapter with overrides ({})",
@@ -724,10 +729,16 @@ class TTSAdapterRegistry:
                 _safe_exception_label(exc),
             )
             return None
-        if not success:
-            logger.error(f"Failed to initialize {provider_key} adapter with overrides")
-            return None
-        return adapter
+        finally:
+            if not initialized:
+                try:
+                    await adapter.close()
+                except Exception as close_error:  # noqa: BLE001 - preserve the primary init result.
+                    logger.warning(
+                        "Error closing abandoned {} override adapter ({})",
+                        provider_key,
+                        type(close_error).__name__,
+                    )
 
     async def _initialize_adapter(
         self,

--- a/tldw_Server_API/app/core/TTS/adapters/kitten_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/kitten_tts_adapter.py
@@ -69,6 +69,7 @@ class KittenTTSAdapter(TTSAdapter):
         self._audio_normalizer = AudioNormalizer()
         self._runtime: Optional[KittenRuntime] = None
         self._runtime_assets = None
+        self._runtime_load_failed = False
         self._runtime_lock = asyncio.Lock()
         self._voice_infos = self._build_voice_infos()
 
@@ -93,6 +94,7 @@ class KittenTTSAdapter(TTSAdapter):
         async with self._runtime_lock:
             active_repo = getattr(self._runtime_assets, "repo_id", None)
             if self._runtime is not None and active_repo == model_name:
+                self._runtime_load_failed = False
                 return self._runtime
 
             try:
@@ -107,6 +109,7 @@ class KittenTTSAdapter(TTSAdapter):
                 )
                 runtime = await asyncio.to_thread(KittenRuntime, assets)
             except Exception as exc:
+                self._runtime_load_failed = True
                 raise TTSProviderInitializationError(
                     "Failed to initialize KittenTTS runtime",
                     provider=self.PROVIDER_KEY,
@@ -115,13 +118,23 @@ class KittenTTSAdapter(TTSAdapter):
 
             self._runtime_assets = assets
             self._runtime = runtime
-            self.model_name = assets.repo_id
-            self.model_revision = assets.revision
+            self._runtime_load_failed = False
             self.sample_rate = int(getattr(runtime, "sample_rate", self.sample_rate))
             return runtime
 
+    def get_runtime_readiness(self) -> dict[str, Any]:
+        """Report loaded-model readiness without loading assets or exposing errors."""
+        reason = (
+            "model_load_failed" if self._runtime_load_failed else "model_not_loaded" if self._runtime is None else None
+        )
+        return {
+            "runtime_ready": reason is None,
+            "runtime_reason": reason,
+            "runtime_model": getattr(self._runtime_assets, "repo_id", None),
+        }
+
     async def initialize(self) -> bool:
-        """Initialize capabilities; load the request-selected model on demand."""
+        """Make the lazy adapter routable; runtime readiness requires a model load."""
         logger.info("KittenTTS adapter initialized; model assets load on demand")
         return True
 
@@ -238,3 +251,4 @@ class KittenTTSAdapter(TTSAdapter):
     async def _cleanup_resources(self) -> None:
         self._runtime = None
         self._runtime_assets = None
+        self._runtime_load_failed = False

--- a/tldw_Server_API/app/core/TTS/adapters/kitten_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/kitten_tts_adapter.py
@@ -117,12 +117,12 @@ class KittenTTSAdapter(TTSAdapter):
             self._runtime = runtime
             self.model_name = assets.repo_id
             self.model_revision = assets.revision
+            self.sample_rate = int(getattr(runtime, "sample_rate", self.sample_rate))
             return runtime
 
     async def initialize(self) -> bool:
-        runtime = await self._load_runtime_for_model(self.model_name)
-        self.sample_rate = int(getattr(runtime, "sample_rate", self.sample_rate))
-        logger.info("KittenTTS adapter initialized for model {}", self.model_name)
+        """Initialize capabilities; load the request-selected model on demand."""
+        logger.info("KittenTTS adapter initialized; model assets load on demand")
         return True
 
     async def get_capabilities(self) -> TTSCapabilities:

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -559,6 +559,28 @@ class TTSServiceV2:
             with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
                 await audio_stream.aclose()
 
+    async def _close_request_adapter(
+        self, adapter: Optional[TTSAdapter], provider_overrides: Optional[dict[str, Any]]
+    ) -> None:
+        """Close non-cached adapters selected by `_get_adapter` for this request.
+
+        Explicit overrides and OmniVoice's injected supervisor create owned
+        instances. All other adapters remain owned by the registry cache.
+        """
+        if adapter is None:
+            return
+        provider_key = self._resolve_provider_key(adapter)
+        if not provider_overrides and provider_key != "omnivoice":
+            return
+        registry = getattr(self.factory or self._factory, "registry", None)
+        cached_adapters = getattr(registry, "_adapters", {})
+        if any(cached is adapter for cached in cached_adapters.values()):
+            return
+        try:
+            await adapter.close()
+        except Exception as exc:  # noqa: BLE001 - cleanup must preserve the primary result.
+            logger.warning("Error closing request-owned {} adapter ({})", provider_key, type(exc).__name__)
+
     async def _prepare_generate_speech_request(
         self,
         *,
@@ -572,6 +594,7 @@ class TTSServiceV2:
     ) -> tuple[TTSAdapter, str, TTSRequest]:
         """Resolve provider-managed request state before execution begins."""
         prepared = False
+        adapter: Optional[TTSAdapter] = None
         try:
             self._apply_token_defaults(tts_request)
             # Run a generic validation pass first so provider-specific requirements
@@ -617,7 +640,10 @@ class TTSServiceV2:
             return adapter, provider_key, request_for_provider
         finally:
             if not prepared:
-                self._cleanup_transient_pocket_tts_cpp_voice_path(tts_request)
+                try:
+                    self._cleanup_transient_pocket_tts_cpp_voice_path(tts_request)
+                finally:
+                    await self._close_request_adapter(adapter, provider_overrides)
 
     def _get_tts_request_observability(
         self,
@@ -2163,19 +2189,20 @@ class TTSServiceV2:
             except _TTS_NONCRITICAL_EXCEPTIONS:
                 pass
 
-        await self._increment_active_requests(provider_key)
-
         # Generate speech with circuit breaker and comprehensive error handling
+        active_requests_incremented = False
+        circuit_breaker = None
+        manual_stream_breaker = False
+        manual_stream_breaker_recorded = False
         try:
+            await self._increment_active_requests(provider_key)
+            active_requests_incremented = True
             async with self._semaphore:
                 async with self._provider_concurrency_guard(provider_key):
                     logger.info(f"Generating speech with {provider_key}")
 
                     # Get circuit breaker if available
-                    circuit_breaker = None
                     breaker_provider_key = provider_key
-                    manual_stream_breaker = False
-                    manual_stream_breaker_recorded = False
                     if self.circuit_manager:
                         breaker_provider_key = self._resolve_circuit_breaker_key(provider_key, adapter)
                         circuit_breaker = await self.circuit_manager.get_breaker(breaker_provider_key)
@@ -2497,13 +2524,16 @@ class TTSServiceV2:
                 else:
                     raise_detached_error(tts_error)
         finally:
-            await self._close_response_audio_stream(response)
-            self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
             try:
-                if not released_active_slot:
-                    await self._decrement_active_requests(provider_key)
-            except _TTS_NONCRITICAL_EXCEPTIONS:
-                pass
+                await self._close_response_audio_stream(response)
+                self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
+                try:
+                    if active_requests_incremented and not released_active_slot:
+                        await self._decrement_active_requests(provider_key)
+                except _TTS_NONCRITICAL_EXCEPTIONS:
+                    pass
+            finally:
+                await self._close_request_adapter(adapter, provider_overrides)
 
         if fallback_plan:
             if metadata_only:

--- a/tldw_Server_API/tests/Audio/test_tts_credential_runtime_boundary.py
+++ b/tldw_Server_API/tests/Audio/test_tts_credential_runtime_boundary.py
@@ -2386,7 +2386,7 @@ async def test_tts_authoritative_overrides_disable_cross_provider_fallback() -> 
             return SimpleNamespace()
 
         def _convert_request(self, _request):
-            return SimpleNamespace(extra_params={})
+            return SimpleNamespace(extra_params={}, backend=None)
 
         def _resolve_observability_context(self, _request, *, explicit_request_id=None):
             return explicit_request_id or "request-id", None

--- a/tldw_Server_API/tests/Docs/test_top_guides_docs_path_hygiene_script.py
+++ b/tldw_Server_API/tests/Docs/test_top_guides_docs_path_hygiene_script.py
@@ -1,11 +1,59 @@
+"""Local documentation checks must not resolve external URLs in this repository."""
+
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
-def test_top_guides_docs_path_hygiene_script_passes() -> None:
+def _load_checker() -> ModuleType:
+    """Load the documentation checker without executing its CLI entry point."""
     script = Path("Helper_Scripts/docs/check_top_guides_docs_path_hygiene.py")
     spec = spec_from_file_location("check_top_guides_docs_path_hygiene", script)
     assert spec is not None and spec.loader is not None
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
+    return module
+
+
+def test_top_guides_docs_path_hygiene_script_passes() -> None:
+    """Check the actual guides for broken repository references."""
+    module = _load_checker()
     assert module.main() == 0
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "[Chatbook](https://github.com/example/chatbook/blob/dev/Docs/User_Guide/index.md)",
+        "<https://example.org/Docs/User_Guide/index.md>",
+        "http://example.org/Docs/User_Guide/index.md",
+        "[Docs](//example.org/Docs/User_Guide/index.md)",
+    ],
+)
+def test_external_urls_do_not_hide_missing_local_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reference: str
+) -> None:
+    """Ignore remote targets while retaining local references on the same line."""
+    module = _load_checker()
+    guide = tmp_path / "guide.md"
+    guide.write_text(f"{reference} and [local](Docs/missing.md)\n", encoding="utf-8")
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "GUIDE_DIRS", ())
+    monkeypatch.setattr(module, "GUIDE_FILES", (guide,))
+    assert module._collect_missing_paths() == [("guide.md", "Docs/missing.md")]
+
+
+def test_repeated_local_slashes_are_not_external_urls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid local path with repeated separators still needs existence checks."""
+    module = _load_checker()
+    (tmp_path / "Docs" / "User_Guides").mkdir(parents=True)
+    guide = tmp_path / "guide.md"
+    guide.write_text("[local](Docs/User_Guides//missing.md)", encoding="utf-8")
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "GUIDE_DIRS", ())
+    monkeypatch.setattr(module, "GUIDE_FILES", (guide,))
+    assert module._collect_missing_paths() == [("guide.md", "Docs/User_Guides//missing.md")]

--- a/tldw_Server_API/tests/Persona/test_live_conversation.py
+++ b/tldw_Server_API/tests/Persona/test_live_conversation.py
@@ -23,7 +23,7 @@ def test_target_resolution_does_not_require_static_credentials(monkeypatch: pyte
     assert live.resolve_persona_conversation_target() is target
 
 
-def test_voice_preflight_rejects_missing_server_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_voice_preflight_accepts_target_without_server_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Chat import chat_service
     from tldw_Server_API.app.core.LLM_Calls import adapter_utils, provider_metadata
 
@@ -35,8 +35,8 @@ def test_voice_preflight_rejects_missing_server_credentials(monkeypatch: pytest.
     )
     monkeypatch.setattr(provider_metadata, "provider_requires_api_key", lambda provider: True)
     monkeypatch.setattr(adapter_utils, "provider_auth_is_resolved", lambda *args, **kwargs: False)
-    with pytest.raises(live.PersonaConversationError, match="server-configured credentials"):
-        live.require_persona_voice_conversation_credentials()
+    target = live.require_persona_voice_conversation_credentials()
+    assert (target.provider, target.model) == ("deepseek", "deepseek-chat")
 
 
 pytestmark = pytest.mark.unit

--- a/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
+++ b/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
@@ -1,0 +1,137 @@
+"""Kitten readiness loads the selected model, without synthesizing speech."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tldw_Server_API.app.core.Persona import live_tts
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_Server_API.app.core.TTS.adapters import kitten_tts_adapter as kitten
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError
+
+pytestmark = pytest.mark.unit
+DEFAULT_MODEL = "KittenML/kitten-tts-nano-0.8-fp32"
+SELECTED_MODEL = "KittenML/kitten-tts-mini-0.8"
+
+
+@pytest.fixture
+def kitten_assets(monkeypatch):
+    available = {SELECTED_MODEL}
+    loaded = []
+    synthesized = []
+
+    def load(model_name, **kwargs):
+        loaded.append(model_name)
+        if model_name not in available:
+            raise FileNotFoundError("Selected model assets are unavailable")
+        return SimpleNamespace(repo_id=model_name, revision="fixture-revision")
+
+    class Runtime:
+        sample_rate = 24000
+
+        def __init__(self, assets):
+            self.assets = assets
+
+        def generate(self, text, **kwargs):
+            synthesized.append((self.assets.repo_id, text))
+            return np.zeros(240, dtype=np.float32)
+
+    monkeypatch.setattr(kitten, "download_model_assets", load)
+    monkeypatch.setattr(kitten, "KittenRuntime", Runtime)
+    return SimpleNamespace(available=available, loaded=loaded, synthesized=synthesized)
+
+
+@pytest.fixture
+def kitten_preparation(monkeypatch, kitten_assets):
+    registry = TTSAdapterRegistry(
+        config={
+            "providers": {
+                "kitten_tts": {
+                    "enabled": True,
+                    "model": DEFAULT_MODEL,
+                    "auto_download": False,
+                }
+            }
+        }
+    )
+
+    class Service:
+        def _convert_request(self, request):
+            return TTSRequest(text=request.input, model=request.model, voice=request.voice, format=AudioFormat.MP3)
+
+        async def _prepare_generate_speech_request(self, **kwargs):
+            adapter = await registry.get_adapter("kitten_tts")
+            return adapter, "kitten_tts", kwargs["tts_request"]
+
+        def _cleanup_transient_pocket_tts_cpp_voice_path(self, request):
+            pass
+
+        async def _close_request_adapter(self, adapter, overrides):
+            assert overrides is None
+
+    @asynccontextmanager
+    async def route(**kwargs):
+        from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
+
+        request = OpenAISpeechRequest(model=kwargs["model"], input=kwargs["text"], voice="Bella")
+        yield Service(), "kitten_tts", request, None
+
+    monkeypatch.setattr(live_tts, "resolve_persona_speech", route)
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_kitten_initialization_does_not_require_default_model_assets(kitten_assets):
+    adapter = kitten.KittenTTSAdapter({"model": DEFAULT_MODEL, "auto_download": False})
+    assert await adapter.ensure_initialized()
+    assert adapter._runtime is None
+    assert kitten_assets.loaded == []
+
+
+@pytest.mark.asyncio
+async def test_preparation_loads_selected_kitten_model_and_reuses_it_for_speech(
+    kitten_preparation,
+    kitten_assets,
+):
+    config = {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": "Bella"}
+    await live_tts.prepare_persona_speech(config)
+    await live_tts.prepare_persona_speech(config)
+    assert kitten_assets.loaded == [SELECTED_MODEL]
+    assert kitten_assets.synthesized == []
+    adapter = await kitten_preparation.get_adapter("kitten_tts")
+    response = await adapter.generate(
+        TTSRequest(
+            text="Selected model speech",
+            model=SELECTED_MODEL,
+            voice="Bella",
+            format=AudioFormat.PCM,
+            stream=False,
+        )
+    )
+    assert response.audio_data
+    assert kitten_assets.loaded == [SELECTED_MODEL]
+    assert kitten_assets.synthesized == [(SELECTED_MODEL, "Selected model speech")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selected_model", [SELECTED_MODEL, "Unsupported/kitten-model"])
+async def test_preparation_rejects_unavailable_selected_kitten_model(
+    kitten_preparation,
+    kitten_assets,
+    selected_model,
+):
+    # Mutate the set used by the asset boundary, keeping the default available.
+    kitten_assets.available.clear()
+    kitten_assets.available.add(DEFAULT_MODEL)
+    with pytest.raises((TTSProviderInitializationError, ValueError)):
+        await live_tts.prepare_persona_speech(
+            {
+                "tts_provider": "kitten_tts",
+                "tts_model": selected_model,
+                "tts_voice": "Bella",
+            }
+        )
+    assert kitten_assets.synthesized == []

--- a/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
+++ b/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
@@ -1,11 +1,14 @@
 """Kitten readiness loads the selected model, without synthesizing speech."""
 
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
 
+from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
 from tldw_Server_API.app.core.Persona import live_tts
 from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterRegistry
 from tldw_Server_API.app.core.TTS.adapters import kitten_tts_adapter as kitten
@@ -18,12 +21,12 @@ SELECTED_MODEL = "KittenML/kitten-tts-mini-0.8"
 
 
 @pytest.fixture
-def kitten_assets(monkeypatch):
+def kitten_assets(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     available = {SELECTED_MODEL}
     loaded = []
     synthesized = []
 
-    def load(model_name, **kwargs):
+    def load(model_name: str, **kwargs: Any) -> SimpleNamespace:
         loaded.append(model_name)
         if model_name not in available:
             raise FileNotFoundError("Selected model assets are unavailable")
@@ -35,13 +38,13 @@ def kitten_assets(monkeypatch):
         sample_rate = 24000
         resolve_voice = real_runtime.resolve_voice
 
-        def __init__(self, assets):
+        def __init__(self, assets: SimpleNamespace) -> None:
             self.assets = assets
             self.voice_aliases = dict(kitten.DEFAULT_VOICE_ALIASES)
             self._lower_aliases = {name.lower(): value for name, value in self.voice_aliases.items()}
             self.voices = dict.fromkeys(self.voice_aliases.values())
 
-        def generate(self, text, **kwargs):
+        def generate(self, text: str, **kwargs: Any) -> np.ndarray:
             synthesized.append((self.assets.repo_id, text))
             return np.zeros(240, dtype=np.float32)
 
@@ -51,7 +54,7 @@ def kitten_assets(monkeypatch):
 
 
 @pytest.fixture
-def kitten_preparation(monkeypatch, kitten_assets):
+def kitten_preparation(monkeypatch: pytest.MonkeyPatch, kitten_assets: SimpleNamespace) -> TTSAdapterRegistry:
     registry = TTSAdapterRegistry(
         config={
             "providers": {
@@ -65,23 +68,25 @@ def kitten_preparation(monkeypatch, kitten_assets):
     )
 
     class Service:
-        def _convert_request(self, request):
+        def _convert_request(self, request: OpenAISpeechRequest) -> TTSRequest:
             return TTSRequest(text=request.input, model=request.model, voice=request.voice, format=AudioFormat.MP3)
 
-        async def _prepare_generate_speech_request(self, **kwargs):
+        async def _prepare_generate_speech_request(
+            self, **kwargs: Any
+        ) -> tuple[kitten.KittenTTSAdapter | None, str, TTSRequest]:
             adapter = await registry.get_adapter("kitten_tts")
             return adapter, "kitten_tts", kwargs["tts_request"]
 
-        def _cleanup_transient_pocket_tts_cpp_voice_path(self, request):
+        def _cleanup_transient_pocket_tts_cpp_voice_path(self, request: TTSRequest) -> None:
             pass
 
-        async def _close_request_adapter(self, adapter, overrides):
+        async def _close_request_adapter(
+            self, adapter: kitten.KittenTTSAdapter, overrides: dict[str, Any] | None
+        ) -> None:
             assert overrides is None
 
     @asynccontextmanager
-    async def route(**kwargs):
-        from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
-
+    async def route(**kwargs: Any) -> AsyncIterator[tuple[Service, str, OpenAISpeechRequest, None]]:
         request = OpenAISpeechRequest(model=kwargs["model"], input=kwargs["text"], voice=kwargs["voice"] or "")
         yield Service(), "kitten_tts", request, None
 
@@ -90,7 +95,7 @@ def kitten_preparation(monkeypatch, kitten_assets):
 
 
 @pytest.mark.asyncio
-async def test_kitten_initialization_does_not_require_default_model_assets(kitten_assets):
+async def test_kitten_initialization_does_not_require_default_model_assets(kitten_assets: SimpleNamespace) -> None:
     adapter = kitten.KittenTTSAdapter({"model": DEFAULT_MODEL, "auto_download": False})
     assert await adapter.ensure_initialized()
     assert adapter._runtime is None
@@ -99,9 +104,9 @@ async def test_kitten_initialization_does_not_require_default_model_assets(kitte
 
 @pytest.mark.asyncio
 async def test_preparation_loads_selected_kitten_model_and_reuses_it_for_speech(
-    kitten_preparation,
-    kitten_assets,
-):
+    kitten_preparation: TTSAdapterRegistry,
+    kitten_assets: SimpleNamespace,
+) -> None:
     config = {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": "Bella"}
     await live_tts.prepare_persona_speech(config)
     await live_tts.prepare_persona_speech(config)
@@ -125,10 +130,10 @@ async def test_preparation_loads_selected_kitten_model_and_reuses_it_for_speech(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("selected_model", [SELECTED_MODEL, "Unsupported/kitten-model"])
 async def test_preparation_rejects_unavailable_selected_kitten_model(
-    kitten_preparation,
-    kitten_assets,
-    selected_model,
-):
+    kitten_preparation: TTSAdapterRegistry,
+    kitten_assets: SimpleNamespace,
+    selected_model: str,
+) -> None:
     # Mutate the set used by the asset boundary, keeping the default available.
     kitten_assets.available.clear()
     kitten_assets.available.add(DEFAULT_MODEL)
@@ -145,7 +150,9 @@ async def test_preparation_rejects_unavailable_selected_kitten_model(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("voice", ["af_heart", "not-a-kitten-voice"])
-async def test_preparation_rejects_voice_missing_from_loaded_kitten_runtime(kitten_preparation, kitten_assets, voice):
+async def test_preparation_rejects_voice_missing_from_loaded_kitten_runtime(
+    kitten_preparation: TTSAdapterRegistry, kitten_assets: SimpleNamespace, voice: str
+) -> None:
     with pytest.raises(ValueError, match="not available"):
         await live_tts.prepare_persona_speech(
             {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": voice}
@@ -155,9 +162,121 @@ async def test_preparation_rejects_voice_missing_from_loaded_kitten_runtime(kitt
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("voice", ["", "bella", "Bella"])
-async def test_preparation_accepts_kitten_default_and_supported_aliases(kitten_preparation, kitten_assets, voice):
+async def test_preparation_accepts_kitten_default_and_supported_aliases(
+    kitten_preparation: TTSAdapterRegistry, kitten_assets: SimpleNamespace, voice: str
+) -> None:
     await live_tts.prepare_persona_speech(
         {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": voice}
     )
     assert kitten_assets.loaded == [SELECTED_MODEL]
+    assert kitten_assets.synthesized == []
+
+
+@pytest.mark.asyncio
+async def test_persona_override_does_not_change_cached_default_model(
+    kitten_preparation: TTSAdapterRegistry, kitten_assets: SimpleNamespace
+) -> None:
+    kitten_assets.available.add(DEFAULT_MODEL)
+    await live_tts.prepare_persona_speech(
+        {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": "Bella"}
+    )
+    adapter = await kitten_preparation.get_adapter("kitten_tts")
+    response = await adapter.generate(
+        TTSRequest(text="Default model speech", voice="Bella", format=AudioFormat.PCM, stream=False)
+    )
+    assert response.model == DEFAULT_MODEL
+    assert kitten_assets.synthesized == [(DEFAULT_MODEL, "Default model speech")]
+
+
+@pytest.fixture
+def kitten_health(
+    monkeypatch: pytest.MonkeyPatch, kitten_preparation: TTSAdapterRegistry
+) -> Callable[[], Awaitable[dict[str, Any]]]:
+    from tldw_Server_API.app.api.v1.endpoints.audio import audio_health
+    from tldw_Server_API.app.core.TTS import adapter_registry
+
+    class Service:
+        def get_status(self) -> dict[str, Any]:
+            return kitten_preparation.get_status_summary()
+
+        async def get_capabilities(self) -> dict[str, Any]:
+            return {}
+
+    async def list_capabilities(**kwargs: Any) -> list[dict[str, Any]]:
+        # Limit health discovery to the provider under test; no other models load.
+        return [{"provider": "kitten_tts", "availability": "enabled", "capabilities": None}]
+
+    async def factory() -> SimpleNamespace:
+        return SimpleNamespace(registry=kitten_preparation)
+
+    monkeypatch.setattr(kitten_preparation, "list_capabilities", list_capabilities)
+    monkeypatch.setattr(adapter_registry, "get_tts_factory", factory)
+
+    async def health() -> dict[str, Any]:
+        return await audio_health.get_tts_health(
+            audio_health._build_internal_health_request("/api/v1/audio/health"), Service()
+        )
+
+    return health
+
+
+@pytest.mark.asyncio
+async def test_kitten_health_does_not_claim_unloaded_runtime_ready(
+    kitten_preparation: TTSAdapterRegistry,
+    kitten_health: Callable[[], Awaitable[dict[str, Any]]],
+    kitten_assets: SimpleNamespace,
+) -> None:
+    await kitten_preparation.get_adapter("kitten_tts")
+    health = await kitten_health()
+    assert health["status"] == "unhealthy"
+    assert health["providers"]["available"] == 0
+    detail = health["providers"]["details"]["kitten_tts"]
+    assert detail["runtime_ready"] is False
+    assert detail["runtime_reason"] == "model_not_loaded"
+    assert health["capabilities_envelope"][0]["availability"] == "unprepared"
+    assert kitten_assets.loaded == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [FileNotFoundError, ImportError])
+async def test_kitten_health_reports_model_or_dependency_load_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    kitten_preparation: TTSAdapterRegistry,
+    kitten_health: Callable[[], Awaitable[dict[str, Any]]],
+    failure: type[Exception],
+) -> None:
+    adapter = await kitten_preparation.get_adapter("kitten_tts")
+
+    def unavailable(*args: Any, **kwargs: Any) -> None:
+        raise failure("private dependency diagnostic")
+
+    monkeypatch.setattr(kitten, "KittenRuntime", unavailable)
+    with pytest.raises(TTSProviderInitializationError):
+        await adapter._load_runtime_for_model(SELECTED_MODEL)
+    health = await kitten_health()
+    assert health["status"] == "unhealthy"
+    detail = health["providers"]["details"]["kitten_tts"]
+    assert detail["runtime_reason"] == "model_load_failed"
+    assert detail["failed"] is True
+    assert "private dependency diagnostic" not in str(health)
+
+
+@pytest.mark.asyncio
+async def test_kitten_health_recovers_after_selected_model_load(
+    kitten_preparation: TTSAdapterRegistry,
+    kitten_health: Callable[[], Awaitable[dict[str, Any]]],
+    kitten_assets: SimpleNamespace,
+) -> None:
+    adapter = await kitten_preparation.get_adapter("kitten_tts")
+    with pytest.raises(TTSProviderInitializationError):
+        await adapter._load_runtime_for_model(DEFAULT_MODEL)
+    await live_tts.prepare_persona_speech(
+        {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": "Bella"}
+    )
+    health = await kitten_health()
+    assert health["status"] == "healthy"
+    detail = health["providers"]["details"]["kitten_tts"]
+    assert detail["runtime_ready"] is True
+    assert detail["runtime_reason"] is None
+    assert detail["runtime_model"] == SELECTED_MODEL
     assert kitten_assets.synthesized == []

--- a/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
+++ b/tldw_Server_API/tests/Persona/test_persona_kitten_model_preparation.py
@@ -29,11 +29,17 @@ def kitten_assets(monkeypatch):
             raise FileNotFoundError("Selected model assets are unavailable")
         return SimpleNamespace(repo_id=model_name, revision="fixture-revision")
 
+    real_runtime = kitten.KittenRuntime
+
     class Runtime:
         sample_rate = 24000
+        resolve_voice = real_runtime.resolve_voice
 
         def __init__(self, assets):
             self.assets = assets
+            self.voice_aliases = dict(kitten.DEFAULT_VOICE_ALIASES)
+            self._lower_aliases = {name.lower(): value for name, value in self.voice_aliases.items()}
+            self.voices = dict.fromkeys(self.voice_aliases.values())
 
         def generate(self, text, **kwargs):
             synthesized.append((self.assets.repo_id, text))
@@ -76,7 +82,7 @@ def kitten_preparation(monkeypatch, kitten_assets):
     async def route(**kwargs):
         from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
 
-        request = OpenAISpeechRequest(model=kwargs["model"], input=kwargs["text"], voice="Bella")
+        request = OpenAISpeechRequest(model=kwargs["model"], input=kwargs["text"], voice=kwargs["voice"] or "")
         yield Service(), "kitten_tts", request, None
 
     monkeypatch.setattr(live_tts, "resolve_persona_speech", route)
@@ -134,4 +140,24 @@ async def test_preparation_rejects_unavailable_selected_kitten_model(
                 "tts_voice": "Bella",
             }
         )
+    assert kitten_assets.synthesized == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("voice", ["af_heart", "not-a-kitten-voice"])
+async def test_preparation_rejects_voice_missing_from_loaded_kitten_runtime(kitten_preparation, kitten_assets, voice):
+    with pytest.raises(ValueError, match="not available"):
+        await live_tts.prepare_persona_speech(
+            {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": voice}
+        )
+    assert kitten_assets.synthesized == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("voice", ["", "bella", "Bella"])
+async def test_preparation_accepts_kitten_default_and_supported_aliases(kitten_preparation, kitten_assets, voice):
+    await live_tts.prepare_persona_speech(
+        {"tts_provider": "kitten_tts", "tts_model": SELECTED_MODEL, "tts_voice": voice}
+    )
+    assert kitten_assets.loaded == [SELECTED_MODEL]
     assert kitten_assets.synthesized == []

--- a/tldw_Server_API/tests/Persona/test_persona_live_tts_providers.py
+++ b/tldw_Server_API/tests/Persona/test_persona_live_tts_providers.py
@@ -1,0 +1,304 @@
+"""Provider choice must survive Persona preparation and synthesis."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def selected_service(monkeypatch):
+    from tldw_Server_API.app.core.TTS import tts_service_v2
+
+    class Adapter:
+        model = "gpt-4o-mini-tts"
+        default_model = "eleven_multilingual_v2"
+
+        async def ensure_initialized(self):
+            return True
+
+        async def validate_request(self, request):
+            return None
+
+        async def close(self):
+            pass
+
+    class Service:
+        def __init__(self):
+            self.selected = []
+            self.requests = []
+            self.adapter = Adapter()
+
+        async def _get_adapter(self, **kwargs):
+            self.selected.append(kwargs)
+            return self.adapter
+
+        def _convert_request(self, request):
+            from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+
+            return TTSRequest(text=request.input, model=request.model, voice=request.voice, format=AudioFormat.MP3)
+
+        async def _prepare_generate_speech_request(self, **kwargs):
+            adapter = await self._get_adapter(
+                model=kwargs["request"].model, provider=kwargs["provider"], overrides=kwargs["provider_overrides"]
+            )
+            return adapter, kwargs["provider"], kwargs["tts_request"]
+
+        def _cleanup_transient_pocket_tts_cpp_voice_path(self, request):
+            pass
+
+        async def _close_request_adapter(self, adapter, overrides):
+            if adapter is not None and overrides:
+                await adapter.close()
+
+        async def generate_speech(self, **kwargs):
+            self.requests.append(kwargs)
+            yield b"provider-audio"
+
+    service = Service()
+    service.credential_owners = []
+    from contextlib import asynccontextmanager
+
+    from tldw_Server_API.app.core.Audio import tts_service as audio_tts
+
+    @asynccontextmanager
+    async def owned_credentials(*, provider, model, request, current_user):
+        service.credential_owners.append((provider, current_user.id))
+        yield current_user.id, {"credentials_resolved": True, "api_key": "fixture-user-key"}, None, None
+
+    monkeypatch.setattr(audio_tts, "tts_provider_credential_scope", owned_credentials)
+
+    async def get_service():
+        return service
+
+    monkeypatch.setattr(tts_service_v2, "get_tts_service_v2", get_service)
+    return service
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["openai", "elevenlabs", "pocket_tts"])
+async def test_preparation_accepts_selected_non_kokoro_provider(selected_service, provider):
+    await persona_ep._prepare_persona_live_tts({"tts_provider": provider, "tts_voice": "selected-voice"})
+    assert selected_service.selected[-1]["provider"] == provider
+    assert selected_service.requests == []  # No synthesis during preparation.
+
+
+@pytest.mark.asyncio
+async def test_browser_preparation_does_not_load_server_tts(selected_service):
+    await persona_ep._prepare_persona_live_tts({"tts_provider": "browser"})
+    assert selected_service.selected == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_voice_and_owner_reach_synthesis(selected_service):
+    audio, format_ = await persona_ep._generate_persona_live_tts_audio(
+        "Provider choice is preserved.",
+        provider="openai",
+        model="gpt-4o-mini-tts",
+        voice="nova",
+        user_id=42,
+    )
+    assert (audio, format_) == (b"provider-audio", "mp3")
+    sent = selected_service.requests[-1]
+    assert (sent["provider"], sent["request"].model, sent["request"].voice, sent["user_id"]) == (
+        "openai",
+        "gpt-4o-mini-tts",
+        "nova",
+        42,
+    )
+    assert sent["fallback"] is False
+
+
+@pytest.mark.asyncio
+async def test_blank_voice_does_not_inject_kokoro_voice(selected_service):
+    await persona_ep._generate_persona_live_tts_audio("Hello", provider="openai", voice=None)
+    assert selected_service.requests[-1]["request"].voice != "af_heart"
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_cannot_fall_back_to_model_inference(selected_service):
+    with pytest.raises(ValueError, match="provider"):
+        await persona_ep._prepare_persona_live_tts({"tts_provider": "nonexistent-provider"})
+    assert selected_service.selected == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_uses_configured_defaults_and_owned_credentials(selected_service):
+    from tldw_Server_API.app.core.TTS.gateway_config import normalize_gateway_specs
+
+    specs = normalize_gateway_specs(
+        {},
+        {
+            "company": {
+                "enabled": True,
+                "display_name": "Company Speech",
+                "base_url": "https://speech.example.com/v1/",
+                "speech_path": "audio/speech",
+                "default_model": "Vendor/Expressive-TTS",
+                "default_voice": "narrator",
+                "allowed_models": ["Vendor/Expressive-TTS"],
+                "api_key": "test-credential",
+                "capability_defaults": {"formats": ["mp3"]},
+            }
+        },
+    )
+    owners = []
+
+    async def credential(backend, *, user_id, gateway_spec):
+        owners.append((backend, user_id))
+        return SimpleNamespace(api_key="test-credential")
+
+    selected_service.gateway_config_manager = SimpleNamespace(get_gateway_specs=lambda: specs)
+    selected_service.gateway_executor = object()
+    selected_service.gateway_credential_resolver = credential
+    await persona_ep._prepare_persona_live_tts({"tts_provider": "gateway:company"}, user_id=42)
+    assert selected_service.requests == []
+    await persona_ep._generate_persona_live_tts_audio(
+        "Gateway choice",
+        provider="gateway:company",
+        voice=None,
+        user_id=42,
+    )
+    sent = selected_service.requests[-1]
+    assert (sent["request"].backend, sent["request"].model, sent["request"].voice) == (
+        "gateway:company",
+        "Vendor/Expressive-TTS",
+        "narrator",
+    )
+    assert sent["request"].allow_fallback is False
+    assert owners == [("gateway:company", 42), ("gateway:company", 42)]
+    assert selected_service.selected == []
+
+
+@pytest.mark.asyncio
+async def test_unavailable_selected_provider_fails_without_other_adapters(selected_service):
+    async def unavailable():
+        return False
+
+    selected_service.adapter.ensure_initialized = unavailable
+    with pytest.raises(RuntimeError, match="selected speech provider"):
+        await persona_ep._prepare_persona_live_tts({"tts_provider": "openai"})
+    assert [entry["provider"] for entry in selected_service.selected] == ["openai"]
+    assert selected_service.requests == []
+
+
+def test_tts_model_persists_in_persona_voice_defaults():
+    from tldw_Server_API.app.api.v1.schemas.persona import PersonaVoiceDefaults
+
+    saved = PersonaVoiceDefaults.model_validate({"tts_provider": "openai", "tts_model": " gpt-4o-mini-tts "})
+    assert saved.model_dump()["tts_model"] == "gpt-4o-mini-tts"
+
+
+# Reuse the owned, persisted session fixture, not a mocked WebSocket handler.
+from tldw_Server_API.tests.Persona.test_persona_live_voice_runtime import voice_socket  # noqa: E402,F401
+
+
+@pytest.mark.parametrize("failure", [False, True])
+def test_non_kokoro_voice_socket_prepares_delivers_or_fails_and_stops(
+    voice_socket,  # noqa: F811 - pytest injects the imported session fixture.
+    selected_service,
+    monkeypatch,
+    failure,
+):
+    from tldw_Server_API.app.core.Persona import live_conversation
+    from tldw_Server_API.app.core.Persona.live_voice_runtime import persona_live_voice_registry
+    from tldw_Server_API.tests.Persona.test_persona_ws import _recv_until, _stub_persona_conversation
+
+    cleanup = []
+
+    class Transcriber:
+        def initialize(self):
+            pass
+
+        def cleanup(self):
+            cleanup.append(True)
+
+        def reset(self):
+            pass
+
+    _stub_persona_conversation(monkeypatch, answer="Selected provider reply")
+    monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())
+    monkeypatch.setattr(persona_ep, "_create_persona_live_stt_transcriber", lambda **kwargs: Transcriber())
+    monkeypatch.setattr(persona_ep, "_create_persona_live_turn_detector", lambda **kwargs: None)
+    if failure:
+
+        async def fail_generation(**kwargs):
+            raise RuntimeError("provider offline")
+            yield  # pragma: no cover
+
+        selected_service.generate_speech = fail_generation
+    voice_socket.send_json(
+        {
+            "type": "voice_config",
+            "session_id": "voice-owned",
+            "tts": {
+                "provider": "openai",
+                "model": "gpt-4o-mini-tts",
+                "voice": "nova",
+            },
+        }
+    )
+    _recv_until(voice_socket, lambda event: event.get("reason_code") == "VOICE_CONFIG_UPDATED")
+    voice_socket.send_json(
+        {"type": "voice_prepare", "session_id": "voice-owned", "client_message_id": "prepare-provider"}
+    )
+    assert _recv_until(voice_socket, lambda event: event.get("event") == "voice_readiness")["ready"] is True
+    voice_socket.send_json(
+        {
+            "type": "voice_commit",
+            "session_id": "voice-owned",
+            "transcript": "Use my selected voice",
+            "client_message_id": "provider-turn",
+        }
+    )
+    if failure:
+        event = _recv_until(voice_socket, lambda event: event.get("reason_code") == "TTS_UNAVAILABLE_TEXT_ONLY")
+        assert event["client_message_id"] == "provider-turn"
+        assert not persona_live_voice_registry.is_ready(user_id="1", session_id="voice-owned")
+    else:
+        event = _recv_until(voice_socket, lambda event: event.get("event") == "tts_audio")
+        assert event["client_message_id"] == "provider-turn"
+        assert voice_socket.receive_bytes() == b"provider-audio"
+        sent = selected_service.requests[-1]
+        assert (sent["provider"], sent["request"].model, sent["request"].voice, sent["user_id"]) == (
+            "openai",
+            "gpt-4o-mini-tts",
+            "nova",
+            1,
+        )
+    voice_socket.send_json({"type": "voice_stop", "session_id": "voice-owned"})
+    _recv_until(voice_socket, lambda event: event.get("reason_code") == "VOICE_STOPPED")
+    assert not persona_live_voice_registry.is_ready(user_id="1", session_id="voice-owned")
+    assert cleanup
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model,voice", [("eleven_multilingual_v2", "nova"), ("gpt-4o-mini-tts", "not-a-voice")])
+async def test_preparation_rejects_invalid_selected_model_or_voice_before_recording(selected_service, model, voice):
+    from unittest.mock import AsyncMock
+
+    from tldw_Server_API.app.core.TTS.adapters.openai_adapter import OpenAITTSAdapter
+    from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+
+    adapter = OpenAITTSAdapter({"openai_api_key": "test-credential"})
+    adapter.ensure_initialized = AsyncMock(return_value=True)
+    selected_service.adapter = adapter
+    with pytest.raises(TTSValidationError):
+        await persona_ep._prepare_persona_live_tts({"tts_provider": "openai", "tts_model": model, "tts_voice": voice})
+    assert selected_service.requests == []
+
+
+@pytest.mark.asyncio
+async def test_authenticated_tts_snapshot_reaches_adapter_and_generation(selected_service):
+    await persona_ep._prepare_persona_live_tts(
+        {"tts_provider": "openai", "tts_model": "gpt-4o-mini-tts", "tts_voice": "nova"}, user_id=42
+    )
+    await persona_ep._generate_persona_live_tts_audio(
+        "Scoped", provider="openai", model="gpt-4o-mini-tts", voice="nova", user_id=42
+    )
+    assert selected_service.credential_owners == [("openai", 42), ("openai", 42)]
+    assert selected_service.selected[-1]["overrides"]["api_key"] == "fixture-user-key"
+    assert selected_service.requests[-1]["provider_overrides"]["api_key"] == "fixture-user-key"

--- a/tldw_Server_API/tests/Persona/test_persona_live_voice_runtime.py
+++ b/tldw_Server_API/tests/Persona/test_persona_live_voice_runtime.py
@@ -81,8 +81,22 @@ def test_readiness_cannot_survive_stop_or_move_between_connections() -> None:
     assert not registry.is_ready(user_id="1", session_id="session")
 
 
+@pytest.fixture
+def local_tts_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    from contextlib import asynccontextmanager
+    from tldw_Server_API.app.core.Audio import tts_service
+
+    @asynccontextmanager
+    async def local_scope(**kwargs: Any) -> Any:
+        yield 1, {"credentials_resolved": True}, None, None
+
+    monkeypatch.setattr(tts_service, "tts_provider_credential_scope", local_scope)
+
+
 @pytest.mark.asyncio
-async def test_live_tts_selects_kokoro_without_provider_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_live_tts_selects_kokoro_without_provider_fallback(
+    monkeypatch: pytest.MonkeyPatch, local_tts_credentials: None
+) -> None:
     from tldw_Server_API.app.core.TTS import tts_service_v2
 
     calls = []
@@ -105,28 +119,40 @@ async def test_live_tts_selects_kokoro_without_provider_fallback(monkeypatch: py
 
 
 @pytest.mark.asyncio
-async def test_preparation_rejects_lazy_adapter_without_loaded_model(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_preparation_rejects_lazy_adapter_without_loaded_model(
+    monkeypatch: pytest.MonkeyPatch, local_tts_credentials: None
+) -> None:
     from tldw_Server_API.app.core.TTS import tts_service_v2
 
     class Adapter:
-        async def ensure_initialized(self) -> Any:
+        async def ensure_initialized(self) -> bool:
             return True
 
-        async def _ensure_model_loaded(self) -> Any:
+        async def validate_request(self, request: Any) -> None:
+            pass
+
+        async def _ensure_model_loaded(self) -> bool:
             return False
 
     class Service:
-        async def _get_adapter(self, **kwargs: Any) -> Any:
-            return Adapter()
+        def _convert_request(self, request: Any) -> Any:
+            return request
+
+        async def _prepare_generate_speech_request(self, **kwargs: Any) -> Any:
+            return Adapter(), kwargs["provider"], kwargs["tts_request"]
+
+        def _cleanup_transient_pocket_tts_cpp_voice_path(self, request: Any) -> None:
+            pass
+
+        async def _close_request_adapter(self, adapter: Any, overrides: Any) -> None:
+            pass
 
     async def get_service() -> Any:
         return Service()
 
     monkeypatch.setattr(tts_service_v2, "get_tts_service_v2", get_service)
-    prepare = getattr(persona_ep, "_prepare_persona_live_tts", None)
-    assert callable(prepare), "Real TTS preparation must exist"
-    with pytest.raises(RuntimeError):
-        await prepare({"tts_provider": "tldw", "tts_voice": "af_heart"})
+    with pytest.raises(RuntimeError, match="Kokoro model and voice assets"):
+        await persona_ep._prepare_persona_live_tts({"tts_provider": "tldw", "tts_voice": "af_heart"})
 
 
 @pytest.fixture
@@ -192,7 +218,7 @@ def test_preparation_publishes_real_runtime_and_stop_revokes(
         def cleanup(self) -> None:
             pass
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         assert runtime["tts_provider"] == "tldw"
 
     monkeypatch.setattr(
@@ -238,7 +264,7 @@ def test_stop_during_model_initialization_cannot_publish_readiness(
         def cleanup(self) -> None:
             cleaned.set()
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         later_stages.append("tts")
 
     monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())
@@ -325,7 +351,7 @@ def prepared_voice(voice_socket: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
 
     transcriber = Transcriber()
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         pass
 
     monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())
@@ -509,7 +535,7 @@ def test_socket_control_does_not_wait_for_decode(
         original_cleanup()
         retired.set()
 
-    async def prepare_tts(runtime: Any) -> None:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> None:
         pass
 
     monkeypatch.setattr(transcriber, "initialize", initialize)
@@ -622,7 +648,7 @@ def test_preparation_keeps_own_connection_configuration(voice_socket: Any, monke
         def cleanup(self) -> None:
             pass
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         selected.append(runtime["tts_provider"])
 
     monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())
@@ -661,7 +687,7 @@ def test_preparation_failures_are_actionable_and_never_ready(
         def cleanup(self) -> None:
             pass
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         if stage == "TTS":
             fail()
 
@@ -851,7 +877,7 @@ def test_preparation_is_singleflight_until_worker_finishes(voice_socket: Any, mo
         def cleanup(self) -> None:
             pass
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         return None
 
     monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())
@@ -898,7 +924,7 @@ def blocked_voice_initialization(voice_socket: Any, monkeypatch: pytest.MonkeyPa
             calls["cleanup"] += 1
             cleaned.set()
 
-    async def prepare_tts(runtime: Any) -> Any:
+    async def prepare_tts(runtime: Any, **kwargs: Any) -> Any:
         calls["tts"] += 1
 
     monkeypatch.setattr(live_conversation, "require_persona_voice_conversation_credentials", lambda: object())

--- a/tldw_Server_API/tests/Persona/test_persona_tts_review_regressions.py
+++ b/tldw_Server_API/tests/Persona/test_persona_tts_review_regressions.py
@@ -1,0 +1,113 @@
+"""Review regressions for Persona voice precedence and owned error cleanup."""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+from tldw_Server_API.app.core.Audio import tts_service as audio_tts
+from tldw_Server_API.app.core.Persona import live_tts
+from tldw_Server_API.app.core.TTS import tts_config
+from tldw_Server_API.app.core.TTS.tts_config import ProviderConfig, TTSConfig
+from tldw_Server_API.tests.Persona.test_persona_live_tts_providers import selected_service  # noqa: F401
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "default_provider,selected,voice,expected",
+    [
+        ("openai", "openai", None, "nova"),
+        ("openai", "openai", "echo", "echo"),
+        ("kokoro", "openai", None, ""),
+        ("tldw", "kokoro", None, ""),
+        (None, "openai", None, ""),
+    ],
+)
+async def test_voice_default_belongs_only_to_its_configured_provider(
+    selected_service,  # noqa: F811 - pytest injects the imported fixture.
+    monkeypatch,
+    default_provider,
+    selected,
+    voice,
+    expected,
+):
+    config = TTSConfig(
+        default_provider=default_provider,
+        default_voice="nova",
+        providers={"openai": ProviderConfig(enabled=True, model="gpt-4o-mini-tts")},
+    )
+    monkeypatch.setattr(audio_tts, "get_tts_config", lambda: config)
+    monkeypatch.setattr(tts_config, "get_tts_config", lambda: config)
+    # Both preparation and synthesis enter this same resolver.
+    async with live_tts.resolve_persona_speech(
+        text="Use the selected voice", provider=selected, model=None, voice=voice, user_id=42
+    ) as (_, _, request, _):
+        assert request.voice == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunks", [[b"ERROR: provider unavailable"], [b"partial-audio", b"ERROR: provider failed"]])
+async def test_error_closes_speech_before_credentials_and_discards_partial_audio(monkeypatch, chunks):
+    events = []
+    streams = []
+
+    class Service:
+        def generate_speech(self, **kwargs):
+            async def output():
+                try:
+                    for chunk in chunks:
+                        yield chunk
+                finally:
+                    events.append("speech_closed")
+
+            stream = output()
+            streams.append(stream)  # Prevent GC from hiding missing deterministic close.
+            return stream
+
+    @asynccontextmanager
+    async def route(**kwargs):
+        try:
+            yield Service(), "openai", object(), {"credentials_resolved": True}
+        finally:
+            events.append("credentials_closed")
+
+    monkeypatch.setattr(live_tts, "resolve_persona_speech", route)
+    try:
+        with pytest.raises(RuntimeError, match="failed to generate audio"):
+            await live_tts.generate_persona_speech("A reply", provider="openai", voice="nova")
+        assert events == ["speech_closed", "credentials_closed"]
+    finally:
+        for stream in streams:
+            await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_closes_speech_before_credentials(monkeypatch):
+    events = []
+    started = asyncio.Event()
+
+    class Service:
+        async def generate_speech(self, **kwargs):
+            try:
+                started.set()
+                await asyncio.Event().wait()
+                yield b"unreachable"
+            finally:
+                events.append("speech_closed")
+
+    @asynccontextmanager
+    async def route(**kwargs):
+        try:
+            yield Service(), "openai", object(), {"credentials_resolved": True}
+        finally:
+            events.append("credentials_closed")
+
+    monkeypatch.setattr(live_tts, "resolve_persona_speech", route)
+    task = asyncio.create_task(live_tts.generate_persona_speech("A reply", provider="openai", voice="nova"))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert events == ["speech_closed", "credentials_closed"]

--- a/tldw_Server_API/tests/Persona/test_persona_voice_chat_preflight.py
+++ b/tldw_Server_API/tests/Persona/test_persona_voice_chat_preflight.py
@@ -1,0 +1,82 @@
+"""Voice preparation must not preempt authenticated Chat credential admission."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI, HTTPException, Request
+
+from tldw_Server_API.app.core.Persona import live_conversation as live
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def configured_target(monkeypatch: pytest.MonkeyPatch) -> Any:
+    from tldw_Server_API.app.core.Chat import chat_service, chat_target_resolution
+
+    target = SimpleNamespace(provider="deepseek", model="deepseek-chat")
+    monkeypatch.setattr(chat_target_resolution, "resolve_chat_target", lambda **kwargs: target)
+
+    def unexpected_static_credentials(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("Voice preparation cannot decide the caller's effective credentials from server keys")
+
+    monkeypatch.setattr(chat_service, "resolve_static_provider_fallback", unexpected_static_credentials)
+    return target
+
+
+def test_voice_preflight_does_not_read_static_credentials(configured_target: Any) -> None:
+    target = live.require_persona_voice_conversation_credentials()
+    assert (target.provider, target.model) == ("deepseek", "deepseek-chat")
+
+
+def test_voice_preflight_retains_invalid_target_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Chat import chat_target_resolution
+    from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
+
+    def invalid_target(**kwargs: Any) -> Any:
+        raise ChatConfigurationError(provider="invalid", message="private configuration detail")
+
+    monkeypatch.setattr(chat_target_resolution, "resolve_chat_target", invalid_target)
+    with pytest.raises(live.PersonaConversationError, match="supported default Chat provider and model") as error:
+        live.require_persona_voice_conversation_credentials()
+    assert "private configuration detail" not in str(error.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("admission_status", "expected_error"),
+    [(200, None), (401, "not authorized"), (403, "not authorized"), (429, "usage is limited")],
+)
+async def test_prepared_voice_dispatch_still_runs_authenticated_http_admission(
+    configured_target: Any, admission_status: int, expected_error: str | None
+) -> None:
+    app = FastAPI()
+    admissions = []
+
+    async def admission(request: Request) -> None:
+        admissions.append((request.headers.get("authorization"), request.client.host))
+        if admission_status != 200:
+            raise HTTPException(admission_status, "private admission detail")
+
+    @app.post("/api/v1/chat/completions", dependencies=[Depends(admission)])
+    async def chat(request: Request) -> Any:
+        body = await request.json()
+        assert (body["api_provider"], body["model"]) == ("deepseek", "deepseek-chat")
+        return {"choices": [{"message": {"content": "Spoken reply"}}]}
+
+    live.require_persona_voice_conversation_credentials()
+    completion = live.complete_persona_conversation(
+        app=app,
+        headers={"authorization": "Bearer test-only"},
+        client=("192.0.2.42", 1234),
+        system_prompt="You are Migu.",
+        turns=[{"role": "user", "content": "Hello"}],
+    )
+    if expected_error is None:
+        assert await completion == "Spoken reply"
+    else:
+        with pytest.raises(live.PersonaConversationError, match=expected_error) as error:
+            await completion
+        assert "private admission detail" not in str(error.value)
+    assert admissions == [("Bearer test-only", "192.0.2.42")]

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -74,7 +74,7 @@ def _prepare_test_voice(ws, session_id: str, *, configure: bool = False) -> None
         async def process_audio_chunk(self, audio):
             return {"type": "partial", "text": "hello from audio"}
 
-    async def prepare_tts(runtime):
+    async def prepare_tts(runtime, **kwargs):
         return None
 
     with pytest.MonkeyPatch.context() as patch:
@@ -3709,6 +3709,7 @@ def test_persona_voice_config_stores_runtime_preferences(monkeypatch):
         "vad_turn_stop_secs": 0.2,
         "vad_min_utterance_secs": 0.4,
         "tts_provider": "openai",
+        "tts_model": None,
         "tts_voice": "alloy",
         "text_only_due_to_tts_failure": False,
     }

--- a/tldw_Server_API/tests/TTS/adapters/test_kittentts_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_kittentts_adapter_mock.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
-
 
 pytestmark = pytest.mark.unit
 
@@ -85,12 +85,8 @@ async def test_kittentts_generate_non_stream(monkeypatch, tmp_path):
     assert response.provider == "kitten_tts"
     assert response.voice_used == "Bella"
     assert response.model == "KittenML/kitten-tts-nano-0.8-fp32"
-    assert download_calls == [
-        ("KittenML/kitten-tts-nano-0.8-fp32", str(tmp_path / "cache"), False, "deadbeef1")
-    ]
-    assert FakeRuntime.instances[0].calls == [
-        ("Hello from Kitten", "Bella", 1.1, True)
-    ]
+    assert download_calls == [("KittenML/kitten-tts-nano-0.8-fp32", str(tmp_path / "cache"), False, "deadbeef1")]
+    assert FakeRuntime.instances[0].calls == [("Hello from Kitten", "Bella", 1.1, True)]
 
 
 @pytest.mark.asyncio
@@ -178,3 +174,22 @@ async def test_kittentts_runtime_load_uses_revision_for_requested_model(monkeypa
     assert download_calls == [
         ("KittenML/kitten-tts-mini-0.8", None, True, mod.resolve_model_revision("KittenML/kitten-tts-mini-0.8"))
     ]
+
+
+@pytest.mark.asyncio
+async def test_kittentts_override_preserves_configured_default_revision(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.TTS.adapters import kitten_tts_adapter as mod
+
+    downloads: list[tuple[str, str | None]] = []
+
+    def load(model_name: str, *, revision: str | None = None, **kwargs: Any) -> SimpleNamespace:
+        downloads.append((model_name, revision))
+        return SimpleNamespace(repo_id=model_name, revision=revision)
+
+    monkeypatch.setattr(mod, "download_model_assets", load)
+    monkeypatch.setattr(mod, "KittenRuntime", lambda assets: SimpleNamespace(assets=assets))
+    adapter = mod.KittenTTSAdapter({"model": "KittenML/kitten-tts-nano-0.8-fp32", "model_revision": "deadbeef12345678"})
+    await adapter._load_runtime_for_model("KittenML/kitten-tts-mini-0.8")
+    await adapter._load_runtime_for_model("KittenML/kitten-tts-nano-0.8-fp32")
+
+    assert downloads[-1] == ("KittenML/kitten-tts-nano-0.8-fp32", "deadbeef12345678")

--- a/tldw_Server_API/tests/TTS/test_tts_override_adapter_lifecycle.py
+++ b/tldw_Server_API/tests/TTS/test_tts_override_adapter_lifecycle.py
@@ -1,0 +1,276 @@
+"""Speech requests own adapters created for credential/config overrides."""
+
+import asyncio
+import io
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
+from tldw_Server_API.app.core.TTS import tts_service_v2
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterFactory, TTSProvider
+from tldw_Server_API.app.core.TTS.adapters.base import (
+    AudioFormat,
+    TTSAdapter,
+    TTSCapabilities,
+    TTSRequest,
+    TTSResponse,
+)
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSGenerationError, TTSValidationError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def speech_runtime(monkeypatch: pytest.MonkeyPatch) -> Any:
+    adapters = []
+    events = []
+    waiting = asyncio.Event()
+    initialized = asyncio.Event()
+
+    class Adapter(TTSAdapter):
+        PROVIDER_KEY = "mock"
+
+        def __init__(self, config: dict[str, Any] | None = None) -> None:
+            super().__init__(config)
+            self.resource = io.BytesIO()
+            self.mode = (config or {}).get("mode", "complete")
+            adapters.append(self)
+
+        async def initialize(self) -> bool:
+            initialized.set()
+            if self.mode == "init_wait":
+                await asyncio.Event().wait()
+            return self.mode != "init_false"
+
+        async def ensure_initialized(self) -> bool:
+            if self.mode == "init_raise":
+                raise RuntimeError("Initialization failed")
+            return await super().ensure_initialized()
+
+        async def get_capabilities(self) -> TTSCapabilities:
+            return TTSCapabilities(
+                provider_name="mock",
+                supported_languages={"en"},
+                supported_voices=[],
+                supported_formats={AudioFormat.MP3},
+                max_text_length=500,
+                supports_streaming=True,
+            )
+
+        async def generate(self, request: TTSRequest) -> TTSResponse:
+            if self.mode == "failure":
+                raise TTSGenerationError("Synthesis failed", provider="mock")
+
+            async def stream():
+                try:
+                    yield b"speech"
+                    if self.mode == "wait":
+                        waiting.set()
+                        await asyncio.Event().wait()
+                finally:
+                    events.append("stream_closed")
+
+            return TTSResponse(audio_stream=stream(), format=AudioFormat.MP3, provider="mock")
+
+        async def _cleanup_resources(self) -> None:
+            events.append("adapter_closed")
+            self.resource.close()
+
+    async def resource_manager():
+        return SimpleNamespace(touch_model=lambda *args: None)
+
+    monkeypatch.setattr(tts_service_v2, "get_resource_manager", resource_manager)
+    factory = TTSAdapterFactory({"providers": {"mock": {"enabled": True}}})
+    factory.registry.register_adapter(TTSProvider.MOCK, Adapter)
+    service = tts_service_v2.TTSServiceV2(factory=factory)
+    return SimpleNamespace(
+        service=service,
+        adapters=adapters,
+        events=events,
+        waiting=waiting,
+        initialized=initialized,
+        adapter_type=Adapter,
+    )
+
+
+def speech(service: tts_service_v2.TTSServiceV2, overrides: dict[str, Any] | None, provider: str = "mock"):
+    return service.generate_speech(
+        OpenAISpeechRequest(input="Hello", model="mock", voice="voice", response_format="mp3", stream=True),
+        provider=provider,
+        provider_overrides=overrides,
+        fallback=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_after_complete_stream(speech_runtime: Any) -> None:
+    chunks = [chunk async for chunk in speech(speech_runtime.service, {"mode": "complete"})]
+    assert chunks == [b"speech"]
+    assert speech_runtime.adapters[0].resource.closed
+    assert speech_runtime.events == ["stream_closed", "adapter_closed"]
+
+
+@pytest.mark.asyncio
+async def test_service_created_omnivoice_overrides_close_without_caller_overrides(
+    speech_runtime: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = speech_runtime.service
+    monkeypatch.setattr(speech_runtime.adapter_type, "PROVIDER_KEY", "omnivoice")
+    service.factory.registry.config["providers"]["omnivoice"] = {"enabled": True}
+    service.factory.registry.register_adapter(TTSProvider.OMNIVOICE, speech_runtime.adapter_type)
+    monkeypatch.setattr(service, "_get_or_create_omnivoice_supervisor", lambda: object())
+    assert [chunk async for chunk in speech(service, None, provider="omnivoice")] == [b"speech"]
+    assert speech_runtime.adapters[0].resource.closed
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_on_generation_failure(speech_runtime: Any) -> None:
+    with pytest.raises(TTSGenerationError):
+        [chunk async for chunk in speech(speech_runtime.service, {"mode": "failure"})]
+    assert speech_runtime.adapters[0].resource.closed
+    assert speech_runtime.events == ["adapter_closed"]
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_when_consumer_stops_stream(speech_runtime: Any) -> None:
+    stream = speech(speech_runtime.service, {"mode": "wait"})
+    assert await stream.__anext__() == b"speech"
+    await stream.aclose()
+    assert speech_runtime.adapters[0].resource.closed
+    assert speech_runtime.events == ["stream_closed", "adapter_closed"]
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_on_cancelled_generation(speech_runtime: Any) -> None:
+    async def consume() -> None:
+        [chunk async for chunk in speech(speech_runtime.service, {"mode": "wait"})]
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(speech_runtime.waiting.wait(), 2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert speech_runtime.adapters[0].resource.closed
+        assert speech_runtime.events == ["stream_closed", "adapter_closed"]
+        assert speech_runtime.service._active_request_counts == {}
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_when_provider_validation_rejects(
+    speech_runtime: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    validate = tts_service_v2.validate_tts_request
+
+    def provider_validation(request: Any, *, provider: str | None, config: Any) -> None:
+        if provider == "mock":
+            raise TTSValidationError("Provider-specific rejection", provider="mock")
+        validate(request, provider=provider, config=config)
+
+    monkeypatch.setattr(tts_service_v2, "validate_tts_request", provider_validation)
+    with pytest.raises(TTSValidationError):
+        [chunk async for chunk in speech(speech_runtime.service, {"mode": "complete"})]
+    assert speech_runtime.adapters[0].resource.closed
+
+
+@pytest.mark.asyncio
+async def test_override_adapter_closes_when_cancelled_waiting_for_active_slot(speech_runtime: Any) -> None:
+    service = speech_runtime.service
+    service._active_request_counts["mock"] = 1
+    await service._active_requests_lock.acquire()
+
+    async def consume() -> None:
+        [chunk async for chunk in speech(service, {"mode": "complete"})]
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(speech_runtime.initialized.wait(), 2)
+        task.cancel()
+    finally:
+        service._active_requests_lock.release()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert speech_runtime.adapters[0].resource.closed
+    assert service._active_request_counts == {"mock": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["init_false", "init_raise"])
+async def test_registry_closes_override_adapter_when_initialization_fails(speech_runtime: Any, mode: str) -> None:
+    adapter = await speech_runtime.service.factory.registry.create_adapter_with_overrides(
+        TTSProvider.MOCK, {"mode": mode}
+    )
+    assert adapter is None
+    assert speech_runtime.adapters[0].resource.closed
+    assert speech_runtime.events == ["adapter_closed"]
+
+
+@pytest.mark.asyncio
+async def test_registry_closes_override_adapter_when_initialization_is_cancelled(speech_runtime: Any) -> None:
+    task = asyncio.create_task(
+        speech_runtime.service.factory.registry.create_adapter_with_overrides(TTSProvider.MOCK, {"mode": "init_wait"})
+    )
+    try:
+        await asyncio.wait_for(speech_runtime.initialized.wait(), 2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert speech_runtime.adapters[0].resource.closed
+        assert speech_runtime.events == ["adapter_closed"]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cached_adapter_remains_open_after_generation(
+    speech_runtime: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cached = speech_runtime.adapter_type({})
+    await cached.ensure_initialized()
+
+    async def get_cached(provider: TTSProvider) -> TTSAdapter:
+        assert provider == TTSProvider.MOCK
+        return cached
+
+    monkeypatch.setattr(speech_runtime.service.factory.registry, "get_adapter", get_cached)
+    try:
+        assert [chunk async for chunk in speech(speech_runtime.service, None)] == [b"speech"]
+        assert not cached.resource.closed
+        assert speech_runtime.events == ["stream_closed"]
+    finally:
+        await cached.close()
+
+
+@pytest.mark.asyncio
+async def test_cached_omnivoice_fallback_remains_open(speech_runtime: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = speech_runtime.service
+    monkeypatch.setattr(speech_runtime.adapter_type, "PROVIDER_KEY", "omnivoice")
+    cached = speech_runtime.adapter_type({})
+    await cached.ensure_initialized()
+    service.factory.registry._adapters["omnivoice"] = cached
+
+    async def missing_adapter(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def fallback_adapter(*args: Any, **kwargs: Any) -> TTSAdapter:
+        return cached
+
+    monkeypatch.setattr(service, "_get_adapter", missing_adapter)
+    monkeypatch.setattr(service, "_get_fallback_adapter", fallback_adapter)
+    try:
+        chunks = [
+            chunk
+            async for chunk in service.generate_speech(
+                OpenAISpeechRequest(input="Hello", model="mock", voice="voice", stream=True), fallback=True
+            )
+        ]
+        assert chunks == [b"speech"]
+        assert not cached.resource.closed
+    finally:
+        await cached.close()


### PR DESCRIPTION
## Change summary

Provided by the human requester:

This PR removes Kokoro as a mandatory dependency for Persona Live, honoring the configured speech provider, model, and voice through existing authentication and provider-policy checks. It fixes shared model defaults, readiness reporting, browser playback cancellation, and provider-catalog recovery, and adds Buddy setup and troubleshooting guides. Validation passed 284 Python, 124 frontend, and 212 documentation tests. Physical voice validation remains follow-up work.

## Summary

Persona Live rejected speech providers other than Kokoro and could replace the selected provider's voice defaults. This change honors configured built-in, browser, and gateway speech providers, with optional model and voice selection. Kokoro is optional; legacy Persona settings retain their existing mapping.

Preparation and synthesis share provider resolution and existing credential policy, while replies continue through the authenticated Chat route with moderation and budget checks. Kitten validates the selected model and voice before recording, preserves its configured defaults across model overrides, and reports actual runtime readiness in public audio health. Request-owned adapters and streams close on completion, failure, Stop, and cancellation before credentials are released.

The UI preserves saved providers, exposes the model selection, handles native browser speech errors and stale cancellation callbacks, exposes provider-catalog failures with Retry, and explains when saved defaults require reconnecting Live. New Buddy documentation covers setup, text and voice use, approvals, and troubleshooting, with matching published guides.

Tracks TASK-13213 and TASK-13214. Architecture: `backlog/decisions/004-persona-live-tts-provider-selection.md`.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] Relevant unit/integration tests pass locally: **284 Python tests** and **124 frontend tests**.
- [x] Documentation updated; MkDocs build and canonical/published mirror checks passed.
- Bandit reported no issues in the touched production scope. Scoped lint checks had no new errors; existing warnings are documented in the review evidence.
- Independent review and follow-up review found no remaining actionable findings.
- Authenticated Parakeet preparation and a controlled DeepSeek reply were exercised through the running server. Native browser speech start/end and Stop interruption were validated through the production voice controller.
- Evidence and exact validation scope: `Docs/Reviews/PERSONA_TTS_PROVIDER_CHOICE_2026_09_07.md`.

Qodo review findings are addressed in `fa189ded2c`; the claimed missing test category was verified as already present at module scope. Documentation URL scanning and the OpenAPI fingerprint were also corrected for the CI gates.

## UX audit scope and remaining validation

Persona-specific frontend tests and a running WebUI check cover the changed controls, default labels, and reconnect guidance. The repository-wide Stage 5/all-pages smoke suites and extension parity audit were not run. Flashcards and Watchlists checklists are not applicable.

Physical microphone/playback UAT was not repeated after the final review fixes. The complete live provider matrix, paid remote synthesis, and floating Buddy animation validation remain follow-up work; the controlled browser checks do not establish those outcomes.

## Risk & Rollback

- Risk level: Medium. Changes touch shared speech adapter cleanup as well as Persona provider preparation and selection; regression tests cover cached versus request-owned adapters and credential lifetime.
- Rollback: revert this PR. No database migration is introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persona Live no longer forces Kokoro: it prepares and synthesizes through the configured built-in, browser, or gateway speech provider, keeps that provider's model and voice defaults, and leaves legacy `tldw` mappings untouched.

**Behavior**
- Preparation and synthesis share one provider resolution path with existing credential, policy, and budget checks; no cross-provider fallback.
- Replies stay on the authenticated Chat route, preserving moderation and budget enforcement.
- Request-owned adapters and streams close on completion, failure, Stop, and cancellation before credentials release; Kitten readiness loads the selected model.

**UI & docs**
- The UI preserves saved providers, exposes model selection, handles native browser speech errors and stale cancellation callbacks, exposes provider-catalog failures with Retry, and explains when saved defaults require reconnecting Live.
- New Persona Buddy guide covers setup, text and voice use, approvals, and troubleshooting. Addresses TASK-13213 and TASK-13214.

<sup>Written for commit fa189ded2c9f78f9b89169c5fa78de3e59b96063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



