### PR TITLE
feat(prompts): customize Writing mood and Echo feedback

### DIFF
--- a/Docs/Design/writing-feedback-service-prompts.md
+++ b/Docs/Design/writing-feedback-service-prompts.md
@@ -1,0 +1,41 @@
+# Writing feedback Service Prompts
+
+Approved scope: expose Writing Playground mood and Echo instructions in the existing shared Service Prompts settings. No new settings or persistence system.
+
+- `writing.feedback.mood`: literal `system_semantics` and `classification_semantics`; the one-word/seven-mood contract and passage carrier remain fixed.
+- `writing.feedback.echo`: atomic literal `alex_system`, `sam_system`, `max_system`, `riley_system`, `jordan_system`; persona identities, rotation and passage carrier remain fixed.
+- Preserve byte-equivalent default chat payloads, model/temperature/token settings, debounce/threshold behavior, text caps and 20-reaction history.
+- Capture a fresh owner-bound snapshot per request. Keep at most one scope lease per feedback channel while state is visible; abort/discard stale work and clear feedback on scope changes. Release leases on replacement or unmount.
+- Reuse packaged fallback only for older-server 404/missing definitions. Other lookup errors must not send a default request.
+
+## Stage 1: Definitions and Settings
+
+**Goal:** Register both prompts with shared client types, labels and packaged defaults.
+**Success Criteria:** Atomic save/reset and older-server behavior match existing Service Prompts.
+**Tests:** Registry/API and shared snapshot/Settings tests.
+**Status:** Complete
+
+## Stage 2: Scoped feedback requests
+
+**Goal:** Apply snapshots in the existing feedback hook.
+**Success Criteria:** Custom semantics reach generation with locked contracts; stale results never update feedback.
+**Tests:** Hook payload, enablement, validation, limits, scope-switch and lifecycle regressions.
+**Status:** Complete
+
+## Stage 3: Verification and review
+
+**Goal:** Verify both clients' shared integration and touched backend scope.
+**Success Criteria:** Focused tests, lint, Bandit and code review completed; limitations recorded in TASK-13215.
+**Tests:** Focused Vitest and pytest suites; touched-scope lint and Bandit.
+**Status:** Complete
+
+## Verification
+
+- Backend registry and API: 97 passing tests, including atomic feedback save/reset.
+- Shared client: 281 passing focused tests across Settings, feedback hooks, Writing Agent, snapshots and scope transport helpers.
+- Direct-browser refresh/scope transport: 47 passing tests.
+- English locale mirrors: 12 new entries match across both bundles.
+- Bandit: no findings. Ruff: clean. ESLint: no errors; 10 existing explicit-any warnings in untouched portions of the shared server service.
+- Global shared-UI typecheck: 158 existing diagnostics, none in changed files (required an 8 GiB Node heap).
+- Independent review approved after a test-first fix preventing late scope errors from cancelled requests from clearing newer feedback.
+- Full repository tests, production builds and live browser smoke tests were not run.

--- a/Docs/Design/writing-feedback-service-prompts.md
+++ b/Docs/Design/writing-feedback-service-prompts.md
@@ -38,4 +38,6 @@ Approved scope: expose Writing Playground mood and Echo instructions in the exis
 - Bandit: no findings. Ruff: clean. ESLint: no errors; 10 existing explicit-any warnings in untouched portions of the shared server service.
 - Global shared-UI typecheck: 158 existing diagnostics, none in changed files (required an 8 GiB Node heap).
 - Independent review approved after a test-first fix preventing late scope errors from cancelled requests from clearing newer feedback.
+- Qodo follow-up: failed, invalid, empty or cancelled feedback releases its temporary snapshot without replacing the lease for existing visible feedback. Unexpected failures log only a static feedback kind and operation stage; cancellation and scope-control flow remain quiet.
+- Qodo fix verification: 249 affected client tests and 97 backend tests passed; 10 added runtime regressions; independent review approved; touched-scope ESLint/Ruff clean and Bandit reported no findings.
 - Full repository tests, production builds and live browser smoke tests were not run.

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -23,6 +23,14 @@
     "title": "Workflow prompts",
     "description": "Review and customize the instructions used by supported content workflows.",
     "definitions": {
+      "writingFeedbackMood": {
+        "label": "Writing feedback: Mood",
+        "description": "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed."
+      },
+      "writingFeedbackEcho": {
+        "label": "Writing feedback: Echo",
+        "description": "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed."
+      },
       "writingAgentQuick": {
         "label": "Writing Agent: Quick",
         "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed."
@@ -114,6 +122,7 @@
     },
     "workflows": {
       "writingAgent": "Writing Playground AI Agent",
+      "writingFeedback": "Writing Playground feedback",
       "studyAssistantFlashcard": "Flashcard Study Assistant",
       "studyAssistantQuiz": "Quiz Study Assistant",
       "mainChatRag": "Main chat RAG",
@@ -140,6 +149,13 @@
       "openChatSettings": "Open Chat settings"
     },
     "parts": {
+      "classifierGuidance": "Classifier guidance",
+      "classificationSemantics": "Classification instructions",
+      "alexSystem": "Alex instructions",
+      "samSystem": "Sam instructions",
+      "maxSystem": "Max instructions",
+      "rileySystem": "Riley instructions",
+      "jordanSystem": "Jordan instructions",
       "guidance": "Guidance",
       "template": "Template",
       "system": "System instructions",

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -150,6 +150,16 @@ const KNOWN_DEFINITIONS = {
     description:
       "Controls system instructions for synchronous document analysis. Without a saved override, server defaults apply."
   },
+  "writing.feedback.mood": {
+    key: "writingFeedbackMood",
+    label: "Writing feedback: Mood",
+    description: "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed."
+  },
+  "writing.feedback.echo": {
+    key: "writingFeedbackEcho",
+    label: "Writing feedback: Echo",
+    description: "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed."
+  },
   "writing.agent.quick": {
     key: "writingAgentQuick",
     label: "Writing Agent: Quick",
@@ -238,6 +248,7 @@ const KNOWN_DEFINITIONS = {
 const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
   "study.assistant.flashcard": { key: "studyAssistantFlashcard", label: "Flashcard Study Assistant" },
   "writing.agent": { key: "writingAgent", label: "Writing Playground AI Agent" },
+  "writing.feedback": { key: "writingFeedback", label: "Writing Playground feedback" },
   "study.assistant.quiz": { key: "studyAssistantQuiz", label: "Quiz Study Assistant" },
   "chat.main.rag": { key: "mainChatRag", label: "Main chat RAG" },
   "chat.tab.rag": { key: "tabChatRag", label: "Tab chat RAG" },
@@ -305,6 +316,12 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
 }
 
 const KNOWN_PARTS: Record<string, { key: string; label: string }> = {
+  classification_semantics: {"key":"classificationSemantics","label":"Classification instructions"},
+  alex_system: {"key":"alexSystem","label":"Alex instructions"},
+  sam_system: {"key":"samSystem","label":"Sam instructions"},
+  max_system: {"key":"maxSystem","label":"Max instructions"},
+  riley_system: {"key":"rileySystem","label":"Riley instructions"},
+  jordan_system: {"key":"jordanSystem","label":"Jordan instructions"},
   guidance: { key: "guidance", label: "Guidance" },
   analysis_guidance: { key: "analysisGuidance", label: "Analysis guidance" },
   presentation_guidance: { key: "presentationGuidance", label: "Presentation guidance" },
@@ -356,8 +373,12 @@ const getWorkflowLabel = (
 const getPartLabel = (
   key: string,
   fallback: string,
-  t: ReturnType<typeof useTranslation>["t"]
+  t: ReturnType<typeof useTranslation>["t"],
+  definitionId: string
 ): string => {
+  if (definitionId === "writing.feedback.mood" && key === "system_semantics") {
+    return t("servicePrompts.parts.classifierGuidance", { defaultValue: "Classifier guidance" })
+  }
   const known = KNOWN_PARTS[key]
   return known
     ? t(`servicePrompts.parts.${known.key}`, { defaultValue: known.label })
@@ -2041,7 +2062,7 @@ export const ServicePromptsSettings = () => {
                 <Form className="mt-5" layout="vertical" onFinish={() => void saveDraft()}>
                   <div className="flex flex-col gap-5">
                     {selectedDefinition.parts.map((part) => {
-                      const partLabel = getPartLabel(part.key, part.label, t)
+                      const partLabel = getPartLabel(part.key, part.label, t, selectedDefinition.id)
                       const fieldId = `service-prompt-${toDomId(
                         selectedDefinition.id
                       )}-${toDomId(part.key)}`
@@ -2104,7 +2125,7 @@ export const ServicePromptsSettings = () => {
                         {selectedDefinition.parts.map((part) => (
                           <div key={part.key} className="min-w-0">
                             <p className="text-xs font-medium text-text-muted">
-                              {getPartLabel(part.key, part.label, t)}
+                              {getPartLabel(part.key, part.label, t, selectedDefinition.id)}
                             </p>
                             <pre
                               className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-surface p-3 text-sm text-text"

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -326,7 +326,75 @@ const catalog: ServicePromptCatalogItem[] = [
       { id: "study.assistant.flashcard", label: "Server flashcard workflow" },
       { id: "study.assistant.quiz", label: "Server quiz workflow" }
     ]
-  }))
+  })),
+  {
+    "id": "writing.feedback.mood",
+    "label": "Writing feedback: Mood",
+    "description": "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed.",
+    "parts": [
+      {
+        "key": "system_semantics",
+        "label": "Classifier guidance",
+        "mode": "literal",
+        "required_variables": []
+      },
+      {
+        "key": "classification_semantics",
+        "label": "Classification instructions",
+        "mode": "literal",
+        "required_variables": []
+      }
+    ],
+    "affected_workflows": [
+      {
+        "id": "writing.feedback",
+        "label": "Writing Playground feedback"
+      }
+    ]
+  },
+  {
+    "id": "writing.feedback.echo",
+    "label": "Writing feedback: Echo",
+    "description": "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed.",
+    "parts": [
+      {
+        "key": "alex_system",
+        "label": "Alex instructions",
+        "mode": "literal",
+        "required_variables": []
+      },
+      {
+        "key": "sam_system",
+        "label": "Sam instructions",
+        "mode": "literal",
+        "required_variables": []
+      },
+      {
+        "key": "max_system",
+        "label": "Max instructions",
+        "mode": "literal",
+        "required_variables": []
+      },
+      {
+        "key": "riley_system",
+        "label": "Riley instructions",
+        "mode": "literal",
+        "required_variables": []
+      },
+      {
+        "key": "jordan_system",
+        "label": "Jordan instructions",
+        "mode": "literal",
+        "required_variables": []
+      }
+    ],
+    "affected_workflows": [
+      {
+        "id": "writing.feedback",
+        "label": "Writing Playground feedback"
+      }
+    ]
+  },
 ]
 
 const detailFor = (
@@ -337,7 +405,9 @@ const detailFor = (
     parts?: Record<string, string>
   } = {}
 ): ServicePromptDetail => {
-  const defaults = definition.id.startsWith("writing.agent.")
+  const defaults = definition.id.startsWith("writing.feedback.")
+    ? Object.fromEntries(definition.parts.map((part) => [part.key, "Default " + part.key]))
+    : definition.id.startsWith("writing.agent.")
     ? { system: "Assist the writer." }
     : definition.id.startsWith("study.assistant.")
     ? { guidance: "Help the learner." }
@@ -614,7 +684,7 @@ describe("ServicePromptsSettings", () => {
     renderSettings()
 
     expect(await screen.findAllByTestId("service-prompt-list-item"))
-      .toHaveLength(22)
+      .toHaveLength(24)
     expect(await screen.findByRole("heading", { name: "Text translation" }))
       .toBeInTheDocument()
     expect(screen.getByText("Server default")).toBeInTheDocument()
@@ -692,6 +762,27 @@ describe("ServicePromptsSettings", () => {
     await waitFor(() => expect(mocks.save).toHaveBeenCalledWith(
       `study.assistant.${action}`,
       { parts: { guidance: "Teach in French {literally}." }, expected_revision: null },
+      { signal: expect.any(AbortSignal), requestScope: scopeOne }
+    ))
+  })
+
+  it.each(["Mood", "Echo"])("edits and saves the complete Writing feedback %s bundle", async (kind) => {
+    renderSettings()
+    await openPrompt(`Writing feedback: ${kind}`)
+    const labels = kind === "Mood"
+      ? [["system_semantics", "Classifier guidance"], ["classification_semantics", "Classification instructions"]]
+      : ["Alex", "Sam", "Max", "Riley", "Jordan"].map((name) => [`${name.toLowerCase()}_system`, `${name} instructions`])
+    expect(screen.getByText("Writing Playground feedback")).toBeVisible()
+    const parts: Record<string, string> = {}
+    for (const [key, label] of labels) {
+      expect(screen.getByLabelText(label)).toHaveValue("Default " + key)
+      parts[key] = "Custom " + key + " {literal}"
+      fireEvent.change(screen.getByLabelText(label), { target: { value: parts[key] } })
+    }
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }))
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledWith(
+      `writing.feedback.${kind.toLowerCase()}`,
+      { parts, expected_revision: null },
       { signal: expect.any(AbortSignal), requestScope: scopeOne }
     ))
   })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.service-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.service-prompts.test.tsx
@@ -1,0 +1,235 @@
+import React from "react"
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import fixture from "@/utils/__fixtures__/service-prompt-rendering.json"
+import type { ServicePromptSnapshot } from "@/services/service-prompts"
+
+const mocks = vi.hoisted(() => ({
+  load: vi.fn(), request: vi.fn(), configListeners: new Set<() => void>(),
+}))
+vi.mock("@/services/background-proxy", () => ({ bgRequest: (...args: unknown[]) => mocks.request(...args) }))
+vi.mock("@/services/service-prompts", () => ({
+  loadServicePromptSnapshot: (...args: unknown[]) => mocks.load(...args),
+  subscribeToServicePromptConfigChanges: (listener: () => void) => {
+    mocks.configListeners.add(listener)
+    return () => mocks.configListeners.delete(listener)
+  },
+}))
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: <T,>(_key: string, initial: T) => React.useState(initial),
+}))
+import { useWritingFeedback } from "../useWritingFeedback"
+
+const requestScope = { config: { serverUrl: "https://server-a.test", authMode: "multi-user" as const }, userId: "owner-a" }
+type FeedbackId = "writing.feedback.mood" | "writing.feedback.echo"
+let scope: AbortController
+let snapshots: ServicePromptSnapshot[]
+let custom: boolean
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+function setup() {
+  return renderHook((editorText: string) => useWritingFeedback({
+    editorText, isOnline: true, isGenerating: false, selectedModel: "test-model",
+  }), { initialProps: "" })
+}
+async function tick(ms = 0) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(60_000)
+  vi.clearAllMocks()
+  scope = new AbortController()
+  snapshots = []
+  custom = true
+  mocks.request.mockResolvedValue({ choices: [{ message: { content: "calm" } }] })
+  mocks.load.mockImplementation(async ([id]: FeedbackId[], { signal }: { signal: AbortSignal }) => {
+    const parts = custom
+      ? Object.fromEntries(Object.keys(fixture.defaults[id]).map((key) => [key, `Custom ${key} {literal}`]))
+      : fixture.defaults[id]
+    const snapshot: ServicePromptSnapshot = {
+      scopeKey: "scope-a", requestScope, capability: "supported",
+      definitions: { [id]: { definition: { id, parts: [] }, parts, source: custom ? "user" : "packaged", revision: null } },
+      scopeSignal: signal, scopeInvalidatedSignal: scope.signal, release: vi.fn(),
+    }
+    snapshots.push(snapshot)
+    return snapshot
+  })
+})
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("Writing feedback Service Prompts", () => {
+  it("does not let a stale scope error clear feedback from a newer request", async () => {
+    const response = deferred<unknown>()
+    mocks.request.mockReturnValueOnce(response.promise)
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick()
+    act(() => scope.abort())
+    scope = new AbortController()
+    hook.rerender("x".repeat(1000))
+    await tick()
+    expect(hook.result.current.echoReactions).toHaveLength(1)
+    await act(async () => response.reject(Object.assign(new Error("Scope changed"), {
+      status: 412, details: { detail: { code: "request_config_scope_changed" } },
+    })))
+    expect(hook.result.current.echoReactions).toHaveLength(1)
+    expect(snapshots.at(-1)!.release).not.toHaveBeenCalled()
+  })
+
+  it("releases completed feedback leases on unmount", async () => {
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick()
+    hook.unmount()
+    expect(snapshots[0].release).toHaveBeenCalledOnce()
+    expect(mocks.configListeners.size).toBe(0)
+  })
+
+  it.each(["writing.feedback.mood", "writing.feedback.echo"] as const)("does not dispatch an incomplete %s snapshot", async (id) => {
+    const loader = mocks.load.getMockImplementation()!
+    mocks.load.mockImplementationOnce(async (...args) => {
+      const snapshot = await loader(...args)
+      snapshot.definitions[id].parts = {}
+      return snapshot
+    })
+    const hook = setup()
+    act(() => id.endsWith("mood") ? hook.result.current.setMoodEnabled(true) : hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick(10_000)
+    expect(mocks.request).not.toHaveBeenCalled()
+  })
+  it("does not look up prompts or generate while feedback is disabled", async () => {
+    const hook = setup()
+    hook.rerender("a".repeat(1000))
+    await tick(60_000)
+    expect(mocks.load).not.toHaveBeenCalled()
+    expect(mocks.request).not.toHaveBeenCalled()
+  })
+
+  it.each([true, false])("sends mood guidance with locked output and capped passage (custom=%s)", async (useCustom) => {
+    custom = useCustom
+    const hook = setup()
+    act(() => hook.result.current.setMoodEnabled(true))
+    hook.rerender("prefix" + "m".repeat(500))
+    await tick(10_000)
+    expect(mocks.request).toHaveBeenCalledWith(expect.objectContaining({
+      servicePromptConfig: { ...requestScope.config, expectedUserId: "owner-a" },
+      headers: { "Content-Type": "application/json", "X-TLDW-Expected-User-ID": "owner-a" },
+      abortSignal: snapshots[0].scopeSignal,
+      body: {
+        model: "test-model", temperature: 0.7, max_tokens: 100,
+        messages: [
+          { role: "system", content: (useCustom ? "Custom system_semantics {literal}" : "You are a mood classifier.") + " Respond with exactly one word." },
+          { role: "user", content: (useCustom ? "Custom classification_semantics {literal}" : "Classify the emotional mood of this text.") + " Respond with ONLY one word from: tense, romantic, melancholic, action, calm, mysterious, humorous\n\nText: " + "m".repeat(500) },
+        ],
+      },
+    }))
+    expect(hook.result.current.currentMood).toBe("calm")
+  })
+
+  it("rejects values outside the fixed mood enum", async () => {
+    mocks.request.mockResolvedValue({ choices: [{ message: { content: "angry" } }] })
+    const hook = setup()
+    act(() => hook.result.current.setMoodEnabled(true))
+    hook.rerender("Some passage")
+    await tick(10_000)
+    expect(hook.result.current.currentMood).toBeNull()
+    expect(hook.result.current.moodAnalyzing).toBe(false)
+  })
+
+  it.each([true, false])("rotates all five Echo instructions with unchanged identities and context (custom=%s)", async (useCustom) => {
+    custom = useCustom
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    for (const [index, persona] of ["Alex", "Sam", "Max", "Riley", "Jordan", "Alex"].entries()) {
+      if (index) await tick(30_000)
+      hook.rerender("prefix" + "e".repeat(1000 + index * 500))
+      await tick()
+      const body = mocks.request.mock.calls.at(-1)![0].body
+      expect(body).toEqual({
+        model: "test-model", temperature: 0.7, max_tokens: 100,
+        messages: [
+          { role: "system", content: useCustom ? `Custom ${persona.toLowerCase()}_system {literal}` : fixture.defaults["writing.feedback.echo"][`${persona.toLowerCase()}_system` as keyof typeof fixture.defaults["writing.feedback.echo"]] },
+          { role: "user", content: "React to this passage:\n\n" + "e".repeat(1000) },
+        ],
+      })
+      expect(hook.result.current.echoReactions[0].persona).toBe(persona)
+      expect(hook.result.current.charsSinceLastEcho).toBe(0)
+    }
+    expect(mocks.load).toHaveBeenCalledTimes(6)
+    expect(snapshots.slice(0, -1).every((snapshot) => vi.mocked(snapshot.release).mock.calls.length === 1)).toBe(true)
+  })
+
+  it("does not send a default request after a failed prompt lookup", async () => {
+    mocks.load.mockRejectedValue(new Error("Forbidden"))
+    const hook = setup()
+    act(() => { hook.result.current.setEchoEnabled(true); hook.result.current.setMoodEnabled(true) })
+    hook.rerender("x".repeat(500))
+    await tick(10_000)
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(hook.result.current.echoAnalyzing).toBe(false)
+    expect(hook.result.current.moodAnalyzing).toBe(false)
+  })
+
+  it("clears both completed feedback channels on scope invalidation and releases leases", async () => {
+    const hook = setup()
+    act(() => { hook.result.current.setEchoEnabled(true); hook.result.current.setMoodEnabled(true) })
+    hook.rerender("x".repeat(500))
+    await tick(10_000)
+    expect(hook.result.current.currentMood).toBe("calm")
+    expect(hook.result.current.echoReactions).toHaveLength(1)
+    act(() => scope.abort())
+    expect(hook.result.current.currentMood).toBeNull()
+    expect(hook.result.current.echoReactions).toEqual([])
+    expect(hook.result.current.charsSinceLastEcho).toBe(0)
+    expect(snapshots.every((snapshot) => vi.mocked(snapshot.release).mock.calls.length === 1)).toBe(true)
+  })
+
+  it.each(["mood", "echo"] as const)("discards a late %s response after account/server invalidation", async (kind) => {
+    const response = deferred<unknown>()
+    mocks.request.mockReturnValue(response.promise)
+    const hook = setup()
+    act(() => kind === "mood" ? hook.result.current.setMoodEnabled(true) : hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick(10_000)
+    expect(mocks.request).toHaveBeenCalledTimes(1)
+    act(() => scope.abort())
+    expect(mocks.request.mock.calls[0][0].abortSignal.aborted).toBe(true)
+    await act(async () => response.resolve({ choices: [{ message: { content: "calm" } }] }))
+    expect(hook.result.current.currentMood).toBeNull()
+    expect(hook.result.current.echoReactions).toEqual([])
+    expect(hook.result.current.moodAnalyzing).toBe(false)
+    expect(hook.result.current.echoAnalyzing).toBe(false)
+  })
+
+  it.each(["auth", "config", "disable", "unmount"])("does not dispatch after delayed lookup and %s boundary", async (boundary) => {
+    const pending = deferred<ServicePromptSnapshot>()
+    const loader = mocks.load.getMockImplementation()!
+    mocks.load.mockImplementationOnce((...args) => { void loader(...args); return pending.promise })
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick()
+    act(() => {
+      if (boundary === "auth") window.dispatchEvent(new Event("tldw:auth-credentials-changed"))
+      if (boundary === "config") mocks.configListeners.forEach((listener) => listener())
+      if (boundary === "disable") hook.result.current.setEchoEnabled(false)
+      if (boundary === "unmount") hook.unmount()
+    })
+    await act(async () => pending.resolve(snapshots[0]))
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(snapshots[0].release).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.service-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.service-prompts.test.tsx
@@ -45,6 +45,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(60_000)
   vi.clearAllMocks()
+  vi.spyOn(console, "warn").mockImplementation(() => {})
   scope = new AbortController()
   snapshots = []
   custom = true
@@ -68,6 +69,68 @@ afterEach(() => {
 })
 
 describe("Writing feedback Service Prompts", () => {
+  it.each(["prompt_lookup", "chat_generation"])("reports safe diagnostics for %s failures without logging private payloads", async (phase) => {
+    const error = Object.assign(new Error("private prompt and credential"), { status: 403, body: "private response" })
+    if (phase === "prompt_lookup") mocks.load.mockRejectedValueOnce(error)
+    else mocks.request.mockRejectedValueOnce(error)
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("secret".repeat(100))
+    await tick()
+    expect(console.warn).toHaveBeenCalledExactlyOnceWith("Writing feedback request failed", { kind: "echo", phase })
+    expect(hook.result.current.echoReactions).toEqual([])
+  })
+
+  it.each(["cancelled", "scope_changed"])("does not warn for %s request control flow", async (reason) => {
+    const response = deferred<unknown>()
+    mocks.request.mockReturnValueOnce(response.promise)
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick()
+    if (reason === "cancelled") act(() => hook.result.current.setEchoEnabled(false))
+    await act(async () => response.reject(reason === "cancelled"
+      ? new DOMException("Aborted", "AbortError")
+      : Object.assign(new Error("Scope changed"), { status: 412, details: { detail: { code: "request_config_scope_changed" } } })))
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it.each(["request_error", "empty", "invalid_mood"])("releases the new lease after %s without retaining invisible feedback", async (outcome) => {
+    if (outcome === "request_error") mocks.request.mockRejectedValueOnce(new Error("Provider failed"))
+    else mocks.request.mockResolvedValueOnce({ choices: [{ message: { content: outcome === "empty" ? "" : "angry" } }] })
+    const hook = setup()
+    act(() => outcome === "invalid_mood" ? hook.result.current.setMoodEnabled(true) : hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick(10_000)
+    expect(snapshots[0].release).toHaveBeenCalledOnce()
+    expect(hook.result.current.currentMood).toBeNull()
+    expect(hook.result.current.echoReactions).toEqual([])
+  })
+
+  it.each(["invalid", "failed", "empty"])("keeps the existing visible-feedback lease when a replacement is %s", async (outcome) => {
+    const hook = setup()
+    act(() => hook.result.current.setEchoEnabled(true))
+    hook.rerender("x".repeat(500))
+    await tick()
+    if (outcome === "invalid") {
+      const loader = mocks.load.getMockImplementation()!
+      mocks.load.mockImplementationOnce(async (...args) => {
+        const snapshot = await loader(...args)
+        snapshot.definitions["writing.feedback.echo"].parts = {}
+        return snapshot
+      })
+    } else if (outcome === "failed") mocks.request.mockRejectedValueOnce(new Error("Provider failed"))
+    else mocks.request.mockResolvedValueOnce({ choices: [{ message: { content: "" } }] })
+    await tick(30_000)
+    hook.rerender("x".repeat(1000))
+    await tick()
+    expect(hook.result.current.echoReactions).toHaveLength(1)
+    expect(snapshots[0].release).not.toHaveBeenCalled()
+    expect(snapshots[1].release).toHaveBeenCalledOnce()
+    act(() => scope.abort())
+    expect(hook.result.current.echoReactions).toEqual([])
+    expect(snapshots[0].release).toHaveBeenCalledOnce()
+  })
   it("does not let a stale scope error clear feedback from a newer request", async () => {
     const response = deferred<unknown>()
     mocks.request.mockReturnValueOnce(response.promise)
@@ -109,6 +172,7 @@ describe("Writing feedback Service Prompts", () => {
     hook.rerender("x".repeat(500))
     await tick(10_000)
     expect(mocks.request).not.toHaveBeenCalled()
+    expect(snapshots[0].release).toHaveBeenCalledOnce()
   })
   it("does not look up prompts or generate while feedback is disabled", async () => {
     const hook = setup()

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/__tests__/useWritingFeedback.test.tsx
@@ -6,6 +6,21 @@ const mocks = vi.hoisted(() => ({
   bgRequest: vi.fn()
 }))
 
+vi.mock("@/services/service-prompts", async () => {
+  const { default: fixture } = await import("@/utils/__fixtures__/service-prompt-rendering.json")
+  return {
+    subscribeToServicePromptConfigChanges: () => () => {},
+    loadServicePromptSnapshot: async ([id]: (keyof typeof fixture.defaults)[], { signal }: { signal: AbortSignal }) => ({
+      scopeKey: "owner-a",
+      requestScope: { config: { serverUrl: "https://server.test", authMode: "multi-user" }, userId: "a" },
+      definitions: { [id]: { parts: fixture.defaults[id] } },
+      scopeSignal: signal,
+      scopeInvalidatedSignal: new AbortController().signal,
+      release: () => {},
+    }),
+  }
+})
+
 vi.mock("@/services/background-proxy", () => ({
   bgRequest: mocks.bgRequest
 }))

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingFeedback.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingFeedback.ts
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useStorage } from "@plasmohq/storage/hook"
 import { bgRequest } from "@/services/background-proxy"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
+import { loadServicePromptSnapshot, subscribeToServicePromptConfigChanges, type ServicePromptSnapshot } from "@/services/service-prompts"
+import { requestScopeFields } from "@/services/tldw/domains/service-prompts"
+import { isRequestConfigScopeChangedError } from "@/services/tldw/service-prompt-scope-error"
 
 export type Mood = "tense" | "romantic" | "melancholic" | "action" | "calm" | "mysterious" | "humorous" | null
 
@@ -12,14 +15,12 @@ export type EchoReaction = {
   timestamp: number
 }
 
-const MOOD_PROMPT = `Classify the emotional mood of this text. Respond with ONLY one word from: tense, romantic, melancholic, action, calm, mysterious, humorous\n\nText: `
-
 const ECHO_PERSONAS = [
-  { name: "Alex", emoji: "🧐", role: "The Analyst", prompt: "You are Alex, a sharp literary analyst. In 1-2 sentences, comment on the structure, foreshadowing, or plot mechanics. Be concise." },
-  { name: "Sam", emoji: "😍", role: "The Shipper", prompt: "You are Sam, obsessed with character relationships. In 1-2 sentences, react to relationship dynamics or romantic tension." },
-  { name: "Max", emoji: "🤨", role: "The Skeptic", prompt: "You are Max, a skeptical reader. In 1-2 sentences, point out anything contrived or unmotivated." },
-  { name: "Riley", emoji: "🎉", role: "The Hype", prompt: "You are Riley, an enthusiastic reader. In 1-2 sentences, react with energy to the most exciting element." },
-  { name: "Jordan", emoji: "📚", role: "The Lore Keeper", prompt: "You are Jordan, a world-building enthusiast. In 1-2 sentences, comment on world-building details or consistency." },
+  { name: "Alex", emoji: "🧐", part: "alex_system" },
+  { name: "Sam", emoji: "😍", part: "sam_system" },
+  { name: "Max", emoji: "🤨", part: "max_system" },
+  { name: "Riley", emoji: "🎉", part: "riley_system" },
+  { name: "Jordan", emoji: "📚", part: "jordan_system" },
 ] as const
 
 const VALID_MOODS = new Set(["tense", "romantic", "melancholic", "action", "calm", "mysterious", "humorous"])
@@ -57,29 +58,27 @@ type ChatCompletionResponse = {
 async function callChat(
   systemPrompt: string,
   userText: string,
-  model?: string,
-  abortSignal?: AbortSignal,
+  model: string | undefined,
+  snapshot: ServicePromptSnapshot,
 ): Promise<string> {
-  try {
-    const data = await bgRequest<ChatCompletionResponse>({
-      path: "/api/v1/chat/completions" as AllowedPath,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      abortSignal,
-      body: {
-        model: model || "default",
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userText },
-        ],
-        temperature: 0.7,
-        max_tokens: 100,
-      },
-    })
-    return data.choices?.[0]?.message?.content?.trim() || ""
-  } catch {
-    return ""
-  }
+  const scopeFields = requestScopeFields(snapshot.requestScope)
+  const data = await bgRequest<ChatCompletionResponse>({
+    path: "/api/v1/chat/completions" as AllowedPath,
+    method: "POST",
+    ...scopeFields,
+    headers: { "Content-Type": "application/json", ...scopeFields.headers },
+    abortSignal: snapshot.scopeSignal,
+    body: {
+      model: model || "default",
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userText },
+      ],
+      temperature: 0.7,
+      max_tokens: 100,
+    },
+  })
+  return data.choices?.[0]?.message?.content?.trim() || ""
 }
 
 export function useWritingFeedback({
@@ -103,6 +102,91 @@ export function useWritingFeedback({
   const echoIndexRef = useRef(0)
   const prevTextLenRef = useRef(editorText.length)
   const moodTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const controllersRef = useRef<Partial<Record<"mood" | "echo", AbortController>>>({})
+  const leasesRef = useRef<Partial<Record<"mood" | "echo", { scopeKey: string; release: () => void }>>>({})
+  const textLengthRef = useRef(editorText.length)
+  textLengthRef.current = editorText.length
+
+  const cancelFeedback = useCallback(() => {
+    moodReqIdRef.current += 1
+    for (const controller of Object.values(controllersRef.current)) controller.abort()
+    controllersRef.current = {}
+    for (const lease of Object.values(leasesRef.current)) lease.release()
+    leasesRef.current = {}
+    if (moodTimerRef.current) clearTimeout(moodTimerRef.current)
+    echoInFlightRef.current = false
+  }, [])
+
+  const resetFeedback = useCallback(() => {
+    cancelFeedback()
+    setCurrentMood(null)
+    setEchoReactions([])
+    setMoodAnalyzing(false)
+    setEchoAnalyzing(false)
+    setCharsSinceLastEcho(0)
+    prevTextLenRef.current = textLengthRef.current
+    lastMoodCallRef.current = 0
+    lastEchoCallRef.current = 0
+    echoIndexRef.current = 0
+  }, [cancelFeedback])
+
+  useEffect(() => {
+    // Pending first lookups have no retained scope lease yet.
+    const clearUnboundState = () => {
+      if (!leasesRef.current.mood && !leasesRef.current.echo) resetFeedback()
+    }
+    const unsubscribe = subscribeToServicePromptConfigChanges(clearUnboundState)
+    window.addEventListener("tldw:auth-credentials-changed", resetFeedback)
+    return () => {
+      unsubscribe()
+      window.removeEventListener("tldw:auth-credentials-changed", resetFeedback)
+      cancelFeedback()
+    }
+  }, [resetFeedback, cancelFeedback])
+
+  const requestFeedback = useCallback(async (
+    kind: "mood" | "echo", text: string, model: string | undefined,
+    controller: AbortController, personaPart?: typeof ECHO_PERSONAS[number]["part"],
+  ): Promise<string> => {
+    try {
+      const id = kind === "mood" ? "writing.feedback.mood" : "writing.feedback.echo"
+      const snapshot = await loadServicePromptSnapshot([id], { signal: controller.signal })
+      if (controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted) {
+        snapshot.release()
+        return ""
+      }
+      if (Object.values(leasesRef.current).some((lease) => lease.scopeKey !== snapshot.scopeKey)) {
+        snapshot.release()
+        resetFeedback()
+        return ""
+      }
+      leasesRef.current[kind]?.release()
+      snapshot.scopeInvalidatedSignal.addEventListener("abort", resetFeedback, { once: true })
+      leasesRef.current[kind] = {
+        scopeKey: snapshot.scopeKey,
+        release: () => {
+          snapshot.scopeInvalidatedSignal.removeEventListener("abort", resetFeedback)
+          snapshot.release()
+        },
+      }
+      const parts = snapshot.definitions[id]?.parts
+      const system = parts?.[kind === "mood" ? "system_semantics" : (personaPart ?? "")]
+      const classification = parts?.classification_semantics
+      if (!system?.trim() || (kind === "mood" && !classification?.trim())) return ""
+      const result = await callChat(
+        kind === "mood" ? `${system} Respond with exactly one word.` : system,
+        kind === "mood"
+          ? `${classification} Respond with ONLY one word from: tense, romantic, melancholic, action, calm, mysterious, humorous\n\nText: ${text.slice(-500)}`
+          : `React to this passage:\n\n${text.slice(-1000)}`,
+        model, snapshot,
+      )
+      return controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted ? "" : result
+    } catch (error) {
+      if (!controller.signal.aborted && isRequestConfigScopeChangedError(error)) resetFeedback()
+      // Feedback remains best-effort, but failed lookups never dispatch defaults.
+      return ""
+    }
+  }, [resetFeedback])
 
   // Track chars typed since last echo
   useEffect(() => {
@@ -128,14 +212,9 @@ export function useWritingFeedback({
 
       const reqId = ++moodReqIdRef.current
       controller = new AbortController()
+      controllersRef.current.mood = controller
       setMoodAnalyzing(true)
-      const textSlice = editorText.slice(-500)
-      const result = await callChat(
-        "You are a mood classifier. Respond with exactly one word.",
-        MOOD_PROMPT + textSlice,
-        selectedModel,
-        controller.signal,
-      )
+      const result = await requestFeedback("mood", editorText, selectedModel, controller)
       if (cancelled) return
       if (reqId !== moodReqIdRef.current) return
       const word = result.toLowerCase().trim().replace(/[^a-z]/g, "")
@@ -151,7 +230,7 @@ export function useWritingFeedback({
       controller?.abort()
       setMoodAnalyzing(false)
     }
-  }, [editorText, moodEnabled, isOnline, isGenerating, selectedModel])
+  }, [editorText, moodEnabled, isOnline, isGenerating, selectedModel, requestFeedback])
 
   // Echo Chamber
   useEffect(() => {
@@ -169,17 +248,12 @@ export function useWritingFeedback({
 
     let cancelled = false
     const controller = new AbortController()
+    controllersRef.current.echo = controller
     setEchoAnalyzing(true)
-    const textSlice = editorText.slice(-1000)
 
-    void callChat(
-      persona.prompt,
-      `React to this passage:\n\n${textSlice}`,
-      selectedModel,
-      controller.signal,
-    ).then(
+    void requestFeedback("echo", editorText, selectedModel, controller, persona.part).then(
       (message) => {
-        if (cancelled) return
+        if (cancelled || controller.signal.aborted) return
         if (message) {
           setCharsSinceLastEcho(0)
           setEchoReactions((prev) => [
@@ -190,16 +264,16 @@ export function useWritingFeedback({
         setEchoAnalyzing(false)
       },
     ).finally(() => {
-      echoInFlightRef.current = false
+      if (controllersRef.current.echo === controller) echoInFlightRef.current = false
     })
 
     return () => {
       cancelled = true
       controller.abort()
       setEchoAnalyzing(false)
-      echoInFlightRef.current = false
+      if (controllersRef.current.echo === controller) echoInFlightRef.current = false
     }
-  }, [charsSinceLastEcho, echoEnabled, isOnline, isGenerating, editorText, selectedModel])
+  }, [charsSinceLastEcho, echoEnabled, isOnline, isGenerating, editorText, selectedModel, requestFeedback])
 
   return {
     moodEnabled: moodEnabled ?? false,

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingFeedback.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingFeedback.ts
@@ -148,31 +148,38 @@ export function useWritingFeedback({
     kind: "mood" | "echo", text: string, model: string | undefined,
     controller: AbortController, personaPart?: typeof ECHO_PERSONAS[number]["part"],
   ): Promise<string> => {
+    let phase = "prompt_lookup"
+    let pendingRelease: (() => void) | undefined
+    const discardPending = () => {
+      pendingRelease?.()
+      pendingRelease = undefined
+    }
     try {
       const id = kind === "mood" ? "writing.feedback.mood" : "writing.feedback.echo"
       const snapshot = await loadServicePromptSnapshot([id], { signal: controller.signal })
-      if (controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted) {
+      const onScopeInvalidated = () => resetFeedback()
+      const releaseSnapshot = () => {
+        snapshot.scopeInvalidatedSignal.removeEventListener("abort", onScopeInvalidated)
         snapshot.release()
+      }
+      pendingRelease = releaseSnapshot
+      if (controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted) {
         return ""
       }
       if (Object.values(leasesRef.current).some((lease) => lease.scopeKey !== snapshot.scopeKey)) {
-        snapshot.release()
         resetFeedback()
         return ""
-      }
-      leasesRef.current[kind]?.release()
-      snapshot.scopeInvalidatedSignal.addEventListener("abort", resetFeedback, { once: true })
-      leasesRef.current[kind] = {
-        scopeKey: snapshot.scopeKey,
-        release: () => {
-          snapshot.scopeInvalidatedSignal.removeEventListener("abort", resetFeedback)
-          snapshot.release()
-        },
       }
       const parts = snapshot.definitions[id]?.parts
       const system = parts?.[kind === "mood" ? "system_semantics" : (personaPart ?? "")]
       const classification = parts?.classification_semantics
-      if (!system?.trim() || (kind === "mood" && !classification?.trim())) return ""
+      if (!system?.trim() || (kind === "mood" && !classification?.trim())) {
+        console.warn("Writing feedback request failed", { kind, phase: "prompt_validation" })
+        return ""
+      }
+      snapshot.scopeInvalidatedSignal.addEventListener("abort", onScopeInvalidated, { once: true })
+      controller.signal.addEventListener("abort", discardPending, { once: true })
+      phase = "chat_generation"
       const result = await callChat(
         kind === "mood" ? `${system} Respond with exactly one word.` : system,
         kind === "mood"
@@ -180,11 +187,27 @@ export function useWritingFeedback({
           : `React to this passage:\n\n${text.slice(-1000)}`,
         model, snapshot,
       )
-      return controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted ? "" : result
+      if (controller.signal.aborted || snapshot.scopeSignal.aborted || snapshot.scopeInvalidatedSignal.aborted) return ""
+      const mood = result.toLowerCase().trim().replace(/[^a-z]/g, "")
+      if (!result || (kind === "mood" && !VALID_MOODS.has(mood))) return ""
+      // Only usable feedback replaces the lease protecting already visible state.
+      leasesRef.current[kind]?.release()
+      leasesRef.current[kind] = { scopeKey: snapshot.scopeKey, release: releaseSnapshot }
+      pendingRelease = undefined
+      return result
     } catch (error) {
-      if (!controller.signal.aborted && isRequestConfigScopeChangedError(error)) resetFeedback()
+      if (!controller.signal.aborted) {
+        if (isRequestConfigScopeChangedError(error)) resetFeedback()
+        else if ((error as { name?: unknown } | null)?.name !== "AbortError") {
+          // Do not log prompt text, credentials, server URLs or provider payloads.
+          console.warn("Writing feedback request failed", { kind, phase })
+        }
+      }
       // Feedback remains best-effort, but failed lookups never dispatch defaults.
       return ""
+    } finally {
+      controller.signal.removeEventListener("abort", discardPending)
+      discardPending()
     }
   }, [resetFeedback])
 

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -1,4 +1,40 @@
 {
+  "servicePrompts_definitions_writingFeedbackMood_label": {
+    "message": "Writing feedback: Mood"
+  },
+  "servicePrompts_definitions_writingFeedbackMood_description": {
+    "message": "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed."
+  },
+  "servicePrompts_definitions_writingFeedbackEcho_label": {
+    "message": "Writing feedback: Echo"
+  },
+  "servicePrompts_definitions_writingFeedbackEcho_description": {
+    "message": "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed."
+  },
+  "servicePrompts_workflows_writingFeedback": {
+    "message": "Writing Playground feedback"
+  },
+  "servicePrompts_parts_classifierGuidance": {
+    "message": "Classifier guidance"
+  },
+  "servicePrompts_parts_classificationSemantics": {
+    "message": "Classification instructions"
+  },
+  "servicePrompts_parts_alexSystem": {
+    "message": "Alex instructions"
+  },
+  "servicePrompts_parts_samSystem": {
+    "message": "Sam instructions"
+  },
+  "servicePrompts_parts_maxSystem": {
+    "message": "Max instructions"
+  },
+  "servicePrompts_parts_rileySystem": {
+    "message": "Riley instructions"
+  },
+  "servicePrompts_parts_jordanSystem": {
+    "message": "Jordan instructions"
+  },
   "navigation_serverAndAuth": {
     "message": "Server & Auth"
   },

--- a/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
@@ -100,6 +100,11 @@ const definition = (
 })
 
 const definitions: Partial<Record<KnownServicePromptId, ServicePromptCatalogItem>> = {
+  ...Object.fromEntries(["writing.feedback.mood", "writing.feedback.echo"].map((id) => [
+    id, definition(id as KnownServicePromptId, Object.keys(fixture.defaults[id as keyof typeof fixture.defaults]).map((key) => ({
+      key, label: key, mode: "literal", required_variables: []
+    })))
+  ])),
   "writing.agent.quick": definition("writing.agent.quick", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
   "writing.agent.planning": definition("writing.agent.planning", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
   "writing.agent.brainstorm": definition("writing.agent.brainstorm", [{ key: "system", label: "System instructions", mode: "literal", required_variables: [] }]),
@@ -180,6 +185,8 @@ const definitions: Partial<Record<KnownServicePromptId, ServicePromptCatalogItem
 describe("Service Prompt validation and rendering", () => {
   it("keeps old-server defaults byte-equivalent to the shared fixture", () => {
     expect(LEGACY_SERVICE_PROMPT_DEFAULTS).toEqual({
+      "writing.feedback.mood": fixture.defaults["writing.feedback.mood"],
+      "writing.feedback.echo": fixture.defaults["writing.feedback.echo"],
       "writing.agent.quick": fixture.defaults["writing.agent.quick"],
       "writing.agent.planning": fixture.defaults["writing.agent.planning"],
       "writing.agent.brainstorm": fixture.defaults["writing.agent.brainstorm"],
@@ -385,6 +392,23 @@ const renderDefinitionFor = (id: KnownServicePromptId) => ({
 })
 
 describe("Service Prompt migration and runtime snapshots", () => {
+  it.each(["writing.feedback.mood", "writing.feedback.echo"] as const)("loads %s atomically with old-server fallback but does not hide errors", async (id) => {
+    const saved = Object.fromEntries(Object.keys(fixture.defaults[id]).map((key) => [key, `Custom ${key} {literal}`]))
+    for (const fallback of ["catalog-404", "omitted", "detail-404", "saved"]) {
+      mocks.listServicePrompts.mockResolvedValue(fallback === "omitted" ? [] : catalog)
+      if (fallback === "catalog-404") mocks.listServicePrompts.mockRejectedValueOnce(new ServicePromptApiError("Not found", { status: 404 }))
+      mocks.getServicePrompt.mockResolvedValue(detailFor(id, { effective_parts: saved, source: "user" }))
+      if (fallback === "detail-404") mocks.getServicePrompt.mockRejectedValueOnce(new ServicePromptApiError("Not found", { status: 404 }))
+      const snapshot = await loadServicePromptSnapshot([id])
+      expect(snapshot.definitions[id]?.parts).toEqual(fallback === "saved" ? saved : fixture.defaults[id])
+      snapshot.release()
+    }
+    for (const status of [401, 403, 409, 422, 500]) {
+      const error = new ServicePromptApiError("Failed", { status })
+      mocks.getServicePrompt.mockRejectedValueOnce(error)
+      await expect(loadServicePromptSnapshot([id])).rejects.toBe(error)
+    }
+  })
   it.each(["quick", "planning", "brainstorm"] as const)("loads %s writing instructions with compatible defaults and no silent error fallback", async (mode) => {
     const id = `writing.agent.${mode}` as const
     for (const fallback of ["catalog-404", "omitted", "detail-404", "saved"]) {

--- a/apps/packages/ui/src/services/service-prompts.ts
+++ b/apps/packages/ui/src/services/service-prompts.ts
@@ -290,6 +290,23 @@ const freezeRenderDefinition = (
 })
 
 const LEGACY_RENDER_DEFINITIONS = Object.freeze({
+  "writing.feedback.mood": freezeRenderDefinition({
+    id: "writing.feedback.mood",
+    parts: [
+      { key: "system_semantics", mode: "literal", required_variables: [] },
+      { key: "classification_semantics", mode: "literal", required_variables: [] },
+    ]
+  }),
+  "writing.feedback.echo": freezeRenderDefinition({
+    id: "writing.feedback.echo",
+    parts: [
+      { key: "alex_system", mode: "literal", required_variables: [] },
+      { key: "sam_system", mode: "literal", required_variables: [] },
+      { key: "max_system", mode: "literal", required_variables: [] },
+      { key: "riley_system", mode: "literal", required_variables: [] },
+      { key: "jordan_system", mode: "literal", required_variables: [] },
+    ]
+  }),
   "writing.agent.quick": freezeRenderDefinition({
     id: "writing.agent.quick",
     parts: [{ key: "system", mode: "literal", required_variables: [] }]
@@ -353,6 +370,8 @@ const LEGACY_RENDER_DEFINITIONS = Object.freeze({
 
 // These features shipped before their Service Prompts definitions.
 const PACKAGED_FALLBACK_IDS = [
+  "writing.feedback.mood",
+  "writing.feedback.echo",
   "image.prompt.refinement",
   "writing.agent.quick",
   "writing.agent.planning",

--- a/apps/packages/ui/src/services/tldw-server.ts
+++ b/apps/packages/ui/src/services/tldw-server.ts
@@ -485,6 +485,17 @@ Generate a response that is informative and relevant to the user's query based o
 `
 
 export const LEGACY_SERVICE_PROMPT_DEFAULTS = Object.freeze({
+  "writing.feedback.mood": Object.freeze({
+    "system_semantics": "You are a mood classifier.",
+    "classification_semantics": "Classify the emotional mood of this text."
+  }),
+  "writing.feedback.echo": Object.freeze({
+    "alex_system": "You are Alex, a sharp literary analyst. In 1-2 sentences, comment on the structure, foreshadowing, or plot mechanics. Be concise.",
+    "sam_system": "You are Sam, obsessed with character relationships. In 1-2 sentences, react to relationship dynamics or romantic tension.",
+    "max_system": "You are Max, a skeptical reader. In 1-2 sentences, point out anything contrived or unmotivated.",
+    "riley_system": "You are Riley, an enthusiastic reader. In 1-2 sentences, react with energy to the most exciting element.",
+    "jordan_system": "You are Jordan, a world-building enthusiast. In 1-2 sentences, comment on world-building details or consistency."
+  }),
   "chat.rag.answer": Object.freeze({ template: DEFAULT_RAG_SYSTEM_PROMPT }),
   "chat.rag.question_rewrite": Object.freeze({
     template: DEFAULT_RAG_QUESTION_PROMPT

--- a/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
+++ b/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
@@ -5,6 +5,8 @@ import type {
 } from "@/services/tldw/TldwApiClient"
 
 export type KnownServicePromptId =
+  | "writing.feedback.mood"
+  | "writing.feedback.echo"
   | "writing.agent.quick"
   | "writing.agent.planning"
   | "writing.agent.brainstorm"

--- a/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
+++ b/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
@@ -1,5 +1,16 @@
 {
   "defaults": {
+    "writing.feedback.mood": {
+      "system_semantics": "You are a mood classifier.",
+      "classification_semantics": "Classify the emotional mood of this text."
+    },
+    "writing.feedback.echo": {
+      "alex_system": "You are Alex, a sharp literary analyst. In 1-2 sentences, comment on the structure, foreshadowing, or plot mechanics. Be concise.",
+      "sam_system": "You are Sam, obsessed with character relationships. In 1-2 sentences, react to relationship dynamics or romantic tension.",
+      "max_system": "You are Max, a skeptical reader. In 1-2 sentences, point out anything contrived or unmotivated.",
+      "riley_system": "You are Riley, an enthusiastic reader. In 1-2 sentences, react with energy to the most exciting element.",
+      "jordan_system": "You are Jordan, a world-building enthusiast. In 1-2 sentences, comment on world-building details or consistency."
+    },
     "writing.agent.quick": {
       "system": "You are a writing assistant. Give brief, direct answers (3 sentences max). The WRITER writes. You ASSIST and ADVISE."
     },

--- a/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Writing mood and Echo prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-07 20:14'
-updated_date: '2026-09-07 20:37'
+updated_date: '2026-09-07 20:54'
 labels: []
 dependencies: []
 references:
@@ -39,6 +39,10 @@ Approved bounded follow-up to Writing Agent prompts: expose mood classifier sema
 Implemented and independently reviewed on codex/writing-feedback-service-prompts from dev e3174f1ad9. Test-first red/green captured for missing definitions/fallbacks, customized/scoped hook requests, Settings classifier label, and stale scope-error race. Verification: 97 backend registry/API tests; 281 focused shared-client tests; 47 direct-browser transport tests; 12 locale mirrors match; Bandit zero findings; Ruff clean; ESLint zero errors and 10 preexisting explicit-any warnings. Shared-UI tsc completes with 158 existing diagnostics, none in changed files, with 8 GiB Node heap. Full-repo tests/build/live browser smoke not run. Ready for integration choice; no PR pushed yet.
 
 PR #2930 created against dev at user request. Feature commit ef699229c6 pushed. Awaiting remote review/checks and integration; worktree retained.
+
+Qodo review at ef699229c6 reported three findings: silent unexpected-error diagnostics, missing registry-test docstring, and retaining new scope leases for failed/invalid feedback. Verified against current head; addressing with targeted regressions while preserving leases for existing visible feedback.
+
+Addressed all three Qodo findings: request-local snapshots now release on invalid/failed/empty/cancelled results and only usable feedback replaces a retained visible-state lease; unique callbacks preserve listener ownership. Unexpected failures log static kind and phase only, with cancellation/scope control flow quiet. Added Python test docstring. Ten added regression cases reproduced failures before the fix. Verification: 249 affected client tests and 97 backend tests pass; touched-scope ESLint/Ruff clean, Bandit zero findings; independent review approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
@@ -4,9 +4,11 @@ title: Expose Writing mood and Echo prompts through Service Prompts
 status: In Progress
 assignee: []
 created_date: '2026-09-07 20:14'
-updated_date: '2026-09-07 20:29'
+updated_date: '2026-09-07 20:37'
 labels: []
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2930'
 documentation:
   - Docs/Design/writing-feedback-service-prompts.md
 ---
@@ -35,6 +37,8 @@ Approved bounded follow-up to Writing Agent prompts: expose mood classifier sema
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented and independently reviewed on codex/writing-feedback-service-prompts from dev e3174f1ad9. Test-first red/green captured for missing definitions/fallbacks, customized/scoped hook requests, Settings classifier label, and stale scope-error race. Verification: 97 backend registry/API tests; 281 focused shared-client tests; 47 direct-browser transport tests; 12 locale mirrors match; Bandit zero findings; Ruff clean; ESLint zero errors and 10 preexisting explicit-any warnings. Shared-UI tsc completes with 158 existing diagnostics, none in changed files, with 8 GiB Node heap. Full-repo tests/build/live browser smoke not run. Ready for integration choice; no PR pushed yet.
+
+PR #2930 created against dev at user request. Feature commit ef699229c6 pushed. Awaiting remote review/checks and integration; worktree retained.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
+++ b/backlog/tasks/task-13215 - Expose-Writing-mood-and-Echo-prompts-through-Service-Prompts.md
@@ -1,0 +1,54 @@
+---
+id: TASK-13215
+title: Expose Writing mood and Echo prompts through Service Prompts
+status: In Progress
+assignee: []
+created_date: '2026-09-07 20:14'
+updated_date: '2026-09-07 20:29'
+labels: []
+dependencies: []
+documentation:
+  - Docs/Design/writing-feedback-service-prompts.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Approved bounded follow-up to Writing Agent prompts: expose mood classifier semantics and five Echo persona instructions through existing Service Prompts in both clients, preserving defaults and scope isolation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Mood and all five Echo instructions are editable through existing Settings
+- [x] #2 Default requests, output contracts, limits, rotation and enablement remain compatible
+- [x] #3 Account or server changes abort stale requests and clear old-scope feedback
+- [x] #4 Focused regressions, lint and Bandit pass with documented verification
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Register literal parts and shared Settings/fallback definitions test-first. 2. Capture request-scoped snapshots in feedback hook with stale-result protection test-first. 3. Verify regression suites, security checks and review; update design and task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented and independently reviewed on codex/writing-feedback-service-prompts from dev e3174f1ad9. Test-first red/green captured for missing definitions/fallbacks, customized/scoped hook requests, Settings classifier label, and stale scope-error race. Verification: 97 backend registry/API tests; 281 focused shared-client tests; 47 direct-browser transport tests; 12 locale mirrors match; Bandit zero findings; Ruff clean; ESLint zero errors and 10 preexisting explicit-any warnings. Shared-UI tsc completes with 158 existing diagnostics, none in changed files, with 8 GiB Node heap. Full-repo tests/build/live browser smoke not run. Ready for integration choice; no PR pushed yet.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Exposes mood classifier guidance and five Echo persona prompts through existing shared Service Prompts settings. Preserves exact default chat payloads and fixed output/rotation/limits, uses existing older-server fallbacks, and binds async generation plus displayed feedback to its starting account/server with bounded retained scope leases. No separate storage or settings system.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -156,6 +156,40 @@ Based on the content between backticks create comprehensive bulleted notes.
 - Do not reference these instructions in your response."""
 
 _DEFINITION_SEQUENCE = (
+    ServicePromptDefinition(
+        id="writing.feedback.mood",
+        label="Writing feedback: Mood",
+        description="Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed.",
+        parts=(
+            ServicePromptPart(key="system_semantics", label="Classifier guidance", mode="literal", required_variables=()),
+            ServicePromptPart(key="classification_semantics", label="Classification instructions", mode="literal", required_variables=()),
+        ),
+        default_parts=MappingProxyType({
+            "system_semantics": "You are a mood classifier.",
+            "classification_semantics": "Classify the emotional mood of this text.",
+        }),
+        affected_workflows=(ServicePromptWorkflow(id="writing.feedback", label="Writing Playground feedback"),),
+    ),
+    ServicePromptDefinition(
+        id="writing.feedback.echo",
+        label="Writing feedback: Echo",
+        description="Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed.",
+        parts=(
+            ServicePromptPart(key="alex_system", label="Alex instructions", mode="literal", required_variables=()),
+            ServicePromptPart(key="sam_system", label="Sam instructions", mode="literal", required_variables=()),
+            ServicePromptPart(key="max_system", label="Max instructions", mode="literal", required_variables=()),
+            ServicePromptPart(key="riley_system", label="Riley instructions", mode="literal", required_variables=()),
+            ServicePromptPart(key="jordan_system", label="Jordan instructions", mode="literal", required_variables=()),
+        ),
+        default_parts=MappingProxyType({
+            "alex_system": "You are Alex, a sharp literary analyst. In 1-2 sentences, comment on the structure, foreshadowing, or plot mechanics. Be concise.",
+            "sam_system": "You are Sam, obsessed with character relationships. In 1-2 sentences, react to relationship dynamics or romantic tension.",
+            "max_system": "You are Max, a skeptical reader. In 1-2 sentences, point out anything contrived or unmotivated.",
+            "riley_system": "You are Riley, an enthusiastic reader. In 1-2 sentences, react with energy to the most exciting element.",
+            "jordan_system": "You are Jordan, a world-building enthusiast. In 1-2 sentences, comment on world-building details or consistency.",
+        }),
+        affected_workflows=(ServicePromptWorkflow(id="writing.feedback", label="Writing Playground feedback"),),
+    ),
     *(
         ServicePromptDefinition(
             id=f"writing.agent.{mode}",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -29,6 +29,18 @@ FIXTURE_PATH = (
 FIXTURE = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 EXPECTED_REGISTRY = {
+    "writing.feedback.mood": {
+        "label": "Writing feedback: Mood",
+        "description": "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed.",
+        "parts": (("system_semantics", "Classifier guidance", "literal", ()), ("classification_semantics", "Classification instructions", "literal", ())),
+        "workflows": (("writing.feedback", "Writing Playground feedback"),),
+    },
+    "writing.feedback.echo": {
+        "label": "Writing feedback: Echo",
+        "description": "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed.",
+        "parts": tuple((f"{name.lower()}_system", f"{name} instructions", "literal", ()) for name in ("Alex", "Sam", "Max", "Riley", "Jordan")),
+        "workflows": (("writing.feedback", "Writing Playground feedback"),),
+    },
     "writing.agent.quick": {
         "label": "Writing Agent: Quick",
         "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
@@ -266,6 +278,20 @@ def test_registry_contains_exact_locked_metadata_and_workflows() -> None:
         assert (
             tuple((workflow.id, workflow.label) for workflow in definition.affected_workflows) == expected["workflows"]
         )
+
+
+@pytest.mark.parametrize("definition_id", ["writing.feedback.mood", "writing.feedback.echo"])
+def test_feedback_overrides_are_atomic_literal_parts(definition_id: str) -> None:
+    definition = get_service_prompt_definition(definition_id)
+    parts = {key: f"Custom {key} {{literal}}" for key in FIXTURE["defaults"][definition_id]}
+    resolved = resolve_service_prompt(_FakePromptsDatabase(_OverrideRow(definition_id, json.dumps(parts), "revision-1")), definition_id)
+    assert dict(resolved.parts) == parts
+    for key, value in parts.items():
+        assert render_service_prompt_part(definition, key, value, {}) == value
+    incomplete = dict(parts)
+    incomplete.pop(next(iter(incomplete)))
+    with pytest.raises(ServicePromptValidationError):
+        validate_service_prompt_parts(definition, incomplete)
 
 
 def test_registry_and_resolved_mappings_are_immutable() -> None:

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -282,6 +282,7 @@ def test_registry_contains_exact_locked_metadata_and_workflows() -> None:
 
 @pytest.mark.parametrize("definition_id", ["writing.feedback.mood", "writing.feedback.echo"])
 def test_feedback_overrides_are_atomic_literal_parts(definition_id: str) -> None:
+    """For the selected mood/Echo definition, render complete literal overrides and reject incomplete bundles."""
     definition = get_service_prompt_definition(definition_id)
     parts = {key: f"Custom {key} {{literal}}" for key in FIXTURE["defaults"][definition_id]}
     resolved = resolve_service_prompt(_FakePromptsDatabase(_OverrideRow(definition_id, json.dumps(parts), "revision-1")), definition_id)

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -88,6 +88,74 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
     assert response.headers["cache-control"] == "no-store"
     assert response.json() == [
         {
+            "id": "writing.feedback.mood",
+            "label": "Writing feedback: Mood",
+            "description": "Controls mood classification guidance. The seven allowed moods, one-word response, passage and provider settings remain fixed.",
+            "parts": [
+                {
+                    "key": "system_semantics",
+                    "label": "Classifier guidance",
+                    "mode": "literal",
+                    "required_variables": []
+                },
+                {
+                    "key": "classification_semantics",
+                    "label": "Classification instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                }
+            ],
+            "affected_workflows": [
+                {
+                    "id": "writing.feedback",
+                    "label": "Writing Playground feedback"
+                }
+            ]
+        },
+        {
+            "id": "writing.feedback.echo",
+            "label": "Writing feedback: Echo",
+            "description": "Controls the five reader reactions. Persona identities, rotation, passage and provider settings remain fixed.",
+            "parts": [
+                {
+                    "key": "alex_system",
+                    "label": "Alex instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                },
+                {
+                    "key": "sam_system",
+                    "label": "Sam instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                },
+                {
+                    "key": "max_system",
+                    "label": "Max instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                },
+                {
+                    "key": "riley_system",
+                    "label": "Riley instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                },
+                {
+                    "key": "jordan_system",
+                    "label": "Jordan instructions",
+                    "mode": "literal",
+                    "required_variables": []
+                }
+            ],
+            "affected_workflows": [
+                {
+                    "id": "writing.feedback",
+                    "label": "Writing Playground feedback"
+                }
+            ]
+        },
+        {
             "id": "writing.agent.quick",
             "label": "Writing Agent: Quick",
             "description": "Controls writing assistance instructions. Manuscript context and provider settings remain fixed.",
@@ -519,6 +587,29 @@ def test_writing_agent_prompt_save_reset_and_mode_isolation(api_context: SimpleN
     reset = api_context.client.delete(path, params={"expected_revision": saved.json()["revision"]})
     assert reset.status_code == 200
     assert reset.json()["effective_parts"] == defaults
+
+
+@pytest.mark.parametrize(
+    "kind,keys",
+    [
+        ("mood", ["system_semantics", "classification_semantics"]),
+        ("echo", ["alex_system", "sam_system", "max_system", "riley_system", "jordan_system"]),
+    ],
+)
+def test_writing_feedback_prompt_atomic_save_and_reset(api_context: SimpleNamespace, kind: str, keys: list[str]) -> None:
+    """Feedback parts save atomically and reset through the existing generic API."""
+    path = f"/api/v1/service-prompts/writing.feedback.{kind}"
+    before = api_context.client.get(path)
+    assert before.status_code == 200
+    custom = {key: f"Custom {key} {{literal}}" for key in keys}
+    incomplete = api_context.client.put(path, json={"parts": {keys[0]: "Partial"}, "expected_revision": None})
+    assert incomplete.status_code == 422
+    saved = api_context.client.put(path, json={"parts": custom, "expected_revision": None})
+    assert saved.status_code == 200
+    assert api_context.client.get(path).json()["effective_parts"] == custom
+    reset = api_context.client.delete(path, params={"expected_revision": saved.json()["revision"]})
+    assert reset.status_code == 200
+    assert reset.json()["effective_parts"] == before.json()["default_parts"]
 
 
 def test_title_prompt_can_be_saved_and_reset_through_generic_api(api_context) -> None:


### PR DESCRIPTION
## Summary

- What changed: Adds `writing.feedback.mood` and `writing.feedback.echo` to Service Prompts in the shared WebUI/browser-extension Settings. Mood exposes two instruction parts; Echo exposes all five persona instructions as one atomic bundle.
- Why: Reuses the existing per-user prompt storage, Settings interface, and old-server compatibility handling. Each feedback request captures one account/server-bound snapshot; bounded retained scope leases clear displayed feedback after scope changes. Existing default payloads, mood output validation, persona rotation, debounce, text/history limits, and provider settings remain unchanged.
- Includes a regression fix so a late scope error from a cancelled request cannot clear newer feedback.
- Tracking: TASK-13215. Design and verification: `Docs/Design/writing-feedback-service-prompts.md`.

## Change summary

Human-owned change summary pending. The technical summary above is AI-authored and is not represented as a human-written summary.

## Validation

- [x] Tests added/updated for behavior changes; failing regressions observed before implementation.
- [x] Relevant unit/integration tests pass locally: 97 backend registry/API tests, 281 focused shared-client tests, and 47 direct-browser transport tests (425 total).
- [x] Docs and task record updated.
- [x] Bandit: zero findings. Ruff: clean. ESLint: zero errors; 10 existing explicit-any warnings in unchanged portions of `tldw-server.ts`.
- [x] Independent code review approved after the stale-error regression fix.
- Shared-UI TypeScript check completes with 158 existing diagnostics, none in changed files (8 GiB Node heap required).
- Full repository tests, production builds, and live browser smoke tests were not run.

## UX Audit Checklist (v2 Stage 5)

- [ ] Stage 5 and all-pages browser smoke tests: not run locally.
- [ ] Live console/deprecation and audited-route checks: not run locally.
- [x] WebUI/extension parity covered through the shared Settings/hook implementation and 12 matching English locale mirror entries.
- Flashcards-specific checks: not applicable.

## Watchlists Accessibility and Scale Checklists

Not applicable: no Watchlists changes.

## Risk & Rollback

- Risk level: Medium. The main risk is asynchronous feedback crossing account/server boundaries; focused lifecycle and transport regressions cover cancellation, stale completion/error handling, and lease cleanup.
- Rollback plan: Revert the feature commit(s). No database migration or new storage system is introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Writing mood and Echo prompts to Service Prompts settings, and cleans up failed feedback requests so they release temporary scope leases without unmounting the lease protecting visible feedback. Unexpected failures log only static kind and phase; cancellation and scope changes stay quiet.

- Registers both prompt definitions in the backend registry and shared client fallbacks with atomic save/reset validation.
- The feedback hook loads per-request snapshots and binds generation and visible feedback to the initiating account/server, aborting stale work and releasing leases on scope changes or unmount.
- Failed, invalid, empty, or cancelled feedback releases its temporary snapshot without replacing the lease for existing visible feedback.
- Failed prompt lookups no longer dispatch default requests; only older-server 404s use packaged fallbacks.

<sup>Written for commit dde149984e756d0d8934adf3bc88c318c054fc4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

