### PR TITLE
fix(auth, chat): repair profile sessions and configured model defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -936,6 +936,7 @@ jobs:
             paths: >-
               tldw_Server_API/tests/AuthNZ/integration/test_admin_*.py
               tldw_Server_API/tests/AuthNZ/integration/test_api_key_*.py
+              tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
               tldw_Server_API/tests/AuthNZ/integration/test_auth_*.py
           - name: auth-integration-authnz
             paths: >-
@@ -1295,14 +1296,20 @@ jobs:
           - name: media-core-api
             paths: >-
               tldw_Server_API/tests/Media/test_archive_member_cap.py
+              tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
               tldw_Server_API/tests/Media/test_cache_index.py
+              tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_email_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
               tldw_Server_API/tests/Media/test_json_*.py
               tldw_Server_API/tests/Media/test_media_*.py
               tldw_Server_API/tests/Media/test_navigation_policy_contract.py
+              tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_process_code_and_uploads.py
               tldw_Server_API/tests/Media/test_upload_sink_security.py
+              tldw_Server_API/tests/Media/test_video_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
               tldw_Server_API/tests/Media/unit
           - name: media-ingestion-new-ocr
             paths: >-
@@ -1327,6 +1334,7 @@ jobs:
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py
+              tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py
           - name: media-ingestion-new-unit-mediawiki
             paths: >-
@@ -2426,6 +2434,7 @@ jobs:
             paths: >-
               tldw_Server_API/tests/AuthNZ/integration/test_admin_*.py
               tldw_Server_API/tests/AuthNZ/integration/test_api_key_*.py
+              tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
               tldw_Server_API/tests/AuthNZ/integration/test_auth_*.py
           - name: auth-integration-authnz
             paths: >-
@@ -2785,14 +2794,20 @@ jobs:
           - name: media-core-api
             paths: >-
               tldw_Server_API/tests/Media/test_archive_member_cap.py
+              tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
               tldw_Server_API/tests/Media/test_cache_index.py
+              tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_email_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
               tldw_Server_API/tests/Media/test_json_*.py
               tldw_Server_API/tests/Media/test_media_*.py
               tldw_Server_API/tests/Media/test_navigation_policy_contract.py
+              tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_process_code_and_uploads.py
               tldw_Server_API/tests/Media/test_upload_sink_security.py
+              tldw_Server_API/tests/Media/test_video_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
               tldw_Server_API/tests/Media/unit
           - name: media-ingestion-new-ocr
             paths: >-
@@ -2817,6 +2832,7 @@ jobs:
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py
+              tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py
           - name: media-ingestion-new-unit-mediawiki
             paths: >-
@@ -2932,6 +2948,7 @@ jobs:
               tldw_Server_API/tests/Visual_Identities
           - name: chat-character-integration-api
             paths: >-
+              tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_behavior_snapshot_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -3785,6 +3802,7 @@ jobs:
             paths: >-
               tldw_Server_API/tests/AuthNZ/integration/test_admin_*.py
               tldw_Server_API/tests/AuthNZ/integration/test_api_key_*.py
+              tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
               tldw_Server_API/tests/AuthNZ/integration/test_auth_*.py
           - name: auth-integration-authnz
             paths: >-
@@ -4144,14 +4162,20 @@ jobs:
           - name: media-core-api
             paths: >-
               tldw_Server_API/tests/Media/test_archive_member_cap.py
+              tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
               tldw_Server_API/tests/Media/test_cache_index.py
+              tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_email_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
               tldw_Server_API/tests/Media/test_json_*.py
               tldw_Server_API/tests/Media/test_media_*.py
               tldw_Server_API/tests/Media/test_navigation_policy_contract.py
+              tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_process_code_and_uploads.py
               tldw_Server_API/tests/Media/test_upload_sink_security.py
+              tldw_Server_API/tests/Media/test_video_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
               tldw_Server_API/tests/Media/unit
           - name: media-ingestion-new-ocr
             paths: >-
@@ -4176,6 +4200,7 @@ jobs:
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py
+              tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py
           - name: media-ingestion-new-unit-mediawiki
             paths: >-
@@ -4291,6 +4316,7 @@ jobs:
               tldw_Server_API/tests/Visual_Identities
           - name: chat-character-integration-api
             paths: >-
+              tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_behavior_snapshot_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -5067,6 +5093,7 @@ jobs:
             paths: >-
               tldw_Server_API/tests/AuthNZ/integration/test_admin_*.py
               tldw_Server_API/tests/AuthNZ/integration/test_api_key_*.py
+              tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
               tldw_Server_API/tests/AuthNZ/integration/test_auth_*.py
           - name: auth-integration-authnz
             paths: >-
@@ -5426,14 +5453,20 @@ jobs:
           - name: media-core-api
             paths: >-
               tldw_Server_API/tests/Media/test_archive_member_cap.py
+              tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
               tldw_Server_API/tests/Media/test_cache_index.py
+              tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_email_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
               tldw_Server_API/tests/Media/test_json_*.py
               tldw_Server_API/tests/Media/test_media_*.py
               tldw_Server_API/tests/Media/test_navigation_policy_contract.py
+              tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_process_code_and_uploads.py
               tldw_Server_API/tests/Media/test_upload_sink_security.py
+              tldw_Server_API/tests/Media/test_video_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
               tldw_Server_API/tests/Media/unit
           - name: media-ingestion-new-ocr
             paths: >-
@@ -5458,6 +5491,7 @@ jobs:
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py
+              tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py
           - name: media-ingestion-new-unit-mediawiki
             paths: >-
@@ -5573,6 +5607,7 @@ jobs:
               tldw_Server_API/tests/Visual_Identities
           - name: chat-character-integration-api
             paths: >-
+              tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_behavior_snapshot_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -6355,6 +6390,7 @@ jobs:
             paths: >-
               tldw_Server_API/tests/AuthNZ/integration/test_admin_*.py
               tldw_Server_API/tests/AuthNZ/integration/test_api_key_*.py
+              tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
               tldw_Server_API/tests/AuthNZ/integration/test_auth_*.py
           - name: auth-integration-authnz
             paths: >-
@@ -6714,14 +6750,20 @@ jobs:
           - name: media-core-api
             paths: >-
               tldw_Server_API/tests/Media/test_archive_member_cap.py
+              tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py
               tldw_Server_API/tests/Media/test_cache_index.py
+              tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_email_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py
               tldw_Server_API/tests/Media/test_json_*.py
               tldw_Server_API/tests/Media/test_media_*.py
               tldw_Server_API/tests/Media/test_navigation_policy_contract.py
+              tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py
               tldw_Server_API/tests/Media/test_process_code_and_uploads.py
               tldw_Server_API/tests/Media/test_upload_sink_security.py
+              tldw_Server_API/tests/Media/test_video_summary_service_prompt.py
+              tldw_Server_API/tests/Media/test_web_summary_service_prompt.py
               tldw_Server_API/tests/Media/unit
           - name: media-ingestion-new-ocr
             paths: >-
@@ -6746,6 +6788,7 @@ jobs:
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py
+              tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py
               tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py
           - name: media-ingestion-new-unit-mediawiki
             paths: >-
@@ -6861,6 +6904,7 @@ jobs:
               tldw_Server_API/tests/Visual_Identities
           - name: chat-character-integration-api
             paths: >-
+              tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_behavior_snapshot_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
               tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py

--- a/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+++ b/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
@@ -19,6 +19,10 @@ publication. Before publication, the branch was rebased onto dev commit
 implementation plan is removed when work is complete; this note retains the
 design, audit, and verification record.
 
+Published as [PR #2939](https://github.com/rmusser01/tldw_server/pull/2939),
+targeting dev. The PR records the repository's human-written Change summary
+requirement before merge.
+
 ## Related-pattern audit
 
 The PostgreSQL array audit followed `ANY`/`ALL` queries through their actual

--- a/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+++ b/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
@@ -166,3 +166,13 @@ test assertions excluded via B101; the array test file also passes Black.
 The full backend and admin UI suites were not run. PostgreSQL verification uses
 the repository's standard local isolated fixture; it does not measure migration
 time or lock behavior on large production session tables.
+
+## Live UAT follow-up
+
+The [September 10 live acceptance report](../Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md)
+records browser login/settings interactions, real PostgreSQL profile and session
+requests, Node 20.20.2 runtime JWT checks, and a 24-case chat matrix. UAT exposed
+additional audio quota DATE bindings and a synchronous RBAC event-loop stall;
+both are repaired with regressions. Review also hardened concurrent initialization
+and reset of the shared RBAC database cache. TASK-13239 and TASK-13240 retain the
+follow-up work and verification history.

--- a/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+++ b/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
@@ -12,9 +12,12 @@ Chat metrics may label an absent model unknown, but execution must retain absenc
 
 ## Work and verification record
 
-Tracked in TASK-13235, TASK-13236, and TASK-13237, based on fetched dev commit
-`751563a966`. The task-owned implementation plan is removed when work is complete;
-this note retains the design, audit, and verification record.
+Tracked in TASK-13235, TASK-13236, and TASK-13237, initially based on fetched dev
+commit `751563a966`. TASK-13238 tracks the migration-test follow-up and PR
+publication. Before publication, the branch was rebased onto dev commit
+`177d58ac6fee87678d65ce3a9db0216021b6b68e` without conflicts. The task-owned
+implementation plan is removed when work is complete; this note retains the
+design, audit, and verification record.
 
 ## Related-pattern audit
 
@@ -73,6 +76,9 @@ keys use the normalized model rather than falling back to the raw request.
 - Combined auth/profile suite: 86 passed, including the new PostgreSQL session
   and array integration tests, session migration/read/refresh coverage, override
   readiness, and SQLite compatibility.
+- Final PR verification on the rebased branch expanded that suite with the
+  API-key, lockout-scope, and usage-truthiness migration tests: 100 passed.
+  The profile-version migration file passed separately with 22 tests.
 - Session worker checks: 24 focused unit tests and 4 PostgreSQL tests passed.
   The older session integration tests now seed through UsersDB and the standard
   isolated fixture, allowing their existing refresh/revocation checks to run
@@ -91,16 +97,18 @@ Final chat verification:
 | Scope | Result |
 | --- | --- |
 | Provider/model resolution, target defaults, default provider, payload construction | 146 passed |
-| Omitted/blank/configured/explicit endpoint cases in both streaming modes | 20 passed |
+| Full simplified endpoint file, including omitted/blank/configured/explicit models in both streaming modes | 215 passed, 1 existing skip |
 | Messages usage | 209 passed |
 | Messages endpoints, overrides, defaults, native errors | 111 passed |
 | Character prechecks and Notes suggestion providers | 30 passed |
 | Chat macros | 7 passed |
 
-The full simplified chat endpoint file passed 203 tests with one existing skip
-before the final whitespace follow-up. All affected endpoint cases were rerun
-afterward. The existing skip is the older streaming test marked as hanging with
-TestClient; the new streaming payload regressions ran successfully.
+After the whitespace follow-up and rebase onto dev, the resolver/default/payload
+tests and full simplified endpoint file passed 361 tests combined, with one
+existing skip. That skip is the older streaming test marked as hanging with
+TestClient; the new streaming payload regressions ran successfully. The four
+focused UI middleware/auth files also passed again on the rebased branch
+(11 tests).
 
 Bandit reports no findings or scan errors across all twelve touched backend
 production files. Python compilation, repository test guards, and git whitespace
@@ -110,15 +118,46 @@ on the original base. Existing whole-file Black drift was left outside the
 behavioral repair. Independent review identified the malformed-algorithm and
 blank-model cases, then cleared all fixes after follow-up.
 
-## Known verification limits
+## Migration-test follow-up
 
 The broader SQLite/AuthNZ migration run passed 52 tests and failed
 `test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys` in
-`tests/AuthNZ/unit/test_profile_version_migration.py`. Its exact users-column
-expectation omits seven columns added by the existing migration path, starting
-with uuid. Running that single test in a detached worktree at the original base
-`751563a966` reproduced the identical failure with migrations 91–97. Migration 98
-does not alter users. This pre-existing test failure remains outside this repair.
+`tests/AuthNZ/unit/test_profile_version_migration.py`. Running that single test in
+a detached worktree at the original base `751563a966` reproduced the identical
+failure with migrations 91–97. Migration 98 does not alter users.
+
+The follow-up isolated the stale expectation: migration 91 preserves the custom
+users schema and appends profile_version, while migration 93 legitimately appends
+uuid, is_active, is_superuser, email_verified, is_verified, storage_quota_mb, and
+storage_used_mb. No production migration change is needed. The regression now
+checks the preserved column prefix and runs both migration 91 alone and the full
+startup upgrade. All existing row, default, constraint, index, trigger, sequence,
+and parent/child foreign-key checks remain intact.
+
+Before the assertion repair, the migration-91 case passed and the latest-upgrade
+case reproduced the failure. After repair, all 22 tests in the profile migration
+file pass. Independent review found no outstanding issues. Ruff, compilation,
+and whitespace checks pass. Bandit reports no findings or scan errors in the
+changed test file with the expected test assertions excluded via B101.
+
+The wider auth run also exposed an order-dependent Hypothesis generation health
+check in the new array property regression. Two wider runs passed 99 tests and
+failed that check, while the same property seed passed alone. Profiling a smaller
+reproduction traced 1.324 seconds of a draw to Hypothesis's first scan of constants
+from 2,159 imported modules. The tested array binding itself was not slow.
+Independent review recommended a test-local, finite 1,000 ms deadline: in the
+installed Hypothesis 6.138.2, this allows five seconds for generation health
+checks. The positive-integer array strategy, length bound, example count, and
+assertion are unchanged, and no health checks are suppressed. This avoids
+patching Hypothesis internals or reducing coverage.
+
+The final wider run passed all 100 tests using the original test-order seed
+`182453889` and Hypothesis seed `219652731782752022987833063022846811844`.
+Hypothesis completed 100 passing examples with typical runtimes below 1 ms.
+Both follow-up test files pass Ruff, compilation, and Bandit with only expected
+test assertions excluded via B101; the array test file also passes Black.
+
+## Known verification limits
 
 The full backend and admin UI suites were not run. PostgreSQL verification uses
 the repository's standard local isolated fixture; it does not measure migration

--- a/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+++ b/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
@@ -1,0 +1,125 @@
+# Regression repair for GitHub issues 2935–2938
+
+## Scope and decisions
+
+The current dev branch already passes a Uint8Array signature to WebCrypto. Preserve that fix, add a regression that detects the old cross-realm ArrayBuffer failure, and validate malformed-token behavior at the middleware boundary.
+
+Production PostgreSQL sessions omit last_activity while session listing, touch, and refresh use it. Add the column through production bootstrap and upgrade handling, including historical values for existing rows. Tests must cover production-created tables so fixture-only columns cannot mask the defect.
+
+DatabasePool supports variadic arguments and a single sequence of arguments. A PostgreSQL array is one argument, so affected profile override callers must pass a sequence containing that array. Keep the shared compatibility contract; do not inspect SQL text to guess whether a list means parameters or one array. Audit other array queries at the actual pool/connection boundary.
+
+Chat metrics may label an absent model unknown, but execution must retain absence until a real configured default is found. Preserve explicit model and administrator default precedence, consult existing provider configuration for local defaults, and reject missing configuration before an upstream call. Audit users of shared resolution helpers and both streaming modes.
+
+## Work and verification record
+
+Tracked in TASK-13235, TASK-13236, and TASK-13237, based on fetched dev commit
+`751563a966`. The task-owned implementation plan is removed when work is complete;
+this note retains the design, audit, and verification record.
+
+## Related-pattern audit
+
+The PostgreSQL array audit followed `ANY`/`ALL` queries through their actual
+connection boundary. Seven methods needed changes:
+
+- Organization and team profile override lists and latest-update queries (four
+  methods from issue 2937).
+- `ManagedSecretRefsRepo.list_refs_by_ids`, including revoked-reference lookup.
+- `AuthnzOrgsTeamsRepo.list_organizations` when the organization-ID array is the
+  only count filter.
+- `AuthnzUsersRepo.list_users` under the same count-filter condition.
+
+Raw acquired/transaction connections retain asyncpg argument semantics and do
+not flatten a single sequence. Billing, generated-file, admin analytics, RBAC,
+data-subject-request, credential-alias, and migration queries using those
+connections therefore do not need the extra wrapper. Queries with multiple
+arguments already preserve their array argument. DatabasePool continues to
+accept both ordinary variadic arguments and a single parameter sequence.
+
+The regression uses the real DatabasePool parameter handling and mocks only the
+external driver. It covers empty, single, and multiple IDs, normalized credential
+IDs, scoped counts, and the existing parameter conventions. A Hypothesis property
+checks preservation of arbitrary positive integer arrays. Separate integration
+tests use the standard isolated PostgreSQL fixture and production schema setup.
+
+The session audit includes fresh and upgraded SQLite databases, historical-row
+backfill, new-session initialization after upgrade, and preservation of existing
+activity timestamps. PostgreSQL tests recreate the sessions table through
+production bootstrap so the fixture's pre-existing activity column cannot hide
+the original defect.
+
+The JWT audit found malformed signature encoding and non-string algorithm
+headers could raise outside the verification error boundary. Both now fail
+closed through the actual middleware. The existing Uint8Array signature argument
+is retained, with a regression that rejects reintroducing the raw ArrayBuffer.
+
+The chat audit follows execution-model values independently of metrics labels
+through shared resolution and both streaming modes. Explicit models and existing
+administrator, DEFAULT_MODEL environment, and Chat-Module defaults retain their
+precedence before provider-configuration fallback. Tests exercise real
+LOCAL_LLM_MODEL environment capture and Local-API.ollama_model parsing. The
+Messages helper also used the metrics placeholder as an execution fallback; it
+now rejects missing models. Review additionally found whitespace-only models
+could bypass the missing-model guard. Both resolution and outgoing payload
+construction now treat blank input like omission. Macro context and tool-policy
+keys use the normalized model rather than falling back to the raw request.
+
+## Verification
+
+- Array regression before fixes: 16 failed and 14 passed, with failures at the
+  actual driver argument boundary.
+- Array regression and existing override-readiness tests after fixes: 49 passed.
+- Real PostgreSQL array integration: 3 passed, covering profile overrides,
+  scoped counts, and bulk managed-secret references.
+- Combined auth/profile suite: 86 passed, including the new PostgreSQL session
+  and array integration tests, session migration/read/refresh coverage, override
+  readiness, and SQLite compatibility.
+- Session worker checks: 24 focused unit tests and 4 PostgreSQL tests passed.
+  The older session integration tests now seed through UsersDB and the standard
+  isolated fixture, allowing their existing refresh/revocation checks to run
+  with the production profile-write guard intact.
+- Bandit for the array production scope: no findings or scan errors.
+- Bandit for the session migration/repository scope: no findings or scan errors.
+- Both new array test files pass Ruff and Black checks. The production scope has
+  one existing Ruff SIM118 finding in unchanged managed-secret row conversion.
+
+JWT checks pass: 11 tests in four focused Vitest files, and the six JWT cases on
+both Node 20 and Node 24. Scoped ESLint and TypeScript checks pass. Independent
+review cleared JWT, array binding, and session migration changes.
+
+Final chat verification:
+
+| Scope | Result |
+| --- | --- |
+| Provider/model resolution, target defaults, default provider, payload construction | 146 passed |
+| Omitted/blank/configured/explicit endpoint cases in both streaming modes | 20 passed |
+| Messages usage | 209 passed |
+| Messages endpoints, overrides, defaults, native errors | 111 passed |
+| Character prechecks and Notes suggestion providers | 30 passed |
+| Chat macros | 7 passed |
+
+The full simplified chat endpoint file passed 203 tests with one existing skip
+before the final whitespace follow-up. All affected endpoint cases were rerun
+afterward. The existing skip is the older streaming test marked as hanging with
+TestClient; the new streaming payload regressions ran successfully.
+
+Bandit reports no findings or scan errors across all twelve touched backend
+production files. Python compilation, repository test guards, and git whitespace
+checks pass. Scoped Ruff checks find no new issues; three existing import-order
+findings in chat.py and the existing managed-secret SIM118 finding are identical
+on the original base. Existing whole-file Black drift was left outside the
+behavioral repair. Independent review identified the malformed-algorithm and
+blank-model cases, then cleared all fixes after follow-up.
+
+## Known verification limits
+
+The broader SQLite/AuthNZ migration run passed 52 tests and failed
+`test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys` in
+`tests/AuthNZ/unit/test_profile_version_migration.py`. Its exact users-column
+expectation omits seven columns added by the existing migration path, starting
+with uuid. Running that single test in a detached worktree at the original base
+`751563a966` reproduced the identical failure with migrations 91–97. Migration 98
+does not alter users. This pre-existing test failure remains outside this repair.
+
+The full backend and admin UI suites were not run. PostgreSQL verification uses
+the repository's standard local isolated fixture; it does not measure migration
+time or lock behavior on large production session tables.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
@@ -12,7 +12,7 @@ Tracked in TASK-13241. Preserve the original issue repairs and live UAT record.
 **Goal**: Verify and resolve each Qodo comment and failed required check.
 **Success Criteria**: Queued macros preserve request-time model defaults; configuration errors are diagnosable; test contracts and documentation are clear; every architecture comment has a supported disposition.
 **Tests**: Red-green macro/default and logging regressions, public array-query outcomes, session migration regressions, affected CI guards, lint and Bandit.
-**Status**: In Progress
+**Status**: Complete
 
 ## Stage 3: Verify, respond, and merge
 **Goal**: Publish reviewed fixes, receive review on the latest changes, and integrate into dev.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
@@ -6,16 +6,16 @@ Tracked in TASK-13241. Preserve the original issue repairs and live UAT record.
 **Goal**: Reapply the PR to the latest fetched development branch.
 **Success Criteria**: Clean rebase, preserved patch intent, recorded old/new base and head.
 **Tests**: Inspect conflicts and range-diff; run affected regressions after review repairs.
-**Status**: In Progress
+**Status**: Complete
 
 ## Stage 2: Address review and CI findings
 **Goal**: Verify and resolve each Qodo comment and failed required check.
 **Success Criteria**: Queued macros preserve request-time model defaults; configuration errors are diagnosable; test contracts and documentation are clear; every architecture comment has a supported disposition.
 **Tests**: Red-green macro/default and logging regressions, public array-query outcomes, session migration regressions, affected CI guards, lint and Bandit.
-**Status**: Not Started
+**Status**: In Progress
 
 ## Stage 3: Verify, respond, and merge
 **Goal**: Publish reviewed fixes, receive review on the latest changes, and integrate into dev.
 **Success Criteria**: Fresh verification and required checks pass, all review findings are addressed, and the repository's human-written Change summary merge requirement is satisfied before merging.
 **Tests**: Final review, current-head CI and remote/base checks, merge result verification.
-**Status**: Not Started
+**Status**: In Progress

--- a/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
@@ -1,0 +1,21 @@
+# PR2939 rebase, review, and merge
+
+Tracked in TASK-13241. Preserve the original issue repairs and live UAT record.
+
+## Stage 1: Rebase on current dev
+**Goal**: Reapply the PR to the latest fetched development branch.
+**Success Criteria**: Clean rebase, preserved patch intent, recorded old/new base and head.
+**Tests**: Inspect conflicts and range-diff; run affected regressions after review repairs.
+**Status**: In Progress
+
+## Stage 2: Address review and CI findings
+**Goal**: Verify and resolve each Qodo comment and failed required check.
+**Success Criteria**: Queued macros preserve request-time model defaults; configuration errors are diagnosable; test contracts and documentation are clear; every architecture comment has a supported disposition.
+**Tests**: Red-green macro/default and logging regressions, public array-query outcomes, session migration regressions, affected CI guards, lint and Bandit.
+**Status**: Not Started
+
+## Stage 3: Verify, respond, and merge
+**Goal**: Publish reviewed fixes, receive review on the latest changes, and integrate into dev.
+**Success Criteria**: Fresh verification and required checks pass, all review findings are addressed, and the repository's human-written Change summary merge requirement is satisfied before merging.
+**Tests**: Final review, current-head CI and remote/base checks, merge result verification.
+**Status**: Not Started

--- a/Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md
+++ b/Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md
@@ -1,0 +1,90 @@
+# Live acceptance checks for issues #2935–#2938
+
+PR: [#2939](https://github.com/rmusser01/tldw_server/pull/2939), targeting `dev`.
+Tracked in TASK-13239 and TASK-13240. Run on September 10, 2026 UTC (September 9 locally).
+
+Earlier verification was automated regression and integration testing. This follow-up exercised browser interactions and real HTTP requests against running services. It exposed additional defects beyond the original regression suite.
+
+## Environment
+
+- macOS arm64; Python 3.11.13; PostgreSQL 18.6.
+- Admin UI: locked Next.js 16.2.2 dependencies, production webpack build and standalone server under Node 20.19.5. The same production artifact also passed the HTTP JWT matrix under checksum-verified official Node 20.20.2, the exact runtime release in the report.
+- WebUI: locked Next.js 16.1.4 dependencies, development webpack server; isolated Chromium browser sessions.
+- Real multi-user API subprocesses with test mode disabled, real password login/JWTs/API keys, and shared JWT signing configuration with the admin UI. Optional heavy startup deferred; CSRF disabled for this isolated run.
+- Disposable database provisioned and held by the standard AuthNZ `isolated_test_environment` fixture. The fixture-created `sessions` table was dropped before API startup; production bootstrap recreated it, so fixture-only columns could not hide #2936.
+- The repository's mock OpenAI server ran as a separate HTTP process. It recorded the outgoing `model` and `stream` fields and rejected unexpected models. These were actual adapter requests, not mocked application calls; no real LLM inference was performed.
+
+This tests the PR checkout plus the UAT fixes described below. It does not certify the previously published Docker image or an external Ollama installation. The production build and browser login used Node 20.19.5; the additional Node 20.20.2 check exercised runtime middleware through HTTP with a freshly issued login JWT.
+
+## Scenario observations
+
+| Issue / scenario | Observation |
+| --- | --- |
+| #2935: real username/password login | Browser reached the authenticated admin dashboard; reload remained authenticated. |
+| #2935: valid access-token cookie | Production middleware returned HTTP 200. |
+| #2935: missing token, malformed JWT, invalid signature, invalid base64 signature, non-string algorithm | Each returned HTTP 307 to login; none returned 500. |
+| #2935: exact Node 20.20.2 runtime | A fresh real login JWT returned 200; all five missing/invalid-token cases redirected 307 to login. |
+| #2936: full profile through Bearer and X-API-KEY | Both returned 200 after the audio DATE repair below, including security and quota sections. |
+| #2936: production-created session activity column | `last_activity` exists as a PostgreSQL timestamp; real login/refresh advanced activity beyond creation time. |
+| #2937: zero, one, and two org/team memberships | All six full-profile requests (two authentication methods × three states) returned 200 with exact membership counts. |
+| #2937: organization/team overrides | Team theme override took precedence, returned its source, and profile version advanced with the new overrides. |
+| #2937: ordinary new-user signup | Real registration and login succeeded; automatic organization/team membership existed and full profile returned 200. |
+| #2936/#2937: session refresh | Refresh and the subsequent authenticated profile request returned 200. |
+| WebUI API-key Save | Initial browser Save received profile 200 and displayed success. Repeated Save exposed the separate RBAC lock stall described below; after repair, Save received profile 200, displayed success, and retained the server URL and API key after reload. |
+
+Zero memberships require a seeded state because ordinary login creates a personal organization. The UAT account first joined an existing organization, logged in, left that organization, and refreshed its token before the zero-membership requests. A stale token retaining removed membership was correctly rejected with 403 during setup.
+
+## Chat model matrix
+
+Every row below was exercised in streaming and non-streaming mode with `messages` containing the issue's one-sentence greeting request.
+
+| Server configuration | Omitted / whitespace-only model | Explicit model |
+| --- | --- | --- |
+| `local-llm`, `LOCAL_LLM_MODEL=uat-configured-default` | 200; provider received `uat-configured-default` | 200; different `uat-explicit-model` preserved |
+| `local-llm`, `[Chat-Module] default_model_local_llm=uat-config-file-default` | 200; provider received `uat-config-file-default` | 200; different `uat-explicit-model` preserved |
+| `ollama`, `[Local-API] ollama_model=uat-config-file-default` | 200; real Ollama adapter sent `uat-config-file-default` | 200 for explicitly selecting that advertised model |
+| `local-llm`, no configured model | 400 with an actionable model-required message; zero provider requests | 200; `uat-explicit-model` still worked |
+
+All successful streaming cases completed with `[DONE]`. An additional explicit, unadvertised Ollama model was correctly rejected before dispatch by existing model-availability policy. No outgoing model became the metrics placeholder `unknown`.
+
+The shipped example config selects OpenAI. The isolated config explicitly set `[API] default_api` to the provider under test as well as `DEFAULT_LLM_PROVIDER`; an environment-only setup initially selected the file's OpenAI default and correctly reported missing credentials.
+
+## Additional findings and repairs
+
+### PostgreSQL DATE binding in audio quotas
+
+Before the follow-up repair, both live authentication methods still returned 500 from the full-profile endpoint. `get_daily_minutes_used` bound an ISO date string to a PostgreSQL `DATE` parameter; asyncpg raised `DataError: 'str' object has no attribute 'toordinal'`.
+
+The same mistake affected legacy audio-usage backfill and job-count increments. Commit `74f86e5c76` applies a six-line production repair that keeps native dates for PostgreSQL and converts to ISO text only in SQLite branches. Four new real PostgreSQL regression cases failed before the repair and passed afterward: full profile with no/current-day usage, job increments that preserve accumulated minutes, and idempotent current-day legacy backfill. Yesterday's usage is excluded.
+
+Validation: 5 PostgreSQL tests passed (4 new plus existing ledger integration), and 49 existing audio/ledger/SQLite tests passed. Ruff, formatting for the new test, whitespace checks, and scoped Bandit passed. Test-only Bandit excludes ordinary pytest assertions; production scan has no exclusions or findings. Independent review found no actionable issues.
+
+### Synchronous RBAC read stalls the event loop
+
+After the initial successful WebUI Save, periodic browser requests exposed an API-wide stall. Native process sampling showed the uvloop main thread waiting in synchronous psycopg. PostgreSQL activity showed the role lookup waiting for an asynchronous schema transaction's relation lock. The blocked event loop could not finish that transaction, and even `/health` stopped responding.
+
+The repair runs the complete synchronous RBAC enrichment helper in a worker thread for both JWT and API-key authentication, including repository construction and role, effective-permission, and fallback lookups. No repository or permission contract changes.
+
+Four new real PostgreSQL regressions cover both authentication methods while either roles or permissions are locked. Each failed before the repair because its authentication event loop could not progress; an independent watchdog thread always releases the lock. All four passed after the fix.
+
+Live checks held a real role-table lock while an authenticated `/api/v1/buddies` request waited: `/health` returned 200 in 7–8 ms before the lock was released, then the waiting request returned 200. The WebUI API-key Save/reload replay succeeded. The RBAC validation batch passed 7 PostgreSQL tests (4 new lock cases plus 3 existing admin RBAC cases) and 53 existing authentication/membership/SQLite tests, with clean process exits. Ruff, new-test formatting, and whitespace checks passed. Bandit reports no new findings; three existing low-severity credential-type literals in the authentication module are unchanged.
+
+Review additionally identified an unguarded cold initialization of the shared synchronous RBAC database cache exposed by concurrent worker calls. A shared reentrant lock now protects singleton/configuration/database construction and test resets, with configuration readiness published only after backend detection. The live cold-start replay sent four simultaneous authenticated requests to a fresh API: all returned 200, the database initialized exactly once, and subsequent profile and health requests returned 200. Warm database reads retain the existing cached instance without serializing RBAC queries.
+
+Five new public-entrypoint concurrency regressions cover duplicate construction, partial configuration publication, both reset methods during construction, and a lazy reset between configuration lookup and database lookup. Each reproduced its failure before the corresponding repair. The last case ensures a changed database URL cannot leave the old database cached; cold construction rechecks configuration initialization inside the same reentrant lock.
+
+Validation included 42 concurrency/configuration/backend/JWT tests and another passing run of the four PostgreSQL lock regressions. After the final lazy-reset repair, all 26 affected concurrency/configuration/backend tests passed with a clean process exit. Ruff, compilation, new-test formatting, and whitespace checks passed; Bandit found no issues in the cache module or its tests. Independent review reproduced the last race, verified the repair with its original probe, and reported no remaining actionable findings. The final source also passed the fresh-API cold-start and live role-lock replays.
+
+## Evidence and reproduction
+
+[Sanitized request observations](evidence/issues_2939_live_uat.json) retain status codes, membership counts, source attribution, and the provider's outgoing model/stream observations. Disposable passwords, JWTs, API keys, and database credentials are excluded.
+
+To repeat: provision the standard isolated PostgreSQL fixture; recreate sessions through production startup; start the real multi-user API, production admin UI, and WebUI with matching configuration; perform password login/reload and the invalid-cookie matrix; create an API key and save it in WebUI settings; run full-profile requests around membership changes and token refresh; then run the chat matrix against a provider that records incoming models. Keep external-provider availability and advertised-model policy explicit when interpreting failures.
+
+The unrelated migration-test follow-up remains documented in [the original repair record](../Design/ISSUES_2935_2938_REGRESSION_REPAIR.md#migration-test-follow-up); its full 22-test verification was completed before this UAT.
+
+## Cleanup and limits
+
+The standard fixture finished successfully and removed its disposable PostgreSQL database; a catalog check confirmed it was gone. All seven owned service ports were closed, isolated browsers were closed, and the temporary one-hour fixture harness was removed. Only permanent regression tests, this report, and sanitized observations are included in the PR.
+
+These are targeted acceptance and regression checks. The full backend/UI suites, external LLM inference, published Docker image, and production-scale migration duration were not retested in this follow-up.

--- a/Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md
+++ b/Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md
@@ -1,0 +1,85 @@
+# PR2939: rebase and Qodo remediation
+
+Tracked in TASK-13241; [PR2939](https://github.com/rmusser01/tldw_server/pull/2939) targets `dev`.
+
+## Rebase
+
+Rebased the original head `5065421d801490bd45a35d355b7eaa6f00e44b7f` onto
+`dev` at `9da94ebcb41ba45d279ab707ec92a285d31ba5c7`, which added 17 commits
+since the previous base. The rebase had no conflicts. `git range-diff` matched
+all nine pre-rebase patches exactly, including the new tracking-only commit.
+The original fixes and [live UAT evidence](ISSUES_2935_2938_LIVE_UAT_2026_09_10.md)
+are preserved.
+
+## Qodo findings
+
+| Comment | Disposition and rationale |
+| --- | --- |
+| [Queued macros use later defaults](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731684) | Confirmed. The macro shortcut ran before ordinary model defaulting. Resolve and validate once before either macro enqueue or direct dispatch, and persist that effective model. Missing defaults return 400 before saving a run or job. |
+| [Configuration failures are silent](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731650) | Confirmed. Both fallback handlers now log normalized provider, source, and exception type with Loguru. Raw exception text is omitted because broken config diagnostics can contain credentials. Existing fallback behavior remains. |
+| [Session SQL ownership](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731652) | Extracted new session schema/backfill SQL into `DB_Management/authnz_session_schema.py`. Helpers retain supplied connections and caller-owned transactions. Existing array repository hunks only correct public `DatabasePool` parameter containers; they add no SQL or direct-driver calls, so the established repositories remain in place. |
+| [Migration contract documentation](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731659) | Added explicit parameter, return, and transaction-ownership documentation to migration 098 and the extracted helpers. |
+| [Session test docstrings](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731666) | Added concise purpose/contract docstrings to the cited modules, classes, helpers, and tests. |
+| [Test annotations](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731672) | Added concrete fixture, repository, identifier, argument, and return annotations to the changed session, array, and chat regression functions. |
+| [Private array mechanics](https://github.com/rmusser01/tldw_server/pull/2939#discussion_r3975731675) | Replaced private `_flatten_params` and mock `await_args` assertions with public repository/pool results through a selecting driver. Retained empty, single, multiple, normalized, generated, scoped-count, and variadic/sequence cases. |
+
+The database extraction follows existing DB-owned helpers such as
+`backends/pg_sharing_schema.py`, `sqlite_schema_helpers.py`, and
+`user_profile_writes.py`. It does not introduce new connections, nested
+transactions, explicit commits, or `executescript` calls. SQLite fresh-table
+creation retains `CURRENT_TIMESTAMP` defaults; upgraded tables retain explicit
+session-write initialization. The latest `dev` content-migration durability
+changes use a separate migration runner from AuthNZ.
+
+## CI shard coverage
+
+The failing Shard coverage guard showed that the new audio quota PostgreSQL
+test was absent from every full-suite shard. Added it to the existing
+`auth-integration-admin-auth` shard in all five OS/Python/release matrices.
+
+The complete workflow-contract run also reproduced inherited assignment drift:
+seven media files were missing from the regular shards, a character snapshot
+test was absent from four sibling matrices, and an already-assigned workspace
+assistant test was missing from the contract's expected set. Updated the
+existing assignments and expectations consistently; no checks were removed or
+weakened. The guard and all 57 workflow-contract tests pass.
+
+The original-head frontend check also reported a real-backend webhook-page
+acceptance failure. Investigation is in progress. Its earlier license-audit
+cancellation was superseded by a successful run on the same head.
+
+## Verification
+
+- Macro regression before repair: 16 failed and 6 passed. Failures were missing
+  persisted models and HTTP 200 queueing when HTTP 400 was expected.
+- Macro regression after repair: 28 passed, including environment, Chat-Module,
+  and administrator defaults; omitted/blank/explicit requests; both response
+  modes; durable model snapshots; and branch execution after defaults change.
+- Configuration logging: both new tests failed before repair; all 30 model-target
+  tests passed after repair, including diagnostics that exclude sensitive text.
+- Array test mutation: removing the production `(org_ids,)` wrapper caused the
+  revised public-behavior regressions to fail for single/multiple identifiers.
+  A clean follow-up run passed all 30 array tests; array plus SQLite-session
+  verification passed 34 tests.
+- Required PostgreSQL session verification passed 4 tests without skips using
+  the standard isolated fixture and final schema extraction.
+- The combined rebased Auth/Profile run passed 76 tests with no skips, including
+  PostgreSQL array/session/quota/lock checks, SQLite custom-schema migrations,
+  and concurrent cache initialization. PostgreSQL was required and provisioned
+  through the standard isolation fixture.
+- The full simplified-chat endpoint file plus target/provider resolution passed
+  260 tests. One pre-existing TestClient streaming test remains skipped; all new
+  streaming regressions ran. Both broad Python batches exited successfully.
+- Six admin authentication/middleware files passed 28 tests on Node 20.19.5.
+- All 30 changed Python files compile. Scoped Ruff has no new findings; the
+  three existing import-order findings in `chat.py` match the baseline.
+- Bandit scanned all 16 changed production Python files with no scan errors
+  or new findings. Three inherited low-severity credential-type literals in
+  `User_DB_Handling.py` remain unchanged. Test scans exclude ordinary assertions
+  (`B101`) and introduce no findings beyond existing fixture literals.
+- Independent review of the Qodo and CI changes found no remaining P1/P2 or
+  other correctness/compatibility issues. Whitespace checks pass.
+
+Current-head remote review, CI, and merge verification are pending publication
+of the fixes. The existing human `Change summary` merge requirement remains
+recorded in the PR, and the requester has been asked to supply their own text.

--- a/Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md
+++ b/Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md
@@ -45,8 +45,24 @@ existing assignments and expectations consistently; no checks were removed or
 weakened. The guard and all 57 workflow-contract tests pass.
 
 The original-head frontend check also reported a real-backend webhook-page
-acceptance failure. Investigation is in progress. Its earlier license-audit
-cancellation was superseded by a successful run on the same head.
+acceptance failure. Browser reproduction confirmed that the backend returns
+HTTP 200 with an additive `delivery` status object, while the admin client's
+exact-key validator accepts only the seven older fields. Both sides of this
+mismatch are unchanged from `dev`; mocked fixtures omitted `delivery` and
+masked the failure. The client now copies the response and discards only the
+unconsumed `delivery` metadata before existing strict validation. All consumed
+fields, nested `limits`/`migration` fields, and unrelated unknown keys retain
+their existing validation. No UI or acceptance-test assertion was changed.
+The earlier license-audit cancellation was superseded by success on the same head.
+
+Two new canonical/legacy client cases failed before the fix (2 failed, 21
+passed). After repair, all 73 webhook API/page/URL cases pass, including invalid
+consumed fields and unexpected keys when `delivery` is present. Scoped ESLint,
+full admin type checking, and a fresh production real-backend build pass on
+Node 20.19.5. The unchanged Chromium JWT webhook acceptance spec then passes
+all 3 tests without retries. Independent review found no actionable issues.
+The harness stopped its API/UI processes, and ports 8101/3101 have no listeners.
+This TypeScript-only follow-up adds no Python Bandit scan surface.
 
 ## Verification
 
@@ -80,6 +96,23 @@ cancellation was superseded by a successful run on the same head.
 - Independent review of the Qodo and CI changes found no remaining P1/P2 or
   other correctness/compatibility issues. Whitespace checks pass.
 
-Current-head remote review, CI, and merge verification are pending publication
-of the fixes. The existing human `Change summary` merge requirement remains
-recorded in the PR, and the requester has been asked to supply their own text.
+The rebase and Qodo repairs were pushed as `475a4900356b17a651d0430cd00e029b3577ab63`
+with a force-with-lease pinned to the checked original remote head. All seven
+original review threads received individual evidence replies and are resolved.
+[Qodo's updated review](https://github.com/rmusser01/tldw_server/pull/2939#issuecomment-5613467031)
+references that exact commit and reports zero bugs or rule violations. Its
+update at 07:03:50 UTC preceded our replies and thread resolution.
+
+The backend, security, container-build, shard-coverage, and trusted-license
+checks passed on that head. Frontend, coverage, and end-to-end checks remain
+in progress at the check recorded above. The frontend job subsequently
+reproduced only the same webhook failure, with 25 other acceptance tests
+passing. A fresh remote check/review cycle is required for the webhook fix.
+
+Effective `dev` rules require current-base status checks and permit only a
+merge commit. The repository's human-written `Change summary` requirement also
+remains recorded in the PR, and the requester has been asked for their own text.
+The `finish-pr-2939-review-and-merge` thread follow-up checks every 15 minutes,
+continues authorized review/CI repairs, and will merge only when all requirements
+are met. It stays quiet on unchanged state and pauses after completion or when
+only the already-requested human input remains.

--- a/Docs/Reviews/evidence/issues_2939_live_uat.json
+++ b/Docs/Reviews/evidence/issues_2939_live_uat.json
@@ -1,0 +1,562 @@
+{
+  "environment": {
+    "postgres": "18.6",
+    "python": "3.11.13",
+    "node_admin": "20.19.5",
+    "next_admin": "16.2.2 (production webpack build)",
+    "next_webui": "16.1.4 (development webpack)",
+    "api_test_mode": false,
+    "csrf_enabled": false,
+    "provider": "repository mock OpenAI server; actual local HTTP requests",
+    "node_admin_build": "20.19.5",
+    "node_admin_runtime_checks": [
+      "20.19.5",
+      "20.20.2"
+    ]
+  },
+  "jwt_http": [
+    {
+      "scenario": "valid",
+      "status": 200,
+      "redirect": null
+    },
+    {
+      "scenario": "missing",
+      "status": 307,
+      "redirect": "/login?redirectTo=%2F"
+    },
+    {
+      "scenario": "malformed",
+      "status": 307,
+      "redirect": "/login?redirectTo=%2F"
+    },
+    {
+      "scenario": "invalid-signature",
+      "status": 307,
+      "redirect": "/login?redirectTo=%2F"
+    },
+    {
+      "scenario": "invalid-base64-signature",
+      "status": 307,
+      "redirect": "/login?redirectTo=%2F"
+    },
+    {
+      "scenario": "non-string-alg",
+      "status": 307,
+      "redirect": "/login?redirectTo=%2F"
+    }
+  ],
+  "chat": [
+    {
+      "configuration": "env",
+      "scenario": "omitted",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-configured-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "env",
+      "scenario": "blank",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-configured-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "env",
+      "scenario": "explicit",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "env",
+      "scenario": "omitted",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-configured-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "env",
+      "scenario": "blank",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-configured-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "env",
+      "scenario": "explicit",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "omitted",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "blank",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "explicit",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "omitted",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "blank",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "config",
+      "scenario": "explicit",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "missing",
+      "scenario": "omitted",
+      "stream": false,
+      "status": 400,
+      "provider_requests": [],
+      "error": "{\"detail\":\"Model is required for provider 'local-llm'. Please select a model in the WebUI or configure a default via environment variable 'DEFAULT_MODEL_LOCAL_LLM'\"}"
+    },
+    {
+      "configuration": "missing",
+      "scenario": "blank",
+      "stream": false,
+      "status": 400,
+      "provider_requests": [],
+      "error": "{\"detail\":\"Model is required for provider 'local-llm'. Please select a model in the WebUI or configure a default via environment variable 'DEFAULT_MODEL_LOCAL_LLM'\"}"
+    },
+    {
+      "configuration": "missing",
+      "scenario": "explicit",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "missing",
+      "scenario": "omitted",
+      "stream": true,
+      "status": 400,
+      "provider_requests": [],
+      "error": "{\"detail\":\"Model is required for provider 'local-llm'. Please select a model in the WebUI or configure a default via environment variable 'DEFAULT_MODEL_LOCAL_LLM'\"}"
+    },
+    {
+      "configuration": "missing",
+      "scenario": "blank",
+      "stream": true,
+      "status": 400,
+      "provider_requests": [],
+      "error": "{\"detail\":\"Model is required for provider 'local-llm'. Please select a model in the WebUI or configure a default via environment variable 'DEFAULT_MODEL_LOCAL_LLM'\"}"
+    },
+    {
+      "configuration": "missing",
+      "scenario": "explicit",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-explicit-model",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "omitted",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "blank",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "explicit",
+      "stream": false,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": false
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "omitted",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "blank",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    },
+    {
+      "configuration": "ollama",
+      "scenario": "explicit",
+      "stream": true,
+      "status": 200,
+      "provider_requests": [
+        {
+          "model": "uat-config-file-default",
+          "stream": true
+        }
+      ],
+      "completed": true
+    }
+  ],
+  "profiles": [
+    {
+      "scenario": "profile",
+      "memberships": 0,
+      "auth": "bearer",
+      "status": 200,
+      "orgs": 0,
+      "teams": 0,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      }
+    },
+    {
+      "scenario": "profile",
+      "memberships": 0,
+      "auth": "api-key",
+      "status": 200,
+      "orgs": 0,
+      "teams": 0,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      }
+    },
+    {
+      "scenario": "profile",
+      "memberships": 1,
+      "auth": "bearer",
+      "status": 200,
+      "orgs": 1,
+      "teams": 1,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      },
+      "theme": {
+        "value": "light",
+        "source": "team"
+      }
+    },
+    {
+      "scenario": "profile",
+      "memberships": 1,
+      "auth": "api-key",
+      "status": 200,
+      "orgs": 1,
+      "teams": 1,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      },
+      "theme": {
+        "value": "light",
+        "source": "team"
+      }
+    },
+    {
+      "scenario": "profile",
+      "memberships": 2,
+      "auth": "bearer",
+      "status": 200,
+      "orgs": 2,
+      "teams": 2,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      },
+      "theme": {
+        "value": "light",
+        "source": "team"
+      }
+    },
+    {
+      "scenario": "profile",
+      "memberships": 2,
+      "auth": "api-key",
+      "status": 200,
+      "orgs": 2,
+      "teams": 2,
+      "active_sessions": 1,
+      "audio": {
+        "daily_minutes_limit": 30.0,
+        "daily_minutes_used": 0.0,
+        "daily_minutes_remaining": 30.0,
+        "concurrent_streams_limit": 1,
+        "concurrent_streams_active": 0,
+        "concurrent_jobs_limit": 1,
+        "max_file_size_mb": 25
+      },
+      "theme": {
+        "value": "light",
+        "source": "team"
+      }
+    },
+    {
+      "scenario": "refresh-and-profile",
+      "refresh_status": 200,
+      "profile_status": 200
+    },
+    {
+      "scenario": "new-signup-profile",
+      "signup_status": 200,
+      "profile_status": 200,
+      "orgs": 1,
+      "teams": 1
+    }
+  ],
+  "sessions": {
+    "last_activity_columns": [
+      {
+        "column_name": "last_activity",
+        "data_type": "timestamp without time zone"
+      }
+    ],
+    "last_activity_advanced": true
+  },
+  "rbac_live_lock": {
+    "scenario": "live-RBAC-lock-concurrency",
+    "database_wait_observed": true,
+    "health_status": 200,
+    "health_seconds": 0.007,
+    "authenticated_request_still_waiting": true,
+    "authenticated_status_after_unlock": 200
+  },
+  "webui": [
+    {
+      "scenario": "WebUI API-key Save",
+      "profileStatus": 200,
+      "successMessage": true
+    },
+    {
+      "scenario": "WebUI saved configuration after reload",
+      "serverUrl": "http://127.0.0.1:8940",
+      "apiKeyPresent": true
+    }
+  ],
+  "jwt_http_node_20_20_2": {
+    "node_runtime": "20.20.2",
+    "build_node": "20.19.5",
+    "login_status": 200,
+    "cases": [
+      {
+        "scenario": "valid",
+        "status": 200,
+        "redirect_to_login": false
+      },
+      {
+        "scenario": "missing",
+        "status": 307,
+        "redirect_to_login": true
+      },
+      {
+        "scenario": "malformed",
+        "status": 307,
+        "redirect_to_login": true
+      },
+      {
+        "scenario": "invalid-signature",
+        "status": 307,
+        "redirect_to_login": true
+      },
+      {
+        "scenario": "invalid-base64-signature",
+        "status": 307,
+        "redirect_to_login": true
+      },
+      {
+        "scenario": "non-string-algorithm",
+        "status": 307,
+        "redirect_to_login": true
+      }
+    ]
+  },
+  "rbac_cold_auth": {
+    "scenario": "cold-concurrent-authentication",
+    "concurrent_requests": 4,
+    "statuses": [
+      200,
+      200,
+      200,
+      200
+    ],
+    "profile_status": 200,
+    "health_status": 200,
+    "cache_initializations_before": 0,
+    "cache_initializations_after": 1,
+    "seconds": 1.184
+  }
+}

--- a/admin-ui/lib/api-client-webhooks.test.ts
+++ b/admin-ui/lib/api-client-webhooks.test.ts
@@ -110,6 +110,49 @@ const STATUS: WebhookStatus = {
   },
 };
 
+// Sanitized delivery metadata returned by the real backend with delivery off.
+const DELIVERY_STATUS = {
+  canonical_schema_version: 1,
+  schema_ready: true,
+  delivery_schema_ready: true,
+  migration_complete: false,
+  key_ready: false,
+  key_primary_match: false,
+  jobs_database_ready: false,
+  queue_ready: false,
+  job_type_ready: false,
+  jobs_backend: 'unavailable',
+  worker: {
+    component: 'worker',
+    ready: false,
+    reason_code: 'worker_unavailable',
+    heartbeat_age_seconds: null,
+  },
+  reconciler: {
+    component: 'reconciler',
+    ready: false,
+    reason_code: 'reconciler_unavailable',
+    heartbeat_age_seconds: null,
+  },
+  retention: {
+    component: 'retention',
+    ready: false,
+    reason_code: 'retention_unavailable',
+    heartbeat_age_seconds: null,
+  },
+  backlog: {
+    pending: 0,
+    enqueue_claimed: 0,
+    queued: 0,
+    processing: 0,
+    retry_wait: 0,
+  },
+  oldest_nonterminal_age_seconds: null,
+  acquisition_ready: false,
+  acquisition_reason_code: 'mode_off',
+  delivery_capability_ready: false,
+};
+
 describe('canonical webhook API client', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -259,9 +302,25 @@ describe('webhook API detection and compatibility isolation', () => {
   });
 
   it.each([
+    ['canonical', canonicalWebhookApi],
+    ['legacy', legacyWebhookApi],
+  ] as const)('accepts additive delivery metadata for the %s client without exposing it', async (routeSelection, client) => {
+    const status = { ...STATUS, route_selection: routeSelection };
+    httpMocks.requestJson.mockResolvedValue({ ...status, delivery: DELIVERY_STATUS });
+
+    await expect(detectWebhookApi()).resolves.toEqual({
+      kind: routeSelection,
+      status,
+      client,
+    });
+  });
+
+  it.each([
     { ...STATUS, route_selection: 'unknown' },
     { ...STATUS, migration: { ...STATUS.migration, legacy_file_restore_permitted: 'yes' } },
     { ...STATUS, migration: { ...STATUS.migration, rollback_window_expires_at: '2026-08-22 12:00:00' } },
+    { ...STATUS, delivery: DELIVERY_STATUS, schema_ready: 'yes' },
+    { ...STATUS, delivery: DELIVERY_STATUS, unexpected: true },
     { route_selection: 'legacy' },
   ])('rejects a malformed successful status response without probing legacy CRUD', async (body) => {
     httpMocks.requestJson.mockResolvedValue(body);

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -335,7 +335,10 @@ const isWebhookStatus = (value: unknown): value is WebhookStatus => {
 };
 
 const getWebhookStatus = async (): Promise<WebhookStatus> => {
-  const status = await requestJson<unknown>('/admin/webhooks/status');
+  const response = await requestJson<unknown>('/admin/webhooks/status');
+  const status = isRecord(response) ? { ...response } : response;
+  // The registration UI does not consume the added delivery runtime details.
+  if (isRecord(status)) delete status.delivery;
   if (!isWebhookStatus(status)) {
     throw new WebhookContractError(200, 'Webhook API returned an invalid status response');
   }

--- a/admin-ui/lib/middleware-jwt-verification.test.ts
+++ b/admin-ui/lib/middleware-jwt-verification.test.ts
@@ -1,0 +1,184 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PRIMARY_SECRET = 'primary-jwt-test-secret-1234567890';
+const SECONDARY_SECRET = 'secondary-jwt-test-secret-1234567890';
+
+const originalJwtSecret = process.env.JWT_SECRET_KEY;
+const originalSecondarySecret = process.env.JWT_SECONDARY_SECRET;
+const originalJwtAlgorithm = process.env.JWT_ALGORITHM;
+
+const encodeBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const encodeJson = (value: object): string =>
+  encodeBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+
+const signJwt = async (
+  secret: string,
+  payload: Record<string, unknown>,
+  header: Record<string, unknown> = { alg: 'HS256', typ: 'JWT' }
+): Promise<string> => {
+  const headerSegment = encodeJson(header);
+  const payloadSegment = encodeJson(payload);
+  const signingInput = `${headerSegment}.${payloadSegment}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(signingInput)
+  );
+  return `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`;
+};
+
+const requestWithJwt = (token: string): NextRequest =>
+  new NextRequest('http://localhost/dashboard', {
+    headers: { cookie: `access_token=${token}` },
+  });
+
+const requestWithBearerJwt = (token: string): NextRequest =>
+  new NextRequest('http://localhost/dashboard', {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+const stubStrictCryptoVerifyBoundary = () => {
+  const realCrypto = crypto;
+  const verify = async (
+    ...args: Parameters<SubtleCrypto['verify']>
+  ): Promise<boolean> => {
+    const signature = args[2];
+    if (!ArrayBuffer.isView(signature)) {
+      throw new TypeError('HMAC signature must remain an ArrayBuffer view');
+    }
+    return realCrypto.subtle.verify(...args);
+  };
+  const strictSubtle = new Proxy(realCrypto.subtle, {
+    get(target, property) {
+      if (property === 'verify') return verify;
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  const strictCrypto = new Proxy(realCrypto, {
+    get(target, property) {
+      if (property === 'subtle') return strictSubtle;
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  vi.stubGlobal('crypto', strictCrypto);
+};
+
+const restoreEnv = (name: string, value: string | undefined): void => {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+};
+
+describe('middleware local JWT verification', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET_KEY = PRIMARY_SECRET;
+    process.env.JWT_SECONDARY_SECRET = SECONDARY_SECRET;
+    process.env.JWT_ALGORITHM = 'HS256';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreEnv('JWT_SECRET_KEY', originalJwtSecret);
+    restoreEnv('JWT_SECONDARY_SECRET', originalSecondarySecret);
+    restoreEnv('JWT_ALGORITHM', originalJwtAlgorithm);
+  });
+
+  it('passes the decoded signature view through the WebCrypto boundary', async () => {
+    const token = await signJwt(PRIMARY_SECRET, {
+      sub: 'jwt-test-user',
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    stubStrictCryptoVerifyBoundary();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('unexpected fallback')))
+    );
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(requestWithJwt(token));
+
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('accepts a valid secondary-secret JWT during key rotation', async () => {
+    const token = await signJwt(SECONDARY_SECRET, {
+      sub: 'jwt-test-user',
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(requestWithJwt(token));
+
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('rejects a JWT with a bad signature', async () => {
+    const token = await signJwt('wrong-jwt-test-secret-1234567890', {
+      sub: 'jwt-test-user',
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(requestWithJwt(token));
+
+    expect(response.headers.get('location')).toContain('/login');
+  });
+
+  it('rejects an expired JWT', async () => {
+    const token = await signJwt(PRIMARY_SECRET, {
+      sub: 'jwt-test-user',
+      exp: Math.floor(Date.now() / 1000) - 1,
+    });
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(requestWithJwt(token));
+
+    expect(response.headers.get('location')).toContain('/login');
+  });
+
+  it('fails closed when the algorithm header is not a string', async () => {
+    const token = await signJwt(
+      PRIMARY_SECRET,
+      {
+        sub: 'jwt-test-user',
+        exp: Math.floor(Date.now() / 1000) + 60,
+      },
+      { alg: 256, typ: 'JWT' }
+    );
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(requestWithJwt(token));
+
+    expect(response.headers.get('location')).toContain('/login');
+  });
+
+  it('fails closed when the signature segment is malformed base64url', async () => {
+    const headerSegment = encodeJson({ alg: 'HS256', typ: 'JWT' });
+    const payloadSegment = encodeJson({
+      sub: 'jwt-test-user',
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+    const { middleware } = await import('../middleware');
+
+    const response = await middleware(
+      requestWithBearerJwt(`${headerSegment}.${payloadSegment}.%%%`)
+    );
+
+    expect(response.headers.get('location')).toContain('/login');
+  });
+});

--- a/admin-ui/middleware.ts
+++ b/admin-ui/middleware.ts
@@ -187,10 +187,17 @@ const verifyJwtLocally = async (
   const [headerSegment, payloadSegment, signatureSegment] = parts;
   const header = base64UrlToJson<{ alg?: string }>(headerSegment);
   if (!header) return { ok: false };
-  if (!header.alg || header.alg.toUpperCase() !== algorithm) return { ok: false };
+  if (typeof header.alg !== 'string' || header.alg.toUpperCase() !== algorithm) {
+    return { ok: false };
+  }
 
   const data = new TextEncoder().encode(`${headerSegment}.${payloadSegment}`);
-  const signature = base64UrlToUint8Array(signatureSegment);
+  let signature: Uint8Array<ArrayBuffer>;
+  try {
+    signature = base64UrlToUint8Array(signatureSegment);
+  } catch {
+    return { ok: false };
+  }
   const secrets = [secret, secondarySecret].filter((value): value is string => !!value);
   let signatureValid = false;
 

--- a/backlog/tasks/task-13235 - Fix-PostgreSQL-profile-session-schema-and-array-binding-issues-2936-and-2937.md
+++ b/backlog/tasks/task-13235 - Fix-PostgreSQL-profile-session-schema-and-array-binding-issues-2936-and-2937.md
@@ -1,0 +1,60 @@
+---
+id: TASK-13235
+title: Fix PostgreSQL profile session schema and array binding (issues 2936 and 2937)
+status: Done
+assignee: []
+created_date: '2026-09-10 03:35'
+updated_date: '2026-09-10 04:08'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/2936'
+  - 'https://github.com/rmusser01/tldw_server/issues/2937'
+documentation:
+  - Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Repair production sessions last_activity schema and profile override array parameters on dev. Audit related PostgreSQL ANY callers and session touch/refresh paths. Add behavior regressions using production schema and the real DatabasePool; validate available PostgreSQL fixtures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh and upgraded PostgreSQL sessions support listing, touch, and refresh without missing columns
+- [x] #2 Org and team overrides preserve empty, single, and multiple ID array bindings through DatabasePool
+- [x] #3 Related callers audited and confirmed defects fixed with regression tests
+- [x] #4 Targeted tests, formatting, Bandit, and review recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Completed session schema repair, seven array-binding method repairs, regressions, and independent review. Design and final audit retained in Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Array audit found three additional affected methods: ManagedSecretRefsRepo.list_refs_by_ids and organization/user scoped total counts. Seven affected methods now preserve a single array parameter through DatabasePool. Regression red: 16 failed, 14 passed; focused green including override readiness: 49 passed. Real PostgreSQL first run verified profile overrides and scoped counts; corrected missing metadata argument in the new managed-secret test and rerun is active. Independent review found no array production defect. Sessions migration work continues.
+
+Final combined auth/profile suite: 86 passed, 78 warnings in 227.54s, including real PostgreSQL production-schema and array cases. Session worker: 24 focused unit tests and 4 PostgreSQL integration tests passed. SQLite compatibility: 8 passed. Existing PostgreSQL session tests now seed through UsersDB and isolated_test_environment; production write guards remain enabled. Independent review found no remaining defects. New test files pass Black and Ruff; session production scope passes Ruff. Array scope has one unchanged SIM118 finding, confirmed against base. Bandit for all eight touched auth/profile production files: zero findings. Broader migrations: 52 passed, 1 existing failure in test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys. Single-test rerun on exact base 751563a966 fails identically with seven extra users columns, starting with uuid; this is unrelated to migration98. Full backend suite was not run.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added PostgreSQL sessions.last_activity bootstrap/upgrade/default and safe historical backfill. Added SQLite migration98 and explicit activity initialization for new sessions after upgrade. Fixed all four profile override array methods plus managed-secret lookup and organization/user scoped counts without changing DatabasePool compatibility. Added real-driver, production-schema, property, refresh, and upgrade regressions; repaired older PostgreSQL session test setup to exercise current guarded writes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13236 - Resolve-omitted-chat-models-from-provider-configuration-issue-2938.md
+++ b/backlog/tasks/task-13236 - Resolve-omitted-chat-models-from-provider-configuration-issue-2938.md
@@ -1,0 +1,57 @@
+---
+id: TASK-13236
+title: Resolve omitted chat models from provider configuration (issue 2938)
+status: Done
+assignee: []
+created_date: '2026-09-10 03:35'
+updated_date: '2026-09-10 04:18'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/2938'
+documentation:
+  - Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent the metrics placeholder unknown from becoming an upstream model. Honor configured provider models, preserve override and explicit model precedence, fail clearly when no model exists, and audit related callers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Omitted models resolve from provider configuration for local-llm and Ollama
+- [x] #2 Explicit models and existing administrator defaults retain precedence
+- [x] #3 Missing configuration never sends unknown upstream and returns a clear client error
+- [x] #4 Regression tests include streaming and non-streaming behavior and related default-model paths
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Completed provider-default repair, metrics/execution separation, blank-model and shared-consumer audit, regressions, and independent review. Retained design and verification: Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Final resolver/default/payload suite: 146 passed. Endpoint omitted, empty, whitespace, configured-default, and explicit-model cases across both streaming modes: 20 passed. Exact LOCAL_LLM_MODEL and Local-API.ollama_model parsing is tested through real configuration helpers. Related suites passed: 209 Messages usage, 111 Messages endpoint/override/default/native-error, 30 character/Notes, and 7 macro tests. Full endpoint file before the whitespace follow-up: 203 passed and 1 existing skip (Streaming tests hang with TestClient); all affected cases were rerun afterward. Independent review found the whitespace bypass and cleared its correction in the resolver, payload builder, Messages, macro context, and tool-policy identity. Compilation, repository guards, and diff checks pass. Bandit on four production files has zero findings. Ruff has no new findings; three existing chat.py import-order findings were reproduced on base 751563a966. Existing whole-file Black drift was retained to avoid unrelated formatting changes. The full backend suite was not run.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Execution now retains omitted or blank models as None while metrics may use unknown. Provider defaults consult the existing configuration snapshot after administrator, DEFAULT_MODEL environment, and Chat-Module precedence. Explicit models retain precedence; missing effective configuration returns HTTP 400 before dispatch. Added regressions for both streaming modes, exact configuration inputs, payload values, precedence, and shared Messages behavior. Audited macro and tool-policy contexts to prevent raw blank-model fallback.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13237 - Regress-edge-JWT-buffer-handling-and-harden-malformed-tokens-issue-2935.md
+++ b/backlog/tasks/task-13237 - Regress-edge-JWT-buffer-handling-and-harden-malformed-tokens-issue-2935.md
@@ -1,0 +1,59 @@
+---
+id: TASK-13237
+title: Regress edge JWT buffer handling and harden malformed tokens (issue 2935)
+status: Done
+assignee: []
+created_date: '2026-09-10 03:36'
+updated_date: '2026-09-10 03:59'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/2935'
+documentation:
+  - Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Protect the existing typed-array JWT verification fix with cross-realm runtime regression coverage, audit nearby WebCrypto buffers and invalid-token handling, and fix confirmed malformed-token failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Valid and invalid JWTs are handled without cross-realm ArrayBuffer failures
+- [x] #2 Malformed signature encoding fails closed without unhandled middleware exceptions
+- [x] #3 Tests detect reintroducing the old raw ArrayBuffer argument
+- [x] #4 Nearby WebCrypto calls audited and relevant checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Completed JWT regression and malformed-token hardening; design, audit, and verification retained in Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Regression detects the historical raw ArrayBuffer crash on Node 20 and a strict typed-array boundary. Confirmed malformed base64url signatures threw and added fail-closed handling. Initial focused middleware run: 10 passed; Node 20 and 24 JWT runs: 5 passed each; lint and TypeScript pass. Independent review found a related non-string alg header exception; adding regression and guard before final checks.
+
+Final independent re-review cleared the prior non-string alg finding and the existing typed-array regression. Fresh focused Vitest: 11 tests across 4 files passed; Node 20 and Node 24 JWT tests: 6 passed each. Scoped ESLint, production TypeScript, and git diff checks passed. Bandit is not applicable to TypeScript. Full admin UI suite was not run; Vitest reports an existing Node 26 deprecation warning. Nearby WebCrypto and malformed JSON type probes found no additional uncaught exceptions.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Preserved the existing Uint8Array JWT fix and added a regression that rejects the historical raw ArrayBuffer on real Node 20 WebCrypto and a strict boundary on newer Node. Fixed malformed signature base64url and non-string algorithm headers returning uncaught middleware exceptions; both now fail closed. Added valid, rotated-secret, invalid-signature, expired, and malformed-token tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13238 - Repair-SQLite-custom-schema-migration-preservation-regression-and-publish-auth-chat-PR.md
+++ b/backlog/tasks/task-13238 - Repair-SQLite-custom-schema-migration-preservation-regression-and-publish-auth-chat-PR.md
@@ -1,0 +1,60 @@
+---
+id: TASK-13238
+title: >-
+  Repair SQLite custom-schema migration preservation regression and publish
+  auth/chat PR
+status: In Progress
+assignee: []
+created_date: '2026-09-10 04:29'
+updated_date: '2026-09-10 04:58'
+labels: []
+dependencies: []
+documentation:
+  - Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the outdated exact-column expectation in test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys. Preserve assertions for legacy columns, data, constraints, triggers, indexes, AUTOINCREMENT, and parent/child foreign keys; exercise migration91 alone and the latest startup upgrade. Update the audit record and publish the complete issues2935-2938 branch as a PR targeting dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Custom users schema preservation passes for migration91 alone and the latest migration chain
+- [x] #2 Existing data, constraints, defaults, indexes, triggers, sequence, and foreign-key behavior remain asserted
+- [x] #3 Focused and broader migration tests, lint, Bandit, and independent review are recorded
+- [ ] #4 Complete branch is published as a pull request targeting dev with accurate validation and human Change summary gate
+- [x] #5 Array property regression remains reliable after the wider auth suite without reducing its input domain or suppressing health checks
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the old exact-column failure and identify intended schema additions. 2. Repair the preservation contract and exercise both the historical migration and full startup upgrade. 3. Run focused and broader validation, review, update audit, commit, push, and create the PR against dev.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Migration repair: reproduced the stale exact-column expectation on the rebased branch. Parameterizing migration 91 and the latest upgrade first produced one pass and one failure. Migration 93 intentionally appends seven user fields. The repaired prefix assertion preserves original column order and all existing data, constraints, defaults, indexes, triggers, sequence, and foreign-key behavior. The full profile migration file passes 22 tests; independent review found no production migration defect or outstanding findings.
+
+Array property reliability: two wider runs passed 99 tests but failed Hypothesis input-generation timing, while the recorded seed passed alone. Profiling a smaller reproduction showed _get_local_constants scanning 2,159 modules for 1.324 seconds. Applied the reviewed public @settings(deadline=1000), retaining a finite deadline, the full array domain and length bound, 100 examples, the assertion, and every health check. No private Hypothesis API or health-check suppression was added.
+
+Final wider auth/profile/migration validation passed all 100 tests using test-order seed 182453889 and Hypothesis seed 219652731782752022987833063022846811844. Hypothesis completed 100 passing examples with typical runtimes below 1 ms. Fresh chat resolution/default/payload and full simplified endpoint validation passed 361 tests with one existing TestClient streaming skip; new streaming cases ran. Focused UI middleware/auth validation passed 11 tests.
+
+Ruff, compilation, repository test guards, and whitespace checks pass. The array test passes Black. Bandit reports zero findings/errors across all 12 changed backend production files and both follow-up test files (B101 assertions excluded only for tests). Existing unrelated lint/format drift, the existing chat skip, and full-suite/large-table verification limits are documented in the retained audit.
+
+Rebased the three unpublished issue-fix commits onto origin/dev at 177d58ac6fee87678d65ce3a9db0216021b6b68e without conflicts. Follow-up touched the two test files and Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md. PR publication is the remaining step.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13238 - Repair-SQLite-custom-schema-migration-preservation-regression-and-publish-auth-chat-PR.md
+++ b/backlog/tasks/task-13238 - Repair-SQLite-custom-schema-migration-preservation-regression-and-publish-auth-chat-PR.md
@@ -3,12 +3,14 @@ id: TASK-13238
 title: >-
   Repair SQLite custom-schema migration preservation regression and publish
   auth/chat PR
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-10 04:29'
-updated_date: '2026-09-10 04:58'
+updated_date: '2026-09-10 05:00'
 labels: []
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2939'
 documentation:
   - Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md
 priority: medium
@@ -25,14 +27,16 @@ Fix the outdated exact-column expectation in test_sqlite_upgrade_preserves_custo
 - [x] #1 Custom users schema preservation passes for migration91 alone and the latest migration chain
 - [x] #2 Existing data, constraints, defaults, indexes, triggers, sequence, and foreign-key behavior remain asserted
 - [x] #3 Focused and broader migration tests, lint, Bandit, and independent review are recorded
-- [ ] #4 Complete branch is published as a pull request targeting dev with accurate validation and human Change summary gate
+- [x] #4 Complete branch is published as a pull request targeting dev with accurate validation and human Change summary gate
 - [x] #5 Array property regression remains reliable after the wider auth suite without reducing its input domain or suppressing health checks
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Reproduce the old exact-column failure and identify intended schema additions. 2. Repair the preservation contract and exercise both the historical migration and full startup upgrade. 3. Run focused and broader validation, review, update audit, commit, push, and create the PR against dev.
+Stage 1 — Complete: reproduce the exact-column failure and identify intended migration 93 additions.
+Stage 2 — Complete: preserve schema behavior across migration 91 and the complete upgrade; diagnose and repair the property-test timing issue without suppressing checks.
+Stage 3 — Complete: validate, independently review, update the audit, commit, push, and publish PR #2939 against dev.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -47,14 +51,22 @@ Final wider auth/profile/migration validation passed all 100 tests using test-or
 Ruff, compilation, repository test guards, and whitespace checks pass. The array test passes Black. Bandit reports zero findings/errors across all 12 changed backend production files and both follow-up test files (B101 assertions excluded only for tests). Existing unrelated lint/format drift, the existing chat skip, and full-suite/large-table verification limits are documented in the retained audit.
 
 Rebased the three unpublished issue-fix commits onto origin/dev at 177d58ac6fee87678d65ce3a9db0216021b6b68e without conflicts. Follow-up touched the two test files and Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md. PR publication is the remaining step.
+
+PR #2939 is open against dev. Verified the published head and target through GitHub; final code/test commit is 46b1fd6934. All acceptance criteria are complete.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Published https://github.com/rmusser01/tldw_server/pull/2939 against dev with all issue 2935–2938 repairs, related-pattern fixes, and the unrelated migration-test correction. The custom-users regression covers migration 91 and the latest upgrade while retaining preservation checks. The array property uses a reviewed finite timing allowance for measured Hypothesis constant-discovery overhead, with full coverage and health checks intact. Fresh validation totals 494 passing targeted tests and one pre-existing chat skip; Bandit has zero findings/errors. GitHub checks have started. The PR clearly records the required human-written Change summary before merge.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
+++ b/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
@@ -4,11 +4,13 @@ title: 'Run live UAT for reported admin login, profile, and chat scenarios'
 status: In Progress
 assignee: []
 created_date: '2026-09-10 05:07'
-updated_date: '2026-09-10 05:49'
+updated_date: '2026-09-10 06:22'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/2939'
+documentation:
+  - Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md
 priority: high
 ---
 
@@ -20,9 +22,9 @@ Verify PR #2939 against the original issue 2935–2938 reproduction scenarios us
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Node 20 admin UI accepts a real login JWT and rejects invalid tokens without HTTP 500
-- [ ] #2 Live PostgreSQL profile requests succeed with Bearer and API-key auth, populated sessions, and zero/one/multiple organization and team memberships
-- [ ] #3 Live chat requests resolve omitted and blank models from configuration, preserve explicit models, and fail clearly before dispatch without a model
+- [x] #1 Node 20 admin UI accepts a real login JWT and rejects invalid tokens without HTTP 500
+- [x] #2 Live PostgreSQL profile requests succeed with Bearer and API-key auth, populated sessions, and zero/one/multiple organization and team memberships
+- [x] #3 Live chat requests resolve omitted and blank models from configuration, preserve explicit models, and fail clearly before dispatch without a model
 - [ ] #4 Scenario results, environment, evidence, limitations, and any follow-up regression checks are recorded on PR #2939
 <!-- AC:END -->
 
@@ -40,6 +42,8 @@ Live PostgreSQL 18.6 UAT exposed an additional full-profile 500: Usage/audio_quo
 Live UAT after quota DATE fix: full profile Bearer and API key 200 for 0/1/2 org and team memberships; team override value/source correct; token refresh and subsequent profile200; real registration auto-creates org/team and profile200. Compiled Next16.2.2 on Node20.19.5 admin browser login and reload pass; invalid JWT matrix redirects307. Local provider wire logs verify streaming/nonstreaming omitted/blank/default/explicit/missing-default behavior; Ollama adapter file default also passes. WebUI Save reports server responded successfully; persistence check in progress.
 
 Quota DATE fix verified: 4 new regressions red with asyncpg DataError, then 5 PostgreSQL +49 existing tests green; Ruff/Black/compilation/diff checks and scoped Bandit pass. Independent review found no actionable issues. Follow-up WebUI persistence retry exposed a separate event-loop/RBAC lock stall, tracked and being fixed under TASK-13240; final UAT report in Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md.
+
+Live acceptance verification is complete. Real browser admin login/reload and WebUI API-key Save/persistence pass; exact Node20.20.2 runtime also passes valid JWT and all five invalid/missing-token redirects. Six profile membership/authentication cases, session activity, refresh, real signup, and24 streaming/nonstreaming chat cases pass. UAT exposed and repaired audio DATE binding and RBAC event-loop stalls, with cache concurrency followups from review. Final fresh API and lock replays pass. Disposable DB removal and all owned server ports stopped are verified; temporary fixture and completed plan removed. Report and sanitized evidence are prepared for PR publication; full-suite/external-provider/Docker limits are explicit.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
+++ b/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
@@ -1,0 +1,53 @@
+---
+id: TASK-13239
+title: 'Run live UAT for reported admin login, profile, and chat scenarios'
+status: In Progress
+assignee: []
+created_date: '2026-09-10 05:07'
+updated_date: '2026-09-10 05:49'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2939'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify PR #2939 against the original issue 2935–2938 reproduction scenarios using a real Node 20 admin UI, an isolated PostgreSQL-backed API provisioned by the repository fixture, browser login and settings paths, and live chat HTTP calls. Record evidence and any test-double limits; repair any defects exposed by the acceptance run and update the existing PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Node 20 admin UI accepts a real login JWT and rejects invalid tokens without HTTP 500
+- [ ] #2 Live PostgreSQL profile requests succeed with Bearer and API-key auth, populated sessions, and zero/one/multiple organization and team memberships
+- [ ] #3 Live chat requests resolve omitted and blank models from configuration, preserve explicit models, and fail clearly before dispatch without a model
+- [ ] #4 Scenario results, environment, evidence, limitations, and any follow-up regression checks are recorded on PR #2939
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Match acceptance cases to original reports and prepare isolated live services. 2. Exercise Node 20 browser login plus live profile and chat requests, recording observed responses. 3. Investigate and repair failures, validate changes, retain evidence, and update the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Live PostgreSQL 18.6 UAT exposed an additional full-profile 500: Usage/audio_quota.py passes an ISO date string to asyncpg DATE in get_daily_minutes_used. Bearer and API-key calls both reproduce. Investigating matching backfill and jobs-started queries; add PostgreSQL regressions and repeat live checks after repair.
+
+Live UAT after quota DATE fix: full profile Bearer and API key 200 for 0/1/2 org and team memberships; team override value/source correct; token refresh and subsequent profile200; real registration auto-creates org/team and profile200. Compiled Next16.2.2 on Node20.19.5 admin browser login and reload pass; invalid JWT matrix redirects307. Local provider wire logs verify streaming/nonstreaming omitted/blank/default/explicit/missing-default behavior; Ollama adapter file default also passes. WebUI Save reports server responded successfully; persistence check in progress.
+
+Quota DATE fix verified: 4 new regressions red with asyncpg DataError, then 5 PostgreSQL +49 existing tests green; Ruff/Black/compilation/diff checks and scoped Bandit pass. Independent review found no actionable issues. Follow-up WebUI persistence retry exposed a separate event-loop/RBAC lock stall, tracked and being fixed under TASK-13240; final UAT report in Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
+++ b/backlog/tasks/task-13239 - Run-live-UAT-for-reported-admin-login-profile-and-chat-scenarios.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13239
 title: 'Run live UAT for reported admin login, profile, and chat scenarios'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-10 05:07'
-updated_date: '2026-09-10 06:22'
+updated_date: '2026-09-10 06:25'
 labels: []
 dependencies: []
 references:
@@ -25,7 +25,7 @@ Verify PR #2939 against the original issue 2935–2938 reproduction scenarios us
 - [x] #1 Node 20 admin UI accepts a real login JWT and rejects invalid tokens without HTTP 500
 - [x] #2 Live PostgreSQL profile requests succeed with Bearer and API-key auth, populated sessions, and zero/one/multiple organization and team memberships
 - [x] #3 Live chat requests resolve omitted and blank models from configuration, preserve explicit models, and fail clearly before dispatch without a model
-- [ ] #4 Scenario results, environment, evidence, limitations, and any follow-up regression checks are recorded on PR #2939
+- [x] #4 Scenario results, environment, evidence, limitations, and any follow-up regression checks are recorded on PR #2939
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,14 +44,22 @@ Live UAT after quota DATE fix: full profile Bearer and API key 200 for 0/1/2 org
 Quota DATE fix verified: 4 new regressions red with asyncpg DataError, then 5 PostgreSQL +49 existing tests green; Ruff/Black/compilation/diff checks and scoped Bandit pass. Independent review found no actionable issues. Follow-up WebUI persistence retry exposed a separate event-loop/RBAC lock stall, tracked and being fixed under TASK-13240; final UAT report in Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md.
 
 Live acceptance verification is complete. Real browser admin login/reload and WebUI API-key Save/persistence pass; exact Node20.20.2 runtime also passes valid JWT and all five invalid/missing-token redirects. Six profile membership/authentication cases, session activity, refresh, real signup, and24 streaming/nonstreaming chat cases pass. UAT exposed and repaired audio DATE binding and RBAC event-loop stalls, with cache concurrency followups from review. Final fresh API and lock replays pass. Disposable DB removal and all owned server ports stopped are verified; temporary fixture and completed plan removed. Report and sanitized evidence are prepared for PR publication; full-suite/external-provider/Docker limits are explicit.
+
+Published UAT fixes and evidence to PR2939 against dev (quota74f86e5c76; RBAC/cache/report a8464cd510), then updated the PR description with all live scenarios and explicit limits. Original Lawrence908 attribution and human-authored pre-merge Change summary gate remain intact. No merge performed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed live acceptance checks for issues2935–2938 using real browser login/settings flows, production admin middleware on Node20.19.5 plus exact20.20.2 runtime HTTP checks, a PostgreSQL-backed API with test mode disabled, six profile membership/authentication cases, refresh/signup/session checks, and24 streaming/nonstreaming chat cases. UAT exposed audio quota DATE binding and an RBAC event-loop stall; both were repaired, with cache-race followups from independent review. Added13 regression cases across quota, PostgreSQL contention, and public cache concurrency. Targeted tests, lint, compilation, Bandit with no new findings, review, and final live replays passed. Retained report and sanitized evidence at Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md and its evidence link. Fixture database, temporary harness, execution plan, and owned services/browsers cleaned up. Chat used a controlled HTTP provider; external inference, published Docker image, full suites, and large-scale migration behavior were not certified. PR updated: https://github.com/rmusser01/tldw_server/pull/2939.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13240 - Prevent-synchronous-RBAC-lookup-from-stalling-live-PostgreSQL-requests.md
+++ b/backlog/tasks/task-13240 - Prevent-synchronous-RBAC-lookup-from-stalling-live-PostgreSQL-requests.md
@@ -1,0 +1,64 @@
+---
+id: TASK-13240
+title: Prevent synchronous RBAC lookup from stalling live PostgreSQL requests
+status: Done
+assignee: []
+created_date: '2026-09-10 05:46'
+updated_date: '2026-09-10 06:22'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2939'
+documentation:
+  - Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Discovered during TASK-13239 live UAT for PR2939: WebUI periodic requests trigger PostgreSQL DDL while a synchronous RBAC role SELECT blocks the API event loop, so even /health and API-key Save time out. Native stack sample shows psycopg wait_c on uvloop main thread; pg_stat_activity in the isolated UAT database shows the SELECT waiting behind an asyncpg schema transaction. Investigate the exact async caller and repair with regression coverage, then repeat the browser Save/reload scenario.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RBAC lookups used by asynchronous request handling do not block the event loop while PostgreSQL locks are held
+- [x] #2 A deterministic regression reproduces the stall before the fix and verifies concurrent event-loop progress afterward
+- [x] #3 Relevant regression tests, lint, Bandit, review, and live WebUI Save/reload acceptance checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the live synchronous RBAC lock stall with an isolated PostgreSQL regression.
+2. Move blocking request-path RBAC/database reads off the event loop while preserving sync repository contracts.
+3. Run regressions and security/lint checks, review, then repeat WebUI Save/reload and document live results in the PR UAT report.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Native sample identified psycopg wait_c on the uvloop main thread. Isolated pg_stat_activity: role SELECT waits on a relation lock held by an asyncpg schema transaction after CREATE rbac_user_rate_limits. Cancelling that read alone did not restore health within5s; investigate all synchronous RBAC helper reads. Related quota fix is committed as74f86e5c76.
+
+Live replay with the fix passed: real roles-table lock observed while authenticated /api/v1/buddies waited; /health200 in7ms before unlocking; authenticated request200 after unlock. WebUI Save received profile200, showed success, and reloaded successfully; final sanitized persistence evidence being captured. Scope is complete _enrich_user_with_rbac offload at JWT/API-key callers.
+
+Independent review found concurrent cold-cache construction and configuration publication races after RBAC moved to worker threads. Added shared initialization/reset RLock and public-entrypoint concurrency regressions; four initially failed, then42 related tests and4 PostgreSQL lock tests passed with clean exits. Final review identified a reset_lazy gap before the cold getter, now receiving its own red-green regression. Fresh live API: four simultaneous authenticated requests200, exactly one shared DB construction, profile200, health200. Real role-lock replay: health200 in8ms while authenticated request waits, then200 after unlock. Exact Node20.20.2 runtime also passed fresh-login JWT and invalid-cookie matrix.
+
+Final review also reproduced a lazy-reset gap between configuration lookup and cold database creation. Added a fifth public-entrypoint regression, observed its stale-path failure, then rechecked initialization inside the existing RLock. The final 26-test configuration/backend batch passed with exit0; previous 42-test batch and four real PostgreSQL lock regressions also passed. Final fresh API replay: four concurrent authenticated requests200, one DB construction, profile200, health200; held-role-lock health200 in7ms, waiting authentication200 after unlock. Reviewer reran its original probe and found no remaining actionable issues. Ruff, compilation, formatting of new tests, whitespace checks, and scoped Bandit pass; three pre-existing low Bandit credential-type literals in User_DB_Handling.py are unchanged. Standard UAT fixture exited0, its database was confirmed absent, all owned ports and browsers stopped. No external LLM or full-suite qualification claimed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved complete synchronous RBAC enrichment for JWT and API-key requests to worker threads so PostgreSQL lock waits cannot stall the API event loop. Protected shared database/configuration construction and test resets with a reentrant lock, including lazy-reset reinitialization, while preserving lock-free warm cache reads. Added four real PostgreSQL contention regressions and five public-entrypoint concurrency regressions; red-green, live UAT, independent review, lint, compilation, and scoped security checks completed. Evidence and limitations: Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md. PR: https://github.com/rmusser01/tldw_server/pull/2939. The completed task-specific execution plan was removed after verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
+++ b/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
@@ -1,0 +1,51 @@
+---
+id: TASK-13241
+title: Rebase PR 2939 and resolve Qodo review before merge
+status: In Progress
+assignee: []
+created_date: '2026-09-10 06:30'
+updated_date: '2026-09-10 06:31'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2939'
+documentation:
+  - Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User requests rebasing PR2939 onto latest dev, addressing all Qodo issues/comments and subsequent review feedback, then merging. Preserve original fixes and UAT evidence. Verify latest reviewed head and repository merge requirements, including the human-owned Change summary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased onto current dev with original regression fixes preserved
+- [ ] #2 Every Qodo finding has a verified fix or evidence-based disposition and regression coverage where behavior changes
+- [ ] #3 Fresh affected tests, lint, Bandit, review, and required CI checks pass on the final head
+- [ ] #4 Merge into dev only after review requirements and repository human-authored Change summary are satisfied
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Track work, fetch dev/reviews, preserve branch, rebase and inspect changes. 2. Reproduce and fix Qodo correctness findings; improve tests/docs and resolve CI failures. 3. Verify final changes, publish responses, wait for fresh review/checks, and merge once requirements are satisfied.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Initial remote PR head5065421d801490bd45a35d355b7eaa6f00e44b7f; latest fetched dev9da94ebcb41ba45d279ab707ec92a285d31ba5c7,17 commits ahead of prior base. Qodo posted seven findings on current PR head: queued macro default snapshot, silent config fallback, migration/test docstrings, test annotations, private array mechanics, and DB-layer ownership. Current CI has a shard-coverage guard failure. Independent bounded investigations assigned for CI, architecture, and test quality while coordinator handles rebase and macro/config fixes.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
+++ b/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
@@ -4,7 +4,7 @@ title: Rebase PR 2939 and resolve Qodo review before merge
 status: In Progress
 assignee: []
 created_date: '2026-09-10 06:30'
-updated_date: '2026-09-10 06:59'
+updated_date: '2026-09-10 07:22'
 labels: []
 dependencies: []
 references:
@@ -44,7 +44,19 @@ Macro RED: 16 failures and 6 explicit-model passes; GREEN: 28 macro tests. Confi
 Fresh combined Auth/Profile: 76 passed, no skips, with PostgreSQL required through the standard fixtures. Full simplified-chat plus target/provider resolution: 260 passed, one existing TestClient streaming skip. Admin auth/middleware: 28 passed on Node 20.19.5. Compilation, scoped lint, and Bandit show no new issues; inherited findings documented in the review report. Independent Qodo-remediation review found no correctness issues. All completed test processes exited successfully.
 
 Investigating the original-head frontend webhook E2E failure; the canceled license audit was superseded by success. Publication, current-head remote checks/review, and merge remain. The repository requires a human-written Change summary explaining what changed and why; requested from the user asynchronously and still pending.
+
+Published rebased review repairs as 475a4900356b17a651d0430cd00e029b3577ab63 with a lease pinned to the verified original remote head. All seven Qodo comments have individual evidence replies and resolved threads. Qodo independently updated its report at 07:03:50 UTC to this exact head with zero bugs/rule violations, before our replies/resolution. Current-head backend, security, container-build, shard, and trusted-license checks pass; frontend, coverage, and e2e remain running.
+
+Browser reproduction identified an inherited webhook status mismatch: backend adds delivery metadata, while admin client exact-key validation permits only the seven older fields. Existing mocks lacked delivery. A minimal API-client compatibility fix with real-response-shaped regressions is in progress; the real-backend acceptance test stays unchanged. Effective dev rules allow only a merge commit. Scheduled same-task follow-up finish-pr-2939-review-and-merge checks every 15 minutes, continues repairs, and merges only after all checks and the pending human Change summary are satisfied.
+
+Webhook compatibility follow-up complete: only admin-ui/lib/api-client.ts and its webhook client test changed. The response is copied and only unused delivery metadata is removed before existing strict validation; UI-consumed fields and unrelated-extra-key rejection remain intact. New canonical/legacy regressions failed before the fix (2 failed, 21 passed); after repair all 73 webhook client/page/URL cases pass. Scoped ESLint, full admin typecheck, and the production real-backend build pass on Node 20.19.5. The unchanged real-backend Chromium JWT webhook spec passes all 3 tests with no retries. Independent review found no issues; temporary services stopped. Latest remote dev remains 9da94ebcb4, and PR head before publishing this follow-up is 475a490035. Current-head CI and Qodo must re-run after push; the human Change summary is still pending.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR2939 onto current dev with original patches preserved, resolved all seven Qodo findings with behavioral regressions and individual review responses, repaired CI shard assignments and the inherited admin webhook delivery-metadata contract failure, and recorded fresh local verification. Qodo independently cleared the rebased backend head. Remaining work is final-head remote checks/review plus the required human-owned Change summary, followed by an authorized merge commit into dev. The thread follow-up continues those steps.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
+++ b/backlog/tasks/task-13241 - Rebase-PR-2939-and-resolve-Qodo-review-before-merge.md
@@ -4,13 +4,13 @@ title: Rebase PR 2939 and resolve Qodo review before merge
 status: In Progress
 assignee: []
 created_date: '2026-09-10 06:30'
-updated_date: '2026-09-10 06:31'
+updated_date: '2026-09-10 06:59'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/2939'
 documentation:
-  - Docs/Plans/IMPLEMENTATION_PLAN_pr2939_rebase_qodo_merge.md
+  - Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md
 priority: high
 ---
 
@@ -22,8 +22,8 @@ User requests rebasing PR2939 onto latest dev, addressing all Qodo issues/commen
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR branch is rebased onto current dev with original regression fixes preserved
-- [ ] #2 Every Qodo finding has a verified fix or evidence-based disposition and regression coverage where behavior changes
+- [x] #1 PR branch is rebased onto current dev with original regression fixes preserved
+- [x] #2 Every Qodo finding has a verified fix or evidence-based disposition and regression coverage where behavior changes
 - [ ] #3 Fresh affected tests, lint, Bandit, review, and required CI checks pass on the final head
 - [ ] #4 Merge into dev only after review requirements and repository human-authored Change summary are satisfied
 <!-- AC:END -->
@@ -37,15 +37,21 @@ User requests rebasing PR2939 onto latest dev, addressing all Qodo issues/commen
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Initial remote PR head5065421d801490bd45a35d355b7eaa6f00e44b7f; latest fetched dev9da94ebcb41ba45d279ab707ec92a285d31ba5c7,17 commits ahead of prior base. Qodo posted seven findings on current PR head: queued macro default snapshot, silent config fallback, migration/test docstrings, test annotations, private array mechanics, and DB-layer ownership. Current CI has a shard-coverage guard failure. Independent bounded investigations assigned for CI, architecture, and test quality while coordinator handles rebase and macro/config fixes.
+Rebased original remote head 5065421d801490bd45a35d355b7eaa6f00e44b7f onto dev 9da94ebcb41ba45d279ab707ec92a285d31ba5c7, 17 commits ahead of the prior base. All nine patches remained identical by range-diff. Qodo posted seven findings: queued macro defaults, silent configuration fallback, DB-layer ownership, migration/test documentation, test annotations, and private array mechanics. Each has a verified repair or supported disposition in Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md.
+
+Macro RED: 16 failures and 6 explicit-model passes; GREEN: 28 macro tests. Configuration diagnostics RED: 2 failures; GREEN: 30 target tests. Removing the production array wrapper triggers the two intended mutation failures; clean array tests pass. Session SQL is now DB-owned and retains caller transaction boundaries. CI shard omission and inherited media/character/workspace assignment drift repaired; all 57 workflow contracts pass.
+
+Fresh combined Auth/Profile: 76 passed, no skips, with PostgreSQL required through the standard fixtures. Full simplified-chat plus target/provider resolution: 260 passed, one existing TestClient streaming skip. Admin auth/middleware: 28 passed on Node 20.19.5. Compilation, scoped lint, and Bandit show no new issues; inherited findings documented in the review report. Independent Qodo-remediation review found no correctness issues. All completed test processes exited successfully.
+
+Investigating the original-head frontend webhook E2E failure; the canceled license audit was superseded by success. Publication, current-head remote checks/review, and merge remain. The repository requires a human-written Change summary explaining what changed and why; requested from the user asynchronously and still pending.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -2243,7 +2243,7 @@ def _create_chat_macro_run_payload(
         request_messages=request_data.messages,
         model_selection={
             "api_provider": selected_provider or request_data.api_provider,
-            "model": selected_model or request_data.model,
+            "model": selected_model,
         },
         output_profile=resolved_profile.name,
         request_metadata=request_metadata,
@@ -3533,7 +3533,7 @@ async def create_chat_completion(
 
         provider = metrics_provider
         model = metrics_model
-        initial_provider = metrics_provider
+        initial_provider = selected_provider
 
         try:
             logger.debug("Provider/model resolution: {}", provider_debug)
@@ -4311,7 +4311,7 @@ async def create_chat_completion(
 
             # Normalize provider/model on the request for downstream logic (already resolved)
             provider = selected_provider
-            model = selected_model or model
+            model = selected_model
 
             try:
                 if not request_model_was_explicit:

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -4182,6 +4182,37 @@ async def create_chat_completion(
                     logger.debug(f"Billing token pre-check failed (fail-open): {_billing_err}")
                     _billing_enforcer = None
 
+            # Resolve one effective model before either durable macro creation or direct dispatch.
+            provider = selected_provider
+            model = selected_model
+
+            try:
+                if not request_model_was_explicit:
+                    default_model_for_provider = _get_default_model_for_provider_name(provider)
+                    if default_model_for_provider:
+                        model = default_model_for_provider
+                        request_data.model = default_model_for_provider
+                override_error = validate_provider_override(provider, model)
+            except ByokResolutionError as credential_error:
+                raise_detached_error(
+                    _provider_credential_http_exception(credential_error)
+                )
+            if not model:
+                # Fail fast with a clear client error instead of cascading into a 500
+                # when downstream provider adapters require an explicit model.
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Model is required for provider '{provider}'. Please select a model in the WebUI "
+                        f"or configure a default via environment variable 'DEFAULT_MODEL_{provider.replace('.', '_').replace('-', '_').upper()}'"
+                    ),
+                )
+
+            if override_error:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=override_error)
+
+            selected_model = model
+
             if chat_macro_intent is not None:
                 macro_command = str(chat_macro_intent["command"])
                 try:
@@ -4308,35 +4339,6 @@ async def create_chat_completion(
                 raise
             except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Moderation input processing error: {e}")
-
-            # Normalize provider/model on the request for downstream logic (already resolved)
-            provider = selected_provider
-            model = selected_model
-
-            try:
-                if not request_model_was_explicit:
-                    default_model_for_provider = _get_default_model_for_provider_name(provider)
-                    if default_model_for_provider:
-                        model = default_model_for_provider
-                        request_data.model = default_model_for_provider
-                override_error = validate_provider_override(provider, model)
-            except ByokResolutionError as credential_error:
-                raise_detached_error(
-                    _provider_credential_http_exception(credential_error)
-                )
-            if not model:
-                # Fail fast with a clear client error instead of cascading into a 500
-                # when downstream provider adapters require an explicit model.
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        f"Model is required for provider '{provider}'. Please select a model in the WebUI "
-                        f"or configure a default via environment variable 'DEFAULT_MODEL_{provider.replace('.', '_').replace('-', '_').upper()}'"
-                    ),
-                )
-
-            if override_error:
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=override_error)
 
             persona_alias_used = _resolve_character_id_from_persona_alias(request_data)
 

--- a/tldw_Server_API/app/api/v1/endpoints/messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/messages.py
@@ -1015,14 +1015,19 @@ def _normalize_llamacpp_base_url(base_url: str) -> str:
 
 
 def _resolve_provider_and_model_for_request(request_data: Any) -> tuple[str, str]:
-    """Resolve provider/model pair from the request payload."""
-    _, metrics_model, selected_provider, selected_model, _debug = resolve_provider_and_model(
+    """Resolve the execution provider/model pair from the request payload."""
+    _, _, selected_provider, selected_model, _debug = resolve_provider_and_model(
         request_data=request_data,
         metrics_default_provider=DEFAULT_LLM_PROVIDER,
         normalize_default_provider=_get_default_provider(),
     )
     provider = selected_provider
-    model = selected_model or metrics_model or getattr(request_data, "model", None)
+    model = selected_model
+    if not isinstance(model, str) or not model.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Model is required for provider '{provider}'.",
+        )
     return provider, model
 
 

--- a/tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py
+++ b/tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py
@@ -2,6 +2,7 @@
 # Description: Handles user authentication and identification based on application mode.
 #
 # Imports
+import asyncio
 import contextlib
 import os
 from typing import Any, Optional, Union
@@ -696,8 +697,8 @@ async def verify_jwt_and_fetch_user(request: Request, token: str = Depends(oauth
         subject_db_id_int = None
 
     # --- Enrich with roles/permissions from central AuthNZ RBAC tables ---
-    roles, perms, is_admin = _enrich_user_with_rbac(
-        subject_db_id_int, user_data, pii_redact_logs=pii_redact_logs
+    roles, perms, is_admin = await asyncio.to_thread(
+        _enrich_user_with_rbac, subject_db_id_int, user_data, pii_redact_logs=pii_redact_logs
     )
 
     # --- Create and validate the User Pydantic model ---
@@ -1167,8 +1168,8 @@ async def authenticate_api_key_user(request: Request, api_key: str) -> User:
         if user_data.get("is_superuser"):
             user_data.setdefault("is_admin", True)
 
-        roles, perms, is_admin_flag = _enrich_user_with_rbac(
-            user_id, user_data, pii_redact_logs=getattr(settings, "PII_REDACT_LOGS", False)
+        roles, perms, is_admin_flag = await asyncio.to_thread(
+            _enrich_user_with_rbac, user_id, user_data, pii_redact_logs=getattr(settings, "PII_REDACT_LOGS", False)
         )
 
         user_data["roles"] = roles

--- a/tldw_Server_API/app/core/AuthNZ/database.py
+++ b/tldw_Server_API/app/core/AuthNZ/database.py
@@ -1975,7 +1975,13 @@ def _normalize_sqlite_sql(query: str) -> str:
 
 
 def _flatten_params(args: tuple[Any, ...]) -> tuple[Any, ...]:
-    """Support both variadic and single-sequence parameter passing."""
+    """Support both variadic and single-sequence parameter passing.
+
+    To bind one PostgreSQL array, pass a parameter sequence containing that
+    array: ``pool.fetchone(sql, (ids,))``. Passing ``ids`` alone denotes the
+    complete parameter sequence, so its elements become separate arguments.
+    Raw acquired connections use asyncpg's variadic convention instead.
+    """
     if len(args) == 1 and isinstance(args[0], (list, tuple)):
         return tuple(args[0])
     return tuple(args)

--- a/tldw_Server_API/app/core/AuthNZ/db_config.py
+++ b/tldw_Server_API/app/core/AuthNZ/db_config.py
@@ -8,6 +8,7 @@
 
 import contextlib
 import os
+import threading
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import unquote, urlparse
@@ -35,19 +36,24 @@ class AuthDatabaseConfig:
     # Singleton instance
     _instance: Optional['AuthDatabaseConfig'] = None
     _user_db: Optional[UserDatabase] = None
+    _initialization_lock = threading.RLock()
 
     def __new__(cls):
         """Ensure singleton pattern."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._initialization_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self):
         """Initialize configuration from environment and settings."""
         if not hasattr(self, '_initialized'):
-            self.settings = get_settings()
-            self._initialized = True
-            self._detect_backend()
+            with self._initialization_lock:
+                if not hasattr(self, '_initialized'):
+                    self.settings = get_settings()
+                    self._detect_backend()
+                    self._initialized = True
 
     def _detect_backend(self):
         """Detect database backend from environment or settings."""
@@ -203,25 +209,32 @@ class AuthDatabaseConfig:
         Returns:
             UserDatabase: Configured database instance
         """
-        if self._user_db is None:
-            config = self.get_config()
-            self._user_db = UserDatabase(config=config, client_id=client_id)
-            logger.info(f"Created UserDatabase with {self.backend_type} backend")
-        return self._user_db
+        database = self._user_db
+        if database is not None:
+            return database
+        with self._initialization_lock:
+            if self._user_db is None:
+                # A lazy reset may follow the public getter's config lookup.
+                self.__init__()
+                config = self.get_config()
+                self._user_db = UserDatabase(config=config, client_id=client_id)
+                logger.info(f"Created UserDatabase with {self.backend_type} backend")
+            return self._user_db
 
     def reset(self) -> None:
         """Reset configuration and database instance (mainly for testing)."""
-        # Close any existing UserDatabase backend connections so tests do not
-        # reuse pools pointing at dropped per-test databases.
-        if self._user_db is not None:
-            self._release_user_db_backend(context="reset")
-        self._user_db = None
-        # Ensure backend detection reflects updated environment/settings.
-        # Note: This will instantiate AuthNZ Settings if it is currently unset.
-        # Tests that need a "lazy" reset (do not instantiate settings yet) should
-        # call `reset_lazy()` instead.
-        self.settings = get_settings()
-        self._detect_backend()
+        with self._initialization_lock:
+            # Close any existing UserDatabase backend connections so tests do not
+            # reuse pools pointing at dropped per-test databases.
+            if self._user_db is not None:
+                self._release_user_db_backend(context="reset")
+            self._user_db = None
+            # Ensure backend detection reflects updated environment/settings.
+            # Note: This will instantiate AuthNZ Settings if it is currently unset.
+            # Tests that need a "lazy" reset (do not instantiate settings yet) should
+            # call `reset_lazy()` instead.
+            self.settings = get_settings()
+            self._detect_backend()
 
     def reset_lazy(self) -> None:
         """Reset caches without instantiating AuthNZ Settings (test helper).
@@ -231,11 +244,12 @@ class AuthDatabaseConfig:
         cases, instantiating Settings too early can freeze the wrong defaults
         (e.g., AUTH_MODE=single_user) and make tests order-dependent.
         """
-        if self._user_db is not None:
-            self._release_user_db_backend(context="reset_lazy")
-        self._user_db = None
-        with contextlib.suppress(Exception):
-            delattr(self, "_initialized")
+        with self._initialization_lock:
+            if self._user_db is not None:
+                self._release_user_db_backend(context="reset_lazy")
+            self._user_db = None
+            with contextlib.suppress(Exception):
+                delattr(self, "_initialized")
 
     def _release_user_db_backend(self, *, context: str) -> None:
         """Close or evict the cached UserDatabase backend during test resets."""

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -26,6 +26,10 @@ from tldw_Server_API.app.core.AuthNZ.sqlite_profile_version_schema import (
     rebuild_sqlite_users_with_profile_version,
     validate_sqlite_profile_version_readiness,
 )
+from tldw_Server_API.app.core.DB_Management.authnz_session_schema import (
+    create_sqlite_sessions_table,
+    ensure_sqlite_session_last_activity,
+)
 from tldw_Server_API.app.core.DB_Management.migrations import Migration, MigrationManager
 from tldw_Server_API.app.core.Infrastructure.distributed_lock import acquire_migration_lock
 from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime as _is_explicit_pytest_runtime
@@ -91,32 +95,7 @@ def migration_001_create_users_table(conn: sqlite3.Connection) -> None:
 
 def migration_002_create_sessions_table(conn: sqlite3.Connection) -> None:
     """Create the sessions table for session management"""
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS sessions (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            token_hash TEXT NOT NULL,
-            refresh_token_hash TEXT,
-            encrypted_token TEXT,
-            encrypted_refresh TEXT,
-            expires_at TIMESTAMP NOT NULL,
-            refresh_expires_at TIMESTAMP,
-            ip_address TEXT,
-            user_agent TEXT,
-            device_id TEXT,
-            is_active INTEGER DEFAULT 1,
-            is_revoked INTEGER DEFAULT 0,
-            revoked_at TIMESTAMP,
-            revoked_by INTEGER,
-            revoke_reason TEXT,
-            access_jti TEXT,
-            refresh_jti TEXT,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )
-    """)
+    create_sqlite_sessions_table(conn)
 
     # Create indexes
     try:
@@ -141,12 +120,7 @@ def migration_002_create_sessions_table(conn: sqlite3.Connection) -> None:
         add_col('revoked_at', "revoked_at TIMESTAMP")
         add_col('revoked_by', "revoked_by INTEGER")
         add_col('revoke_reason', "revoke_reason TEXT")
-        add_col('last_activity', "last_activity TIMESTAMP")
-        conn.execute(
-            "UPDATE sessions "
-            "SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
-            "WHERE last_activity IS NULL"
-        )
+        ensure_sqlite_session_last_activity(conn)
     except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
         pass
 
@@ -6566,26 +6540,16 @@ def migration_097_backfill_user_uuid(conn: sqlite3.Connection) -> None:
 
 
 def migration_098_add_session_last_activity(conn: sqlite3.Connection) -> None:
-    """Add and backfill the session activity timestamp for legacy databases."""
-    if not _sqlite_table_exists(conn, "sessions"):
-        return
+    """Add and backfill the session activity timestamp for legacy databases.
 
-    columns = {
-        str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
-    }
-    if "last_activity" not in columns:
-        conn.execute("ALTER TABLE sessions ADD COLUMN last_activity TIMESTAMP")
-    if "created_at" in columns:
-        conn.execute(
-            "UPDATE sessions "
-            "SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
-            "WHERE last_activity IS NULL"
-        )
-    else:
-        conn.execute(
-            "UPDATE sessions SET last_activity = CURRENT_TIMESTAMP "
-            "WHERE last_activity IS NULL"
-        )
+    Args:
+        conn: SQLite connection supplied by the AuthNZ migration runner.
+
+    Returns:
+        None. Existing activity values and missing session tables are unchanged;
+        the migration runner owns the transaction and its commit or rollback.
+    """
+    ensure_sqlite_session_last_activity(conn)
 
 
 def apply_authnz_migrations(db_path: Path, target_version: int = None) -> None:

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -112,6 +112,7 @@ def migration_002_create_sessions_table(conn: sqlite3.Connection) -> None:
             access_jti TEXT,
             refresh_jti TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
@@ -140,6 +141,12 @@ def migration_002_create_sessions_table(conn: sqlite3.Connection) -> None:
         add_col('revoked_at', "revoked_at TIMESTAMP")
         add_col('revoked_by', "revoked_by INTEGER")
         add_col('revoke_reason', "revoke_reason TEXT")
+        add_col('last_activity', "last_activity TIMESTAMP")
+        conn.execute(
+            "UPDATE sessions "
+            "SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
+            "WHERE last_activity IS NULL"
+        )
     except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
         pass
 
@@ -6517,6 +6524,11 @@ def get_authnz_migrations() -> list[Migration]:
             "Backfill NULL users.uuid values",
             migration_097_backfill_user_uuid,
         ),
+        Migration(
+            98,
+            "Add and backfill sessions.last_activity",
+            migration_098_add_session_last_activity,
+        ),
     ]
 
 
@@ -6551,6 +6563,29 @@ def migration_097_backfill_user_uuid(conn: sqlite3.Connection) -> None:
         WHERE uuid IS NULL OR trim(uuid) = ''
         """
     )
+
+
+def migration_098_add_session_last_activity(conn: sqlite3.Connection) -> None:
+    """Add and backfill the session activity timestamp for legacy databases."""
+    if not _sqlite_table_exists(conn, "sessions"):
+        return
+
+    columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
+    }
+    if "last_activity" not in columns:
+        conn.execute("ALTER TABLE sessions ADD COLUMN last_activity TIMESTAMP")
+    if "created_at" in columns:
+        conn.execute(
+            "UPDATE sessions "
+            "SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
+            "WHERE last_activity IS NULL"
+        )
+    else:
+        conn.execute(
+            "UPDATE sessions SET last_activity = CURRENT_TIMESTAMP "
+            "WHERE last_activity IS NULL"
+        )
 
 
 def apply_authnz_migrations(db_path: Path, target_version: int = None) -> None:

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -14,6 +14,9 @@ from typing import Any
 import asyncpg
 from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.authnz_session_schema import (
+    ensure_postgres_session_last_activity,
+)
 from tldw_Server_API.app.core.DB_Management.backends.pg_sharing_schema import (
     apply_postgres_sharing_schema,
     postgres_sharing_schema_issues,
@@ -1075,7 +1078,6 @@ _CREATE_AUTHNZ_CORE_TABLES = [
             access_jti VARCHAR(128),
             refresh_jti VARCHAR(128),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
@@ -1086,16 +1088,6 @@ _CREATE_AUTHNZ_CORE_TABLES = [
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS is_revoked BOOLEAN DEFAULT FALSE", ()),
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS access_jti VARCHAR(128)", ()),
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS refresh_jti VARCHAR(128)", ()),
-    ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_activity TIMESTAMP", ()),
-    (
-        "UPDATE sessions SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
-        "WHERE last_activity IS NULL",
-        (),
-    ),
-    (
-        "ALTER TABLE sessions ALTER COLUMN last_activity SET DEFAULT CURRENT_TIMESTAMP",
-        (),
-    ),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_token_hash ON sessions(token_hash)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)", ()),
@@ -3550,6 +3542,7 @@ async def ensure_authnz_core_tables_pg(pool: DatabasePool | None = None) -> bool
         async with db_pool.transaction() as conn:
             for sql, params in _CREATE_AUTHNZ_CORE_TABLES:
                 await conn.execute(sql, *params)
+            await ensure_postgres_session_last_activity(conn)
             has_legacy_uses = await conn.fetchval(
                 "SELECT EXISTS ("
                 "SELECT 1 FROM information_schema.columns "

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1075,6 +1075,7 @@ _CREATE_AUTHNZ_CORE_TABLES = [
             access_jti VARCHAR(128),
             refresh_jti VARCHAR(128),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
@@ -1085,6 +1086,16 @@ _CREATE_AUTHNZ_CORE_TABLES = [
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS is_revoked BOOLEAN DEFAULT FALSE", ()),
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS access_jti VARCHAR(128)", ()),
     ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS refresh_jti VARCHAR(128)", ()),
+    ("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_activity TIMESTAMP", ()),
+    (
+        "UPDATE sessions SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) "
+        "WHERE last_activity IS NULL",
+        (),
+    ),
+    (
+        "ALTER TABLE sessions ALTER COLUMN last_activity SET DEFAULT CURRENT_TIMESTAMP",
+        (),
+    ),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_token_hash ON sessions(token_hash)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)", ()),

--- a/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
@@ -325,7 +325,7 @@ class ManagedSecretRefsRepo:
                         FROM managed_secret_refs
                         WHERE id = ANY($1::int[])
                         """
-                rows = await self.db_pool.fetchall(list_refs_sql, normalized_ids)
+                rows = await self.db_pool.fetchall(list_refs_sql, (normalized_ids,))
             else:
                 list_refs_sql = """
                     SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,

--- a/tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py
@@ -280,7 +280,7 @@ class AuthnzOrgsTeamsRepo:
                 total = (
                     await self.db_pool.fetchval(
                         f"SELECT COUNT(*) FROM organizations{where_clause}",  # nosec B608
-                        *params,
+                        params,
                     )
                     if with_total
                     else 0

--- a/tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py
@@ -118,9 +118,9 @@ class AuthnzSessionsRepo:
                         encrypted_token, encrypted_refresh,
                         expires_at, refresh_expires_at,
                         ip_address, user_agent, device_id,
-                        access_jti, refresh_jti
+                        access_jti, refresh_jti, last_activity
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
                     """,
                     (
                         user_id,

--- a/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
@@ -296,7 +296,7 @@ class AuthnzUsersRepo:
             # Total count
             count_query_template = "SELECT COUNT(DISTINCT users.id) FROM users{join_clause}{where_clause}"
             count_query = count_query_template.format_map(locals())  # nosec B608
-            total = await db.db_pool.fetchval(count_query, *params)
+            total = await db.db_pool.fetchval(count_query, params)
 
             # Page of users
             if is_pg:

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -1581,7 +1581,7 @@ def _find_catalog_providers_for_model_cached(model: str) -> tuple[str, ...]:
 def infer_provider_from_model_catalog(
     *,
     provider: str,
-    model: str,
+    model: str | None,
     provider_explicit: bool,
 ) -> tuple[str, dict[str, Any]]:
     """Infer provider from model catalog when the current provider likely mismatches.
@@ -1785,7 +1785,12 @@ def parse_provider_model_for_metrics(
 
     Returns (provider, model_for_metrics).
     """
-    model_str = getattr(request_data, "model", None) or "unknown"
+    raw_model = getattr(request_data, "model", None)
+    model_str = (
+        raw_model.strip()
+        if isinstance(raw_model, str) and raw_model.strip()
+        else "unknown"
+    )
     api_provider = getattr(request_data, "api_provider", None)
     model_provider, model_name, _ = _split_inline_provider_model(model_str)
     if model_provider is not None and model_name is not None:
@@ -1924,7 +1929,7 @@ def resolve_provider_and_model(
     metrics_default_provider: str,
     normalize_default_provider: str,
     routing_decision: RoutingDecision | None = None,
-) -> tuple[str, str, str, str, dict[str, Any]]:
+) -> tuple[str, str, str, str | None, dict[str, Any]]:
     """Resolve provider/model for metrics and execution and record the decision path.
 
     Returns a 5-tuple:
@@ -1983,7 +1988,11 @@ def resolve_provider_and_model(
     )
 
     selected_provider = metrics_provider
-    selected_model = metrics_model
+    selected_model = (
+        raw_model.strip()
+        if isinstance(raw_model, str) and raw_model.strip()
+        else None
+    )
 
     # Step 2: normalize provider/model for execution (may mutate request_data.model)
     try:
@@ -1992,14 +2001,17 @@ def resolve_provider_and_model(
         )
         selected_provider = normalized_provider
         new_model = getattr(request_data, "model", None)
-        if new_model:
-            selected_model = new_model
+        selected_model = (
+            new_model.strip()
+            if isinstance(new_model, str) and new_model.strip()
+            else None
+        )
     except _CHAT_NONCRITICAL_EXCEPTIONS as exc:
-        # Do not block the request if normalization fails; fall back to metrics values.
+        # Keep the pre-normalization execution values if optional normalization fails.
         pass
         logger.debug(
             "resolve_provider_and_model: normalization failed, "
-            "falling back to metrics provider/model. Error={}",
+            "keeping pre-normalization execution values. Error={}",
             exc,
         )
 
@@ -2778,8 +2790,11 @@ def build_call_params_from_request(
             and (not isinstance(declared_fields, Mapping) or key in declared_fields)
         )
     }
-    if resolved_model:
-        call_params["model"] = resolved_model
+    call_model = resolved_model if resolved_model is not None else call_params.get("model")
+    if isinstance(call_model, str) and call_model.strip():
+        call_params["model"] = call_model.strip()
+    else:
+        call_params.pop("model", None)
 
     # Rename keys to match chat_api_call's generic signature
     if "temperature" in call_params:
@@ -2809,7 +2824,7 @@ def build_call_params_from_request(
         tools=chat_tools if isinstance(chat_tools, list) else None,
         allow_catalog=get_chat_tool_allow_catalog(),
         rollout_mode=rollout_mode,
-        provider_key=f"{target_api_provider}:{call_params.get('model') or getattr(request_data, 'model', None) or ''}",
+        provider_key=f"{target_api_provider}:{call_params.get('model') or ''}",
         provider_allowlist=provider_allowlist,
         streaming=bool(getattr(request_data, "stream", False)),
         presentation_variant=presentation_variant,

--- a/tldw_Server_API/app/core/Chat/chat_target_resolution.py
+++ b/tldw_Server_API/app/core/Chat/chat_target_resolution.py
@@ -6,6 +6,8 @@ import os
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from loguru import logger
+
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import (
     DEFAULT_LLM_PROVIDER,
 )
@@ -127,15 +129,27 @@ def get_default_model_for_provider(
             )
             if isinstance(configured, str) and configured.strip():
                 return configured.strip()
-    except (AttributeError, KeyError, TypeError, ValueError):
-        pass
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        # Configuration diagnostics can contain credentials; log context and type only.
+        # The provider snapshot may still supply a usable default after this failure.
+        logger.warning(
+            "Default model lookup failed: provider={}, source=Chat-Module, error_type={}; trying provider snapshot",
+            normalized_provider,
+            type(exc).__name__,
+        )
 
     try:
         return configured_provider_model_from_snapshot(
             normalized_provider,
             provider_config_loader(),
         )
-    except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError):
+    except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        # Retain the missing-model result so callers apply their existing request error.
+        logger.warning(
+            "Default model lookup failed: provider={}, source=provider snapshot, error_type={}; no default available",
+            normalized_provider,
+            type(exc).__name__,
+        )
         return None
 
 

--- a/tldw_Server_API/app/core/Chat/chat_target_resolution.py
+++ b/tldw_Server_API/app/core/Chat/chat_target_resolution.py
@@ -9,10 +9,14 @@ from typing import Any, Callable
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import (
     DEFAULT_LLM_PROVIDER,
 )
+from tldw_Server_API.app.core.AuthNZ.byok_helpers import load_server_config_snapshot
 from tldw_Server_API.app.core.AuthNZ.llm_provider_overrides import (
     get_llm_provider_override,
     get_override_default_model,
     validate_provider_override,
+)
+from tldw_Server_API.app.core.AuthNZ.provider_credential_runtime import (
+    configured_provider_model_from_snapshot,
 )
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
 from tldw_Server_API.app.core.Chat.chat_service import (
@@ -90,6 +94,7 @@ def get_default_model_for_provider(
     override_default_resolver: Callable[[str], str | None] = get_override_default_model,
     override_resolver: Callable[[str], Any] = get_llm_provider_override,
     config_loader: Callable[[], Any] = load_comprehensive_config,
+    provider_config_loader: Callable[[], dict[str, Any]] = load_server_config_snapshot,
 ) -> str | None:
     """Resolve the ordinary server default model for one provider."""
 
@@ -123,8 +128,15 @@ def get_default_model_for_provider(
             if isinstance(configured, str) and configured.strip():
                 return configured.strip()
     except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+
+    try:
+        return configured_provider_model_from_snapshot(
+            normalized_provider,
+            provider_config_loader(),
+        )
+    except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError):
         return None
-    return None
 
 
 def _configuration_error(provider: str | None = None) -> ChatConfigurationError:

--- a/tldw_Server_API/app/core/DB_Management/authnz_session_schema.py
+++ b/tldw_Server_API/app/core/DB_Management/authnz_session_schema.py
@@ -1,0 +1,88 @@
+"""DB-owned AuthNZ session schema changes on caller-owned connections."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def create_sqlite_sessions_table(conn: sqlite3.Connection) -> None:
+    """Create the session table with an activity default for new rows.
+
+    Args:
+        conn: SQLite connection supplied by the AuthNZ migration runner.
+
+    Returns:
+        None. The caller owns the transaction and its commit or rollback.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token_hash TEXT NOT NULL,
+            refresh_token_hash TEXT,
+            encrypted_token TEXT,
+            encrypted_refresh TEXT,
+            expires_at TIMESTAMP NOT NULL,
+            refresh_expires_at TIMESTAMP,
+            ip_address TEXT,
+            user_agent TEXT,
+            device_id TEXT,
+            is_active INTEGER DEFAULT 1,
+            is_revoked INTEGER DEFAULT 0,
+            revoked_at TIMESTAMP,
+            revoked_by INTEGER,
+            revoke_reason TEXT,
+            access_jti TEXT,
+            refresh_jti TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    """)
+
+
+def ensure_sqlite_session_last_activity(conn: sqlite3.Connection) -> None:
+    """Add and backfill session activity without replacing existing values.
+
+    Args:
+        conn: SQLite connection supplied by the AuthNZ migration runner.
+
+    Returns:
+        None. Missing session tables are left unchanged; the caller owns the
+        transaction and its commit or rollback.
+    """
+    table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        ("sessions",),
+    ).fetchone()
+    if table is None:
+        return
+
+    columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+    if "last_activity" not in columns:
+        conn.execute("ALTER TABLE sessions ADD COLUMN last_activity TIMESTAMP")
+    if "created_at" in columns:
+        conn.execute(
+            "UPDATE sessions SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) WHERE last_activity IS NULL"
+        )
+    else:
+        conn.execute("UPDATE sessions SET last_activity = CURRENT_TIMESTAMP WHERE last_activity IS NULL")
+
+
+async def ensure_postgres_session_last_activity(conn: Any) -> None:
+    """Add, backfill, and default activity for an existing PostgreSQL session table.
+
+    Args:
+        conn: PostgreSQL connection in the AuthNZ bootstrap transaction.
+
+    Returns:
+        None. Existing activity values remain unchanged, and the caller owns
+        the transaction and its commit or rollback.
+    """
+    await conn.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_activity TIMESTAMP")
+    await conn.execute(
+        "UPDATE sessions SET last_activity = COALESCE(created_at, CURRENT_TIMESTAMP) WHERE last_activity IS NULL"
+    )
+    await conn.execute("ALTER TABLE sessions ALTER COLUMN last_activity SET DEFAULT CURRENT_TIMESTAMP")

--- a/tldw_Server_API/app/core/Usage/audio_quota.py
+++ b/tldw_Server_API/app/core/Usage/audio_quota.py
@@ -602,7 +602,7 @@ async def _get_user_override_limits(user_id: int) -> dict[str, float | None]:
 async def get_daily_minutes_used(user_id: int) -> float:
     pool = await get_db_pool()
     await _ensure_tables(pool)
-    day = datetime.now(timezone.utc).date().isoformat()
+    day = datetime.now(timezone.utc).date()
     try:
         if pool.pool:
             row = await pool.fetchrow(
@@ -615,7 +615,7 @@ async def get_daily_minutes_used(user_id: int) -> float:
             rows = await pool.fetch(
                 "SELECT minutes_used FROM audio_usage_daily WHERE user_id=? AND day=?",
                 user_id,
-                day,
+                day.isoformat(),
             )
             return float(rows[0][0]) if rows else 0.0
     except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS:
@@ -687,7 +687,7 @@ async def _backfill_audio_usage_daily_to_ledger(ledger: ResourceDailyLedger) -> 
         # Ensure legacy tables exist if callers created them previously; this
         # is a no-op when they do not.
         await _ensure_tables(pool)
-        day = datetime.now(timezone.utc).date().isoformat()
+        day = datetime.now(timezone.utc).date()
         rows = []
         if pool.pool:
             try:
@@ -703,7 +703,7 @@ async def _backfill_audio_usage_daily_to_ledger(ledger: ResourceDailyLedger) -> 
             try:
                 rows = await pool.fetch(
                     "SELECT user_id, minutes_used FROM audio_usage_daily WHERE user_id IS NOT NULL AND day=?",
-                    day,
+                    day.isoformat(),
                 )
                 iterable = [(int(r[0]), float(r[1])) for r in rows or []]
             except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS:
@@ -982,7 +982,7 @@ async def _ledger_remaining_minutes(user_id: int, daily_limit_minutes: float) ->
 async def increment_jobs_started(user_id: int) -> None:
     pool = await get_db_pool()
     await _ensure_tables(pool)
-    day = datetime.now(timezone.utc).date().isoformat()
+    day = datetime.now(timezone.utc).date()
     try:
         if pool.pool:
             await pool.execute(
@@ -1002,7 +1002,7 @@ async def increment_jobs_started(user_id: int) -> None:
                 ON CONFLICT(user_id, day) DO UPDATE SET jobs_started = jobs_started + 1
                 """,
                 user_id,
-                day,
+                day.isoformat(),
             )
     except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS:
         logger.debug("increment_jobs_started failed")

--- a/tldw_Server_API/app/core/UserProfiles/overrides_repo.py
+++ b/tldw_Server_API/app/core/UserProfiles/overrides_repo.py
@@ -335,7 +335,7 @@ class OrgProfileOverridesRepo:
                     WHERE org_id = ANY($1)
                     ORDER BY org_id, key
                     """,
-                    org_ids,
+                    (org_ids,),
                 )
                 return [self._row_to_dict(dict(r)) for r in rows]
 
@@ -448,7 +448,7 @@ class OrgProfileOverridesRepo:
             if getattr(self.db_pool, "pool", None) is not None:
                 row = await self.db_pool.fetchone(
                     "SELECT MAX(updated_at) AS updated_at FROM public.org_config_overrides WHERE org_id = ANY($1)",
-                    org_ids,
+                    (org_ids,),
                 )
                 return row.get("updated_at") if row else None
 
@@ -533,7 +533,7 @@ class TeamProfileOverridesRepo:
                     WHERE team_id = ANY($1)
                     ORDER BY team_id, key
                     """,
-                    team_ids,
+                    (team_ids,),
                 )
                 return [self._row_to_dict(dict(r)) for r in rows]
 
@@ -646,7 +646,7 @@ class TeamProfileOverridesRepo:
             if getattr(self.db_pool, "pool", None) is not None:
                 row = await self.db_pool.fetchone(
                     "SELECT MAX(updated_at) AS updated_at FROM public.team_config_overrides WHERE team_id = ANY($1)",
-                    team_ids,
+                    (team_ids,),
                 )
                 return row.get("updated_at") if row else None
 

--- a/tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_audio_quota_dates_postgres.py
@@ -1,0 +1,143 @@
+"""Exercise audio quota DATE parameters through a real PostgreSQL backend."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def audio_postgres(isolated_test_environment, monkeypatch):
+    """Use the standard isolated database and a stable UTC quota day."""
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    client, _db_name = isolated_test_environment
+    pool = await get_db_pool()
+    await audio_quota._ensure_tables(pool)
+    monkeypatch.setattr(
+        audio_quota,
+        "datetime",
+        SimpleNamespace(now=lambda _tz: datetime(2026, 9, 10, 12, tzinfo=timezone.utc)),
+    )
+    monkeypatch.setattr(audio_quota, "_audio_minutes_legacy_backfill_done", False)
+    return client, pool
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("minutes_used", [None, 2.5], ids=["no-usage", "existing-usage"])
+async def test_postgres_full_profile_reports_current_day_audio_usage(audio_postgres, minutes_used) -> None:
+    """The default profile must include real audio quotas without a DATE encoding error."""
+    from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
+
+    client, pool = audio_postgres
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        user_id = await connection.fetchval(
+            """
+            INSERT INTO users (uuid, username, email, password_hash, is_active, is_verified)
+            VALUES ($1, 'audio-profile', 'audio-profile@example.test', $2, TRUE, TRUE)
+            RETURNING id
+            """,
+            uuid.uuid4(),
+            PasswordService().hash_password("AudioProfile@Test2026!"),
+        )
+    finally:
+        await connection.close()
+    await pool.execute(
+        """
+        INSERT INTO audio_usage_daily (user_id, day, minutes_used)
+        VALUES ($1, DATE '2026-09-09', 9.0)
+        """,
+        user_id,
+    )
+    if minutes_used is not None:
+        await pool.execute(
+            """
+            INSERT INTO audio_usage_daily (user_id, day, minutes_used)
+            VALUES ($1, DATE '2026-09-10', $2)
+            """,
+            user_id,
+            minutes_used,
+        )
+
+    login = client.post(
+        "/api/v1/auth/login",
+        data={
+            "username": "audio-profile",
+            "password": "AudioProfile@Test2026!",  # nosec B105
+        },
+    )
+    assert login.status_code == 200
+    response = client.get(
+        "/api/v1/users/me/profile",
+        headers={"Authorization": f"Bearer {login.json()['access_token']}"},
+    )
+
+    assert response.status_code == 200
+    audio = response.json()["quotas"]["audio"]
+    assert audio["daily_minutes_used"] == (0.0 if minutes_used is None else 2.5)
+    assert audio["daily_minutes_remaining"] == (30.0 if minutes_used is None else 27.5)
+
+
+@pytest.mark.asyncio
+async def test_postgres_audio_jobs_increment_current_day_without_replacing_minutes(audio_postgres) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    _client, pool = audio_postgres
+    await pool.execute(
+        """
+        INSERT INTO audio_usage_daily (user_id, day, minutes_used, jobs_started)
+        VALUES (7, DATE '2026-09-09', 9.0, 4)
+        """
+    )
+
+    await audio_quota.increment_jobs_started(7)
+    await pool.execute("UPDATE audio_usage_daily SET minutes_used = 2.5 WHERE user_id = 7 AND day = DATE '2026-09-10'")
+    await audio_quota.increment_jobs_started(7)
+
+    rows = await pool.fetch(
+        "SELECT day, minutes_used, jobs_started FROM audio_usage_daily WHERE user_id = 7 ORDER BY day"
+    )
+    assert rows == [
+        {"day": date(2026, 9, 9), "minutes_used": 9.0, "jobs_started": 4},
+        {"day": date(2026, 9, 10), "minutes_used": 2.5, "jobs_started": 2},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_postgres_legacy_audio_backfill_preserves_current_day_usage_once(audio_postgres, monkeypatch) -> None:
+    from tldw_Server_API.app.core.DB_Management.Resource_Daily_Ledger import ResourceDailyLedger
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    _client, pool = audio_postgres
+    await pool.execute(
+        """
+        INSERT INTO audio_usage_daily (user_id, day, minutes_used)
+        VALUES (7, DATE '2026-09-09', 9.0), (7, DATE '2026-09-10', 2.5), (8, DATE '2026-09-10', 0.0)
+        """
+    )
+    ledger = ResourceDailyLedger(db_pool=pool)
+    await ledger.initialize()
+
+    await audio_quota._backfill_audio_usage_daily_to_ledger(ledger)
+    # A new process retries the backfill; the existing operation id prevents double counting.
+    monkeypatch.setattr(audio_quota, "_audio_minutes_legacy_backfill_done", False)
+    await audio_quota._backfill_audio_usage_daily_to_ledger(ledger)
+
+    rows = await pool.fetch("SELECT day_utc, entity_value, units, op_id FROM resource_daily_ledger")
+    assert rows == [
+        {
+            "day_utc": date(2026, 9, 10),
+            "entity_value": "7",
+            "units": 150,
+            "op_id": "audio-minutes-legacy:7:2026-09-10",
+        }
+    ]

--- a/tldw_Server_API/tests/AuthNZ/integration/test_authnz_session_schema_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_authnz_session_schema_postgres.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import asyncpg
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_user(connection: asyncpg.Connection, username: str) -> int:
+    return int(
+        await connection.fetchval(
+            """
+            INSERT INTO users (uuid, username, email, password_hash)
+            VALUES ($1, $2, $3, 'hash')
+            RETURNING id
+            """,
+            uuid.uuid4(),
+            username,
+            f"{username}@example.test",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_production_bootstrap_creates_usable_session_activity_schema(
+    isolated_test_environment,
+) -> None:
+    _client, _db_name = isolated_test_environment
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_authnz_core_tables_pg,
+    )
+    from tldw_Server_API.app.core.AuthNZ.repos.sessions_repo import AuthnzSessionsRepo
+
+    pool = await get_db_pool()
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        await connection.execute("DROP TABLE sessions")
+    finally:
+        await connection.close()
+
+    assert await ensure_authnz_core_tables_pg(pool) is True
+
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        user_id = await _seed_user(connection, "session-bootstrap-user")
+        column = await connection.fetchrow(
+            """
+            SELECT data_type, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'sessions'
+              AND column_name = 'last_activity'
+            """
+        )
+    finally:
+        await connection.close()
+
+    assert column is not None
+    assert column["data_type"] == "timestamp without time zone"
+    assert column["column_default"] is not None
+
+    repo = AuthnzSessionsRepo(pool)
+    now = datetime.now(timezone.utc)
+    session_id = await repo.create_session_record(
+        user_id=user_id,
+        token_hash="bootstrap-access",
+        refresh_token_hash="bootstrap-refresh",
+        encrypted_token="encrypted-access",
+        encrypted_refresh="encrypted-refresh",
+        expires_at=now + timedelta(hours=1),
+        refresh_expires_at=now + timedelta(days=1),
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        device_id="bootstrap-device",
+        access_jti="bootstrap-access-jti",
+        refresh_jti="bootstrap-refresh-jti",
+    )
+
+    sessions = await repo.get_active_sessions_for_user(user_id)
+    assert [session["id"] for session in sessions] == [session_id]
+    assert sessions[0]["last_activity"] is not None
+
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        old_activity = datetime(2000, 1, 1)
+        await connection.execute(
+            "UPDATE sessions SET last_activity = $1 WHERE id = $2",
+            old_activity,
+            session_id,
+        )
+    finally:
+        await connection.close()
+
+    await repo.update_last_activity(session_id)
+    touched_activity = await pool.fetchval(
+        "SELECT last_activity FROM sessions WHERE id = ?",
+        session_id,
+    )
+    assert touched_activity > old_activity
+
+    refreshed = await repo.update_session_tokens_for_refresh(
+        session_id=session_id,
+        expected_access_hash="bootstrap-access",
+        expected_refresh_hash="bootstrap-refresh",
+        new_access_hash="bootstrap-access-new",
+        access_jti="bootstrap-access-jti-new",
+        expires_at=now + timedelta(hours=2),
+        encrypted_access_token="encrypted-access-new",
+        refresh_hash_update="bootstrap-refresh-new",
+        refresh_jti="bootstrap-refresh-jti-new",
+        refresh_expires_at=now + timedelta(days=2),
+        encrypted_refresh_token="encrypted-refresh-new",
+    )
+    assert refreshed is True
+    assert (
+        await pool.fetchval(
+            "SELECT last_activity FROM sessions WHERE id = ?",
+            session_id,
+        )
+        >= touched_activity
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_production_bootstrap_backfills_legacy_session_rows_idempotently(
+    isolated_test_environment,
+) -> None:
+    _client, _db_name = isolated_test_environment
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_authnz_core_tables_pg,
+    )
+
+    pool = await get_db_pool()
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        await connection.execute("DROP TABLE sessions")
+        await connection.execute(
+            """
+            CREATE TABLE sessions (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                token_hash VARCHAR(64) NOT NULL,
+                expires_at TIMESTAMP NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        user_id = await _seed_user(connection, "session-upgrade-user")
+        session_id = int(
+            await connection.fetchval(
+                """
+                INSERT INTO sessions (user_id, token_hash, expires_at, created_at)
+                VALUES ($1, 'legacy-access', '2030-01-01 00:00:00',
+                        '2025-02-03 04:05:06')
+                RETURNING id
+                """,
+                user_id,
+            )
+        )
+    finally:
+        await connection.close()
+
+    assert await ensure_authnz_core_tables_pg(pool) is True
+
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        backfilled = await connection.fetchval(
+            "SELECT last_activity FROM sessions WHERE id = $1",
+            session_id,
+        )
+        preserved = datetime(2025, 6, 7, 8, 9, 10)
+        await connection.execute(
+            "UPDATE sessions SET last_activity = $1 WHERE id = $2",
+            preserved,
+            session_id,
+        )
+    finally:
+        await connection.close()
+
+    assert backfilled == datetime(2025, 2, 3, 4, 5, 6)
+    assert await ensure_authnz_core_tables_pg(pool) is True
+    assert (
+        await pool.fetchval(
+            "SELECT last_activity FROM sessions WHERE id = ?",
+            session_id,
+        )
+        == preserved
+    )

--- a/tldw_Server_API/tests/AuthNZ/integration/test_authnz_session_schema_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_authnz_session_schema_postgres.py
@@ -1,3 +1,5 @@
+"""Verify production PostgreSQL bootstrap creates and upgrades session activity storage."""
+
 from __future__ import annotations
 
 import uuid
@@ -5,11 +7,13 @@ from datetime import datetime, timedelta, timezone
 
 import asyncpg
 import pytest
+from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.integration
 
 
 async def _seed_user(connection: asyncpg.Connection, username: str) -> int:
+    """Insert a user for session schema checks in the fixture's isolated database."""
     return int(
         await connection.fetchval(
             """
@@ -26,8 +30,9 @@ async def _seed_user(connection: asyncpg.Connection, username: str) -> int:
 
 @pytest.mark.asyncio
 async def test_postgres_production_bootstrap_creates_usable_session_activity_schema(
-    isolated_test_environment,
+    isolated_test_environment: tuple[TestClient, str],
 ) -> None:
+    """Fresh session tables support activity reads, touches, and token refreshes."""
     _client, _db_name = isolated_test_environment
 
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -128,8 +133,9 @@ async def test_postgres_production_bootstrap_creates_usable_session_activity_sch
 
 @pytest.mark.asyncio
 async def test_postgres_production_bootstrap_backfills_legacy_session_rows_idempotently(
-    isolated_test_environment,
+    isolated_test_environment: tuple[TestClient, str],
 ) -> None:
+    """Repeated bootstrap backfills missing activity without replacing existing values."""
     _client, _db_name = isolated_test_environment
 
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool

--- a/tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py
@@ -1,53 +1,40 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-import uuid
 
 import pytest
 
 from tldw_Server_API.app.core.AuthNZ.repos.sessions_repo import AuthnzSessionsRepo
-
+from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.asyncio
-async def test_authnz_sessions_repo_validation_and_refresh_postgres(test_db_pool):
-    """AuthnzSessionsRepo validation/refresh helpers should work on Postgres."""
-    pool = test_db_pool
-
-    # Seed a user row for FK
-    created_at = datetime.utcnow().replace(microsecond=0)
-    async with pool.acquire() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (
-                uuid,
-                username,
-                email,
-                password_hash,
-                role,
-                is_active,
-                is_verified,
-                storage_quota_mb,
-                storage_used_mb,
-                created_at
-            )
-            VALUES ($1, $2, $3, $4, $5, TRUE, TRUE, 5120, 0.0, $6)
-            """,
-            str(uuid.uuid4()),
-            "pg_sessions_user",
-            "pg_sessions_user@example.com",
-            "x",
-            "user",
-            created_at,
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = $1",
-        "pg_sessions_user",
+async def _create_user(pool, username: str) -> int:
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+    created = await users_db.create_user(
+        username=username,
+        email=f"{username}@example.test",
+        password_hash="hash",
+        role="user",
+        is_active=True,
+        is_superuser=False,
+        storage_quota_mb=5120,
     )
-    assert user_id is not None
+    return int(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_authnz_sessions_repo_validation_and_refresh_postgres(
+    isolated_test_environment,
+):
+    """AuthnzSessionsRepo validation/refresh helpers should work on Postgres."""
+    _client, _db_name = isolated_test_environment
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+    pool = await get_db_pool()
+    user_id = await _create_user(pool, "pg_sessions_user")
 
     repo = AuthnzSessionsRepo(pool)
 
@@ -57,7 +44,7 @@ async def test_authnz_sessions_repo_validation_and_refresh_postgres(test_db_pool
 
     # Create a session record with known hashes
     session_id = await repo.create_session_record(
-        user_id=int(user_id),
+        user_id=user_id,
         token_hash="hash-access",
         refresh_token_hash="hash-refresh",
         encrypted_token="enc-access",
@@ -76,7 +63,7 @@ async def test_authnz_sessions_repo_validation_and_refresh_postgres(test_db_pool
     by_id = await repo.fetch_session_for_validation_by_id(session_id)
     assert by_id is not None
     assert by_id["id"] == session_id
-    assert by_id["user_id"] == int(user_id)
+    assert by_id["user_id"] == user_id
     assert bool(by_id["user_active"]) is True
 
     by_hash = await repo.fetch_session_for_validation_by_token_hash("hash-access")
@@ -87,12 +74,10 @@ async def test_authnz_sessions_repo_validation_and_refresh_postgres(test_db_pool
     assert missing is None
 
     # Refresh helpers: find by refresh hash candidates and update tokens
-    found = await repo.find_active_session_by_refresh_hash_candidates(
-        ["does-not-exist", "hash-refresh"]
-    )
+    found = await repo.find_active_session_by_refresh_hash_candidates(["does-not-exist", "hash-refresh"])
     assert found is not None
     assert found["id"] == session_id
-    assert found["user_id"] == int(user_id)
+    assert found["user_id"] == user_id
     assert found["token_hash"] == "hash-access"
     assert found["refresh_token_hash"] == "hash-refresh"
 
@@ -150,42 +135,15 @@ async def test_authnz_sessions_repo_validation_and_refresh_postgres(test_db_pool
 
 
 @pytest.mark.asyncio
-async def test_authnz_sessions_repo_bulk_revocation_postgres(test_db_pool):
+async def test_authnz_sessions_repo_bulk_revocation_postgres(
+    isolated_test_environment,
+):
     """AuthnzSessionsRepo bulk revocation helpers should work on Postgres."""
-    pool = test_db_pool
+    _client, _db_name = isolated_test_environment
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 
-    # Seed a user row for FK
-    created_at = datetime.utcnow().replace(microsecond=0)
-    async with pool.acquire() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (
-                uuid,
-                username,
-                email,
-                password_hash,
-                role,
-                is_active,
-                is_verified,
-                storage_quota_mb,
-                storage_used_mb,
-                created_at
-            )
-            VALUES ($1, $2, $3, $4, $5, TRUE, TRUE, 5120, 0.0, $6)
-            """,
-            str(uuid.uuid4()),
-            "pg_sessions_bulk_user",
-            "pg_sessions_bulk_user@example.com",
-            "x",
-            "user",
-            created_at,
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = $1",
-        "pg_sessions_bulk_user",
-    )
-    assert user_id is not None
+    pool = await get_db_pool()
+    user_id = await _create_user(pool, "pg_sessions_bulk_user")
 
     repo = AuthnzSessionsRepo(pool)
 
@@ -195,7 +153,7 @@ async def test_authnz_sessions_repo_bulk_revocation_postgres(test_db_pool):
 
     for idx in range(2):
         await repo.create_session_record(
-            user_id=int(user_id),
+            user_id=user_id,
             token_hash=f"hash-access-bulk-{idx}",
             refresh_token_hash=f"hash-refresh-bulk-{idx}",
             encrypted_token=f"enc-access-bulk-{idx}",
@@ -209,12 +167,12 @@ async def test_authnz_sessions_repo_bulk_revocation_postgres(test_db_pool):
             refresh_jti=f"refresh-jti-bulk-{idx}",
         )
 
-    sessions = await repo.fetch_session_token_metadata_for_user(int(user_id))
+    sessions = await repo.fetch_session_token_metadata_for_user(user_id)
     assert len(sessions) >= 2
 
     affected = await repo.mark_sessions_revoked_for_user_with_audit(
-        user_id=int(user_id),
-        revoked_by=int(user_id),
+        user_id=user_id,
+        revoked_by=user_id,
         reason="bulk-logout",
     )
     assert affected >= 2
@@ -225,7 +183,7 @@ async def test_authnz_sessions_repo_bulk_revocation_postgres(test_db_pool):
         FROM sessions
         WHERE user_id = $1
         """,
-        int(user_id),
+        user_id,
     )
     assert rows
     for row in rows:
@@ -235,5 +193,5 @@ async def test_authnz_sessions_repo_bulk_revocation_postgres(test_db_pool):
         revoke_reason = row["revoke_reason"]
         assert not bool(is_active)
         assert bool(is_revoked)
-        assert revoked_by == int(user_id)
+        assert revoked_by == user_id
         assert revoke_reason == "bulk-logout"

--- a/tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py
@@ -1,16 +1,21 @@
+"""Exercise session validation, refresh, and revocation against isolated PostgreSQL."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 from tldw_Server_API.app.core.AuthNZ.repos.sessions_repo import AuthnzSessionsRepo
 from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
 
 pytestmark = pytest.mark.integration
 
 
-async def _create_user(pool, username: str) -> int:
+async def _create_user(pool: DatabasePool, username: str) -> int:
+    """Create the user that owns the session records under test."""
     users_db = UsersDB(pool)
     await users_db.initialize()
     created = await users_db.create_user(
@@ -27,8 +32,8 @@ async def _create_user(pool, username: str) -> int:
 
 @pytest.mark.asyncio
 async def test_authnz_sessions_repo_validation_and_refresh_postgres(
-    isolated_test_environment,
-):
+    isolated_test_environment: tuple[TestClient, str],
+) -> None:
     """AuthnzSessionsRepo validation/refresh helpers should work on Postgres."""
     _client, _db_name = isolated_test_environment
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -136,8 +141,8 @@ async def test_authnz_sessions_repo_validation_and_refresh_postgres(
 
 @pytest.mark.asyncio
 async def test_authnz_sessions_repo_bulk_revocation_postgres(
-    isolated_test_environment,
-):
+    isolated_test_environment: tuple[TestClient, str],
+) -> None:
     """AuthnzSessionsRepo bulk revocation helpers should work on Postgres."""
     _client, _db_name = isolated_test_environment
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool

--- a/tldw_Server_API/tests/AuthNZ/integration/test_profile_array_parameters_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_profile_array_parameters_postgres.py
@@ -1,0 +1,120 @@
+"""Exercise profile-related array queries with the real PostgreSQL driver."""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import ensure_authnz_core_tables_pg
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import ManagedSecretRefsRepo
+from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+from tldw_Server_API.app.core.AuthNZ.settings import Settings
+from tldw_Server_API.app.core.UserProfiles.overrides_repo import (
+    OrgProfileOverridesRepo,
+    TeamProfileOverridesRepo,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def profile_array_pool(isolated_test_environment):
+    """Use the standard isolated database and production schema bootstrap."""
+    pool = DatabasePool(Settings(DATABASE_URL=os.environ["TEST_DATABASE_URL"]))
+    await pool.initialize()
+    try:
+        assert await ensure_authnz_core_tables_pg(pool)
+        yield pool
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_profile_override_membership_arrays_postgres(profile_array_pool):
+    pool = profile_array_pool
+    org_repo = OrgProfileOverridesRepo(pool)
+    team_repo = TeamProfileOverridesRepo(pool)
+    org_ids = [
+        await pool.fetchval("INSERT INTO organizations (name) VALUES ($1) RETURNING id", name)
+        for name in ("array-org-one", "array-org-two", "array-org-unrelated")
+    ]
+    team_ids = [
+        await pool.fetchval(
+            "INSERT INTO teams (org_id, name) VALUES ($1, $2) RETURNING id",
+            org_id,
+            "array-team",
+        )
+        for org_id in org_ids
+    ]
+    for org_id, team_id in zip(org_ids, team_ids):
+        await org_repo.upsert_override(org_id=org_id, key="theme", value="dark", updated_by=None)
+        await team_repo.upsert_override(team_id=team_id, key="theme", value="light", updated_by=None)
+
+    assert await org_repo.list_overrides_for_orgs([]) == []
+    assert await team_repo.get_latest_update_for_teams([]) is None
+    for size in (1, 2):
+        organizations = await org_repo.list_overrides_for_orgs(org_ids[:size])
+        teams = await team_repo.list_overrides_for_teams(team_ids[:size])
+        assert [row["org_id"] for row in organizations] == org_ids[:size]
+        assert [row["team_id"] for row in teams] == team_ids[:size]
+        assert await org_repo.get_latest_update_for_orgs(org_ids[:size]) == max(
+            row["updated_at"] for row in organizations
+        )
+        assert await team_repo.get_latest_update_for_teams(team_ids[:size]) == max(row["updated_at"] for row in teams)
+
+
+@pytest.mark.asyncio
+async def test_scoped_user_and_organization_counts_postgres(profile_array_pool):
+    pool = profile_array_pool
+    # Seed through an unmanaged fixture connection; production users writes have
+    # a separate ownership guard and are not part of this read/binding regression.
+    connection = await asyncpg.connect(os.environ["TEST_DATABASE_URL"])
+    try:
+        user_id = await connection.fetchval(
+            "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id",
+            "array-count-user",
+            "array-count-user@example.test",
+            "fixture-password-hash",
+        )
+    finally:
+        await connection.close()
+    org_id = await pool.fetchval("INSERT INTO organizations (name) VALUES ($1) RETURNING id", "scoped-org")
+    await pool.execute("INSERT INTO org_members (org_id, user_id) VALUES ($1, $2)", org_id, user_id)
+
+    organizations, org_total = await AuthnzOrgsTeamsRepo(pool).list_organizations(org_ids=[org_id], with_total=True)
+    users, user_total = await AuthnzUsersRepo(pool).list_users(org_ids=[org_id], limit=10, offset=0)
+
+    assert ([row["id"] for row in organizations], org_total) == ([org_id], 1)
+    assert ([row["id"] for row in users], user_total) == ([user_id], 1)
+
+
+@pytest.mark.asyncio
+async def test_managed_secret_reference_arrays_postgres(profile_array_pool):
+    repo = ManagedSecretRefsRepo(profile_array_pool)
+    await repo.ensure_tables()
+    await repo.ensure_backend_registration(name="array-test", display_name="Array test")
+    first = await repo.upsert_ref(
+        backend_name="array-test",
+        owner_scope_type="user",
+        owner_scope_id=71,
+        provider_key="openai",
+        backend_ref="test/first",
+        metadata=None,
+    )
+    second = await repo.upsert_ref(
+        backend_name="array-test",
+        owner_scope_type="user",
+        owner_scope_id=72,
+        provider_key="openai",
+        backend_ref="test/second",
+        metadata=None,
+    )
+
+    assert await repo.list_refs_by_ids([]) == {}
+    assert set(await repo.list_refs_by_ids([first["id"]])) == {first["id"]}
+    assert set(await repo.list_refs_by_ids([first["id"], second["id"]])) == {first["id"], second["id"]}

--- a/tldw_Server_API/tests/AuthNZ/integration/test_rbac_auth_event_loop_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_rbac_auth_event_loop_postgres.py
@@ -1,0 +1,162 @@
+"""A contended RBAC query must not block the async authentication event loop."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import uuid
+
+import asyncpg
+import psycopg
+import pytest
+from psycopg import sql
+from starlette.requests import Request
+
+pytestmark = pytest.mark.integration
+
+
+def _hold_rbac_lock_until_event_loop_progress(
+    database_url: str,
+    table: str,
+    lock_acquired: threading.Event,
+    query_blocked: threading.Event,
+    event_loop_progress: threading.Event,
+    stop: threading.Event,
+) -> bool:
+    """Release a real table lock even when the regression blocks the event loop."""
+    options = {"connect_timeout": 5, "options": "-c statement_timeout=5000 -c lock_timeout=3000"}
+    query_fragment = "%COALESCE(r.is_system%" if table == "roles" else "%JOIN role_permissions rp%"
+    with psycopg.connect(database_url, autocommit=True, **options) as blocker:
+        with psycopg.connect(database_url, autocommit=True, **options) as monitor:
+            blocker.execute("BEGIN")
+            try:
+                blocker.execute(sql.SQL("LOCK TABLE {} IN ACCESS EXCLUSIVE MODE").format(sql.Identifier(table)))
+                blocker_pid = blocker.info.backend_pid
+                lock_acquired.set()
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline and not stop.is_set():
+                    waiting = monitor.execute(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM pg_stat_activity
+                            WHERE datname = current_database()
+                              AND wait_event_type = 'Lock'
+                              AND %s = ANY(pg_blocking_pids(pid))
+                              AND query LIKE %s
+                        )
+                        """,
+                        (blocker_pid, query_fragment),
+                    ).fetchone()[0]
+                    if waiting:
+                        query_blocked.set()
+                        # An independent thread is the watchdog: a blocked loop cannot
+                        # prevent rollback, even when asyncio timeouts cannot fire.
+                        return event_loop_progress.wait(timeout=2)
+                    stop.wait(timeout=0.01)
+                raise AssertionError("Authentication did not reach the contended RBAC query")
+            finally:
+                blocker.execute("ROLLBACK")
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("auth_kind", ["jwt", "api-key"])
+@pytest.mark.parametrize("locked_table", ["roles", "permissions"])
+async def test_postgres_authentication_allows_event_loop_progress_during_rbac_lock(
+    isolated_test_environment,
+    auth_kind: str,
+    locked_table: str,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ import User_DB_Handling as user_handling
+    from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
+
+    _client, _db_name = isolated_test_environment
+    pool = await get_db_pool()
+    connection = await asyncpg.connect(pool.settings.DATABASE_URL)
+    try:
+        user_id = await connection.fetchval(
+            """
+            INSERT INTO users (uuid, username, email, password_hash, is_active, is_verified)
+            VALUES ($1, 'rbac-progress', 'rbac-progress@example.test', 'unused-test-hash', TRUE, TRUE)
+            RETURNING id
+            """,
+            uuid.uuid4(),
+        )
+        await connection.execute(
+            "INSERT INTO roles (name, is_system) VALUES ('admin', TRUE) ON CONFLICT (name) DO NOTHING"
+        )
+        await connection.execute("INSERT INTO permissions (name) VALUES ('media.read') ON CONFLICT (name) DO NOTHING")
+        await connection.execute(
+            """
+            INSERT INTO user_roles (user_id, role_id)
+            SELECT $1, id FROM roles WHERE name = 'admin'
+            """,
+            user_id,
+        )
+        await connection.execute(
+            """
+            INSERT INTO role_permissions (role_id, permission_id)
+            SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+            WHERE r.name = 'admin' AND p.name = 'media.read'
+            ON CONFLICT DO NOTHING
+            """
+        )
+    finally:
+        await connection.close()
+
+    if auth_kind == "jwt":
+        token = get_jwt_service().create_access_token(user_id, "rbac-progress", "admin")
+        api_key = None
+    else:
+        manager = await get_api_key_manager()
+        key_info = await manager.create_api_key(user_id, name="rbac-progress", scope="admin")
+        token = None
+        api_key = key_info["key"]
+
+    async def authenticate():
+        request = Request({"type": "http", "method": "GET", "path": "/test", "headers": [], "client": ("127.0.0.1", 0)})
+        return await user_handling.get_request_user(request, api_key=api_key, token=token)
+
+    # Initialize the actual synchronous repository before introducing contention.
+    # Each authentication uses a fresh request, so no resolved principal is reused.
+    await authenticate()
+    lock_acquired = threading.Event()
+    query_blocked = threading.Event()
+    event_loop_progress = threading.Event()
+    stop = threading.Event()
+    blocker = asyncio.create_task(
+        asyncio.to_thread(
+            _hold_rbac_lock_until_event_loop_progress,
+            pool.settings.DATABASE_URL,
+            locked_table,
+            lock_acquired,
+            query_blocked,
+            event_loop_progress,
+            stop,
+        )
+    )
+
+    async def probe_event_loop() -> None:
+        if await asyncio.to_thread(query_blocked.wait, 10):
+            event_loop_progress.set()
+
+    probe = asyncio.create_task(probe_event_loop())
+    try:
+        assert await asyncio.to_thread(lock_acquired.wait, 10), "RBAC lock was not acquired"
+        user = await asyncio.wait_for(authenticate(), timeout=15)
+    finally:
+        stop.set()
+        probe.cancel()
+        await asyncio.gather(probe, return_exceptions=True)
+        responsive = await asyncio.wait_for(blocker, timeout=15)
+
+    assert (
+        responsive
+    ), "Synchronous RBAC authentication prevented event-loop progress until the watchdog released the lock"
+    assert user.id == user_id
+    assert user.roles == ["admin"]
+    assert user.is_admin is True
+    assert {"media.read", "system.configure"} <= set(user.permissions)

--- a/tldw_Server_API/tests/AuthNZ/unit/test_db_config_concurrency.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_db_config_concurrency.py
@@ -1,0 +1,169 @@
+"""Concurrent public AuthNZ database lookups share one completed initialization."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, wait
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ import db_config
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+class _Database:
+    """Record the lifetime of a constructed database without opening external resources."""
+
+    def __init__(self, *, config, client_id: str) -> None:
+        self.config = config
+        self.client_id = client_id
+        self.closed = False
+        self.backend = SimpleNamespace(get_pool=lambda: self)
+
+    def close_all(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _cold_auth_database_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'users.db'}")
+    reset_settings()
+    monkeypatch.setattr(db_config.AuthDatabaseConfig, "_instance", None)
+    monkeypatch.setattr(db_config, "UserDatabase", _Database)
+    yield
+    if db_config.AuthDatabaseConfig._instance is not None:
+        db_config.AuthDatabaseConfig._instance.reset_lazy()
+    reset_settings()
+
+
+def test_concurrent_public_lookups_construct_one_database_and_reuse_it(monkeypatch) -> None:
+    # Configuration may already exist while its expensive database cache is cold.
+    db_config.AuthDatabaseConfig()
+    constructor_entered = threading.Event()
+    all_constructors_entered = threading.Event()
+    release_constructor = threading.Event()
+    created = []
+
+    def construct(**kwargs):
+        database = _Database(**kwargs)
+        created.append(database)
+        constructor_entered.set()
+        if len(created) == 4:
+            all_constructors_entered.set()
+        assert release_constructor.wait(timeout=5), "Constructor watchdog expired"
+        return database
+
+    monkeypatch.setattr(db_config, "UserDatabase", construct)
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(db_config.get_configured_user_database, f"caller-{index}") for index in range(4)]
+        try:
+            assert constructor_entered.wait(timeout=5)
+            # The broken getter admits every caller; the fixed getter admits only
+            # one constructor while the remaining callers wait for publication.
+            all_constructors_entered.wait(timeout=0.2)
+        finally:
+            release_constructor.set()
+        databases = [future.result(timeout=5) for future in futures]
+
+    assert len(created) == 1
+    assert all(database is databases[0] for database in databases)
+    assert db_config.get_configured_user_database("warm-caller") is databases[0]
+    assert len(created) == 1
+
+
+def test_concurrent_public_lookups_wait_for_backend_detection(monkeypatch) -> None:
+    detection_entered = threading.Event()
+    release_detection = threading.Event()
+    original_detect = db_config.AuthDatabaseConfig._detect_backend
+
+    def detect_backend(config):
+        detection_entered.set()
+        assert release_detection.wait(timeout=5), "Configuration watchdog expired"
+        original_detect(config)
+
+    monkeypatch.setattr(db_config.AuthDatabaseConfig, "_detect_backend", detect_backend)
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        first = executor.submit(db_config.get_configured_user_database, "first-caller")
+        try:
+            assert detection_entered.wait(timeout=5)
+            others = [executor.submit(db_config.get_configured_user_database, f"caller-{index}") for index in range(3)]
+            wait(others, timeout=0.2)
+        finally:
+            release_detection.set()
+        databases = [future.result(timeout=5) for future in [first, *others]]
+
+    assert all(database is databases[0] for database in databases)
+    assert databases[0].config.sqlite_path.endswith("users.db")
+
+
+def test_public_lookup_refreshes_config_after_interleaved_lazy_reset(monkeypatch, tmp_path) -> None:
+    config_resolved = threading.Event()
+    resume_lookup = threading.Event()
+    original_get_config = db_config.get_auth_db_config
+    config = original_get_config()
+    replacement_path = str((tmp_path / "replacement.db").resolve())
+
+    def get_config():
+        resolved = original_get_config()
+        config_resolved.set()
+        assert resume_lookup.wait(timeout=5), "Public lookup watchdog expired"
+        return resolved
+
+    monkeypatch.setattr(db_config, "get_auth_db_config", get_config)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        getter = executor.submit(db_config.get_configured_user_database, "racing-caller")
+        try:
+            assert config_resolved.wait(timeout=5)
+            monkeypatch.setenv("DATABASE_URL", f"sqlite:///{replacement_path}")
+            reset_settings()
+            config.reset_lazy()
+        finally:
+            resume_lookup.set()
+        database = getter.result(timeout=5)
+
+    later_database = db_config.get_configured_user_database("later-caller")
+    assert database.config.sqlite_path == replacement_path
+    assert later_database is database
+    assert later_database.config.sqlite_path == replacement_path
+
+
+@pytest.mark.parametrize("reset_method", ["reset", "reset_lazy"])
+def test_reset_during_database_initialization_closes_and_discards_the_created_database(
+    monkeypatch, reset_method
+) -> None:
+    config = db_config.AuthDatabaseConfig()
+    constructor_entered = threading.Event()
+    release_constructor = threading.Event()
+    reset_entered = threading.Event()
+    created = []
+
+    def construct(**kwargs):
+        database = _Database(**kwargs)
+        created.append(database)
+        constructor_entered.set()
+        assert release_constructor.wait(timeout=5), "Constructor watchdog expired"
+        return database
+
+    def reset():
+        reset_entered.set()
+        getattr(config, reset_method)()
+
+    monkeypatch.setattr(db_config, "UserDatabase", construct)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        getter = executor.submit(db_config.get_configured_user_database, "first-caller")
+        try:
+            assert constructor_entered.wait(timeout=5)
+            resetter = executor.submit(reset)
+            assert reset_entered.wait(timeout=5)
+            wait([resetter], timeout=0.2)
+        finally:
+            release_constructor.set()
+        first = getter.result(timeout=5)
+        resetter.result(timeout=5)
+
+    second = db_config.get_configured_user_database("after-reset")
+    assert first.closed is True
+    assert second is not first
+    assert len(created) == 2

--- a/tldw_Server_API/tests/AuthNZ/unit/test_profile_version_migration.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_profile_version_migration.py
@@ -252,9 +252,12 @@ def test_current_sqlite_schema_fails_startup_on_profile_metadata_drift(
         ensure_authnz_tables(db_path)
 
 
+@pytest.mark.parametrize("target_version", [91, None], ids=["profile-migration", "latest"])
 def test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys(
     tmp_path: Path,
+    target_version: int | None,
 ) -> None:
+    """Preserve custom schema through the profile rebuild and later upgrades."""
     db_path = tmp_path / "custom-schema.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
@@ -318,7 +321,10 @@ def test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys(
             """
         )
 
-    ensure_authnz_tables(db_path)
+    if target_version is None:
+        ensure_authnz_tables(db_path)
+    else:
+        apply_authnz_migrations(db_path, target_version=target_version)
 
     with sqlite3.connect(db_path) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
@@ -421,7 +427,7 @@ def test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys(
             "SELECT COUNT(*) FROM user_children WHERE user_id = 7"
         ).fetchone()[0]
 
-    assert columns == [
+    preserved_columns = [
         "id",
         "username",
         "email",
@@ -431,6 +437,8 @@ def test_sqlite_upgrade_preserves_custom_users_schema_objects_and_foreign_keys(
         "display_name",
         "profile_version",
     ]
+    # Later migrations may append columns without changing the preserved schema.
+    assert columns[: len(preserved_columns)] == preserved_columns
     assert row == (
         7,
         3,

--- a/tldw_Server_API/tests/AuthNZ/unit/test_session_schema_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_session_schema_migrations.py
@@ -1,6 +1,9 @@
+"""Check SQLite session activity defaults, legacy backfills, and repository writes."""
+
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -15,13 +18,17 @@ pytestmark = pytest.mark.unit
 
 
 class _SQLitePool:
+    """Expose the repository transaction interface over a test SQLite connection."""
+
     pool = None
 
     def __init__(self, connection: aiosqlite.Connection) -> None:
+        """Keep the caller-owned connection available for repository transactions."""
         self._connection = connection
 
     @asynccontextmanager
-    async def transaction(self):
+    async def transaction(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Commit successful repository writes and roll back failed transactions."""
         try:
             yield self._connection
             await self._connection.commit()
@@ -35,6 +42,7 @@ def _create_legacy_database(
     *,
     include_last_activity: bool,
 ) -> None:
+    """Build a version-97 database with an optional legacy activity column."""
     last_activity_column = ", last_activity TIMESTAMP" if include_last_activity else ""
     with sqlite3.connect(db_path) as conn:
         conn.execute(
@@ -93,6 +101,7 @@ def _create_legacy_database(
 
 
 def test_fresh_sqlite_sessions_have_last_activity_default(tmp_path: Path) -> None:
+    """New sessions receive a timestamp from the initial schema's activity default."""
     db_path = tmp_path / "fresh-sessions.db"
 
     apply_authnz_migrations(db_path, target_version=2)
@@ -118,6 +127,7 @@ def test_fresh_sqlite_sessions_have_last_activity_default(tmp_path: Path) -> Non
 def test_sqlite_session_upgrade_adds_and_backfills_last_activity(
     tmp_path: Path,
 ) -> None:
+    """The activity migration runs once and backfills from session creation time."""
     db_path = tmp_path / "legacy-sessions.db"
     _create_legacy_database(db_path, include_last_activity=False)
     with sqlite3.connect(db_path) as conn:
@@ -143,6 +153,7 @@ def test_sqlite_session_upgrade_adds_and_backfills_last_activity(
 def test_sqlite_session_upgrade_preserves_existing_activity_values(
     tmp_path: Path,
 ) -> None:
+    """An upgrade fills null activity values while preserving recorded activity."""
     db_path = tmp_path / "partial-sessions.db"
     _create_legacy_database(db_path, include_last_activity=True)
     with sqlite3.connect(db_path) as conn:
@@ -173,6 +184,7 @@ def test_sqlite_session_upgrade_preserves_existing_activity_values(
 async def test_sqlite_session_writer_initializes_activity_after_legacy_upgrade(
     tmp_path: Path,
 ) -> None:
+    """Repository writes initialize activity when an upgraded column has no default."""
     db_path = tmp_path / "upgraded-session-writer.db"
     _create_legacy_database(db_path, include_last_activity=False)
     apply_authnz_migrations(db_path)

--- a/tldw_Server_API/tests/AuthNZ/unit/test_session_schema_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_session_schema_migrations.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.migrations import apply_authnz_migrations
+from tldw_Server_API.app.core.AuthNZ.repos.sessions_repo import AuthnzSessionsRepo
+
+pytestmark = pytest.mark.unit
+
+
+class _SQLitePool:
+    pool = None
+
+    def __init__(self, connection: aiosqlite.Connection) -> None:
+        self._connection = connection
+
+    @asynccontextmanager
+    async def transaction(self):
+        try:
+            yield self._connection
+            await self._connection.commit()
+        except BaseException:
+            await self._connection.rollback()
+            raise
+
+
+def _create_legacy_database(
+    db_path: Path,
+    *,
+    include_last_activity: bool,
+) -> None:
+    last_activity_column = ", last_activity TIMESTAMP" if include_last_activity else ""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL,
+                email TEXT NOT NULL,
+                password_hash TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                token_hash TEXT NOT NULL,
+                refresh_token_hash TEXT,
+                encrypted_token TEXT,
+                encrypted_refresh TEXT,
+                expires_at TIMESTAMP NOT NULL,
+                refresh_expires_at TIMESTAMP,
+                ip_address TEXT,
+                user_agent TEXT,
+                device_id TEXT,
+                is_active INTEGER DEFAULT 1,
+                is_revoked INTEGER DEFAULT 0,
+                revoked_at TIMESTAMP,
+                revoked_by INTEGER,
+                revoke_reason TEXT,
+                access_jti TEXT,
+                refresh_jti TEXT,
+                created_at TIMESTAMP
+                {last_activity_column}
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users (id, username, email, password_hash) "
+            "VALUES (1, 'legacy', 'legacy@example.test', 'hash')"
+        )
+        conn.execute(
+            """
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at TIMESTAMP NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations (version, name, applied_at) "
+            "VALUES (97, 'legacy current', CURRENT_TIMESTAMP)"
+        )
+
+
+def test_fresh_sqlite_sessions_have_last_activity_default(tmp_path: Path) -> None:
+    db_path = tmp_path / "fresh-sessions.db"
+
+    apply_authnz_migrations(db_path, target_version=2)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1]: row for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+        conn.execute(
+            "INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)",
+            ("fresh", "fresh@example.test", "hash"),
+        )
+        user_id = int(conn.execute("SELECT id FROM users").fetchone()[0])
+        conn.execute(
+            "INSERT INTO sessions (user_id, token_hash, expires_at) VALUES (?, ?, ?)",
+            (user_id, "fresh-token", "2030-01-01 00:00:00"),
+        )
+        activity = conn.execute("SELECT last_activity FROM sessions").fetchone()[0]
+
+    assert columns["last_activity"][2].upper() == "TIMESTAMP"
+    assert "CURRENT_TIMESTAMP" in columns["last_activity"][4].upper()
+    assert activity is not None
+
+
+def test_sqlite_session_upgrade_adds_and_backfills_last_activity(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "legacy-sessions.db"
+    _create_legacy_database(db_path, include_last_activity=False)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at)
+            VALUES (1, 1, 'legacy-token', '2030-01-01 00:00:00',
+                    '2025-02-03 04:05:06')
+            """
+        )
+
+    apply_authnz_migrations(db_path)
+    apply_authnz_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        activity = conn.execute("SELECT last_activity FROM sessions WHERE id = 1").fetchone()[0]
+        migration_count = conn.execute("SELECT COUNT(*) FROM schema_migrations WHERE version = 98").fetchone()[0]
+
+    assert activity == "2025-02-03 04:05:06"
+    assert migration_count == 1
+
+
+def test_sqlite_session_upgrade_preserves_existing_activity_values(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "partial-sessions.db"
+    _create_legacy_database(db_path, include_last_activity=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO sessions (
+                id, user_id, token_hash, expires_at, created_at, last_activity
+            ) VALUES (?, 1, ?, '2030-01-01 00:00:00', ?, ?)
+            """,
+            (
+                (1, "preserved-token", "2025-01-01 00:00:00", "2025-06-01 00:00:00"),
+                (2, "backfilled-token", "2025-02-01 00:00:00", None),
+            ),
+        )
+
+    apply_authnz_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, last_activity FROM sessions ORDER BY id").fetchall()
+
+    assert rows == [
+        (1, "2025-06-01 00:00:00"),
+        (2, "2025-02-01 00:00:00"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_writer_initializes_activity_after_legacy_upgrade(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "upgraded-session-writer.db"
+    _create_legacy_database(db_path, include_last_activity=False)
+    apply_authnz_migrations(db_path)
+
+    connection = await aiosqlite.connect(db_path)
+    try:
+        repo = AuthnzSessionsRepo(_SQLitePool(connection))
+        now = datetime.now(timezone.utc)
+        session_id = await repo.create_session_record(
+            user_id=1,
+            token_hash="upgraded-access",
+            refresh_token_hash="upgraded-refresh",
+            encrypted_token="encrypted-access",
+            encrypted_refresh="encrypted-refresh",
+            expires_at=now + timedelta(hours=1),
+            refresh_expires_at=now + timedelta(days=1),
+            ip_address="127.0.0.1",
+            user_agent="pytest",
+            device_id="upgraded-device",
+            access_jti="upgraded-access-jti",
+            refresh_jti="upgraded-refresh-jti",
+        )
+        row = await (
+            await connection.execute(
+                "SELECT last_activity FROM sessions WHERE id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+    finally:
+        await connection.close()
+
+    assert row is not None
+    assert row[0] is not None

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -1041,14 +1041,20 @@ def test_full_suite_splits_slow_chat_and_retrieval_shards() -> None:
         }
         assert shard_path_sets["media-core-api"] == {
             "tldw_Server_API/tests/Media/test_archive_member_cap.py",
+            "tldw_Server_API/tests/Media/test_audio_summary_service_prompt.py",
             "tldw_Server_API/tests/Media/test_auto_chunking_process_endpoints.py",
             "tldw_Server_API/tests/Media/test_cache_index.py",
+            "tldw_Server_API/tests/Media/test_ebook_summary_service_prompt.py",
+            "tldw_Server_API/tests/Media/test_email_summary_service_prompt.py",
             "tldw_Server_API/tests/Media/test_ingest_web_content_endpoint_sanitization.py",
             "tldw_Server_API/tests/Media/test_json_*.py",
             "tldw_Server_API/tests/Media/test_media_*.py",
             "tldw_Server_API/tests/Media/test_navigation_policy_contract.py",
+            "tldw_Server_API/tests/Media/test_pdf_summary_service_prompt.py",
             "tldw_Server_API/tests/Media/test_process_code_and_uploads.py",
             "tldw_Server_API/tests/Media/test_upload_sink_security.py",
+            "tldw_Server_API/tests/Media/test_video_summary_service_prompt.py",
+            "tldw_Server_API/tests/Media/test_web_summary_service_prompt.py",
             "tldw_Server_API/tests/Media/unit",
         }
         assert shard_path_sets["media-ingestion-new-ocr"] == {
@@ -1073,6 +1079,7 @@ def test_full_suite_splits_slow_chat_and_retrieval_shards() -> None:
             "tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest*.py",
             "tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py",
             "tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py",
+            "tldw_Server_API/tests/MediaIngestion_NEW/unit/test_original_file_replacement.py",
             "tldw_Server_API/tests/MediaIngestion_NEW/unit/test_research_discovery_handoff.py",
         }
         assert shard_path_sets["media-ingestion-new-unit-mediawiki"] == {
@@ -1393,6 +1400,7 @@ def test_full_suite_splits_slow_chat_and_retrieval_shards() -> None:
         # a feature directory rather than a DB-specific one).
         auth_db_extra_files = {
             "tldw_Server_API/tests/Media_DB/test_media_clone_snapshot_repository.py",
+            "tldw_Server_API/tests/Workspaces/test_workspace_assistant_creation.py",
             "tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py",
             "tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py",
             "tldw_Server_API/tests/Workspaces/test_workspace_clone_target_lifecycle.py",

--- a/tldw_Server_API/tests/Chat/integration/test_chat_endpoint_simplified.py
+++ b/tldw_Server_API/tests/Chat/integration/test_chat_endpoint_simplified.py
@@ -7,6 +7,7 @@ import json
 import os
 import sqlite3
 import threading
+from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
 from contextvars import ContextVar
@@ -16,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
 from loguru import logger
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
@@ -48,6 +50,7 @@ from tldw_Server_API.app.core.Chat.Chat_Deps import (
     ChatProviderError,
 )
 from tldw_Server_API.app.core.Chat.streaming_utils import StreamingResponseHandler
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.exceptions import ProviderCredentialTerminalError
 from tldw_Server_API.app.core.LLM_Calls.routing.models import RouterRequest, RoutingPolicy
 from tldw_Server_API.app.main import app
@@ -1022,34 +1025,36 @@ def test_chat_completion_default_model_tracks_model(authenticated_client, mock_c
     ],
 )
 def test_chat_completion_omitted_model_uses_provider_configuration_in_payload(
-    authenticated_client,
-    mock_chacha_db,
-    setup_dependencies,
-    monkeypatch,
-    streaming,
-    provider,
-    snapshot,
-    expected_model,
-    request_model,
-):
+    authenticated_client: TestClient,
+    mock_chacha_db: CharactersRAGDB,
+    setup_dependencies: None,
+    monkeypatch: pytest.MonkeyPatch,
+    streaming: bool,
+    provider: str,
+    snapshot: dict[str, dict[str, str]],
+    expected_model: str,
+    request_model: str | None,
+) -> None:
+    """Both response modes send configured defaults instead of missing execution models."""
     captured: dict[str, object] = {}
     runtime_type = _credential_runtime_double(api_keys={provider: None})
     provider_manager = MagicMock()
-    provider_manager.circuit_breakers = {
-        provider: SimpleNamespace(can_attempt_call=lambda: True)
-    }
+    provider_manager.circuit_breakers = {provider: SimpleNamespace(can_attempt_call=lambda: True)}
 
-    async def execute_non_stream(**kwargs):
+    async def execute_non_stream(**kwargs: Any) -> dict[str, Any]:
+        """Capture the outgoing provider payload and return a normal completion."""
         captured.update(kwargs["cleaned_args"])
         return {
             "id": "chatcmpl-default-model",
             "choices": [{"message": {"role": "assistant", "content": "ok"}}],
         }
 
-    async def execute_stream(**kwargs):
+    async def execute_stream(**kwargs: Any) -> StreamingResponse:
+        """Capture the outgoing provider payload and return a completed SSE stream."""
         captured.update(kwargs["cleaned_args"])
 
-        async def body():
+        async def body() -> AsyncIterator[str]:
+            """Yield one provider delta followed by the completion marker."""
             yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
             yield "data: [DONE]\n\n"
 
@@ -1060,7 +1065,8 @@ def test_chat_completion_omitted_model_uses_provider_configuration_in_payload(
         raising=False,
     )
 
-    def default_model(target_provider):
+    def default_model(target_provider: str) -> str | None:
+        """Resolve the supplied provider snapshot through the production default policy."""
         return chat_target_resolution.get_default_model_for_provider(
             target_provider,
             config_loader=lambda: None,
@@ -1097,12 +1103,13 @@ def test_chat_completion_omitted_model_uses_provider_configuration_in_payload(
 @pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize("request_model", [None, "", "   "])
 def test_chat_completion_omitted_model_without_configuration_fails_before_dispatch(
-    authenticated_client,
-    mock_chacha_db,
-    setup_dependencies,
-    streaming,
-    request_model,
-):
+    authenticated_client: TestClient,
+    mock_chacha_db: CharactersRAGDB,
+    setup_dependencies: None,
+    streaming: bool,
+    request_model: str | None,
+) -> None:
+    """Missing defaults fail before either provider execution path is entered."""
     provider_call = AsyncMock()
     with (
         patch.object(chat_endpoint, "_get_default_model_for_provider_name", return_value=None),
@@ -1126,29 +1133,31 @@ def test_chat_completion_omitted_model_without_configuration_fails_before_dispat
 
 @pytest.mark.parametrize("streaming", [False, True])
 def test_chat_completion_explicit_model_precedes_provider_configuration(
-    authenticated_client,
-    mock_chacha_db,
-    setup_dependencies,
-    streaming,
-):
+    authenticated_client: TestClient,
+    mock_chacha_db: CharactersRAGDB,
+    setup_dependencies: None,
+    streaming: bool,
+) -> None:
+    """Explicit model selection bypasses configured defaults in both response modes."""
     captured: dict[str, object] = {}
     runtime_type = _credential_runtime_double(api_keys={"ollama": None})
     provider_manager = MagicMock()
-    provider_manager.circuit_breakers = {
-        "ollama": SimpleNamespace(can_attempt_call=lambda: True)
-    }
+    provider_manager.circuit_breakers = {"ollama": SimpleNamespace(can_attempt_call=lambda: True)}
 
-    async def execute_non_stream(**kwargs):
+    async def execute_non_stream(**kwargs: Any) -> dict[str, Any]:
+        """Capture the outgoing provider payload and return a normal completion."""
         captured.update(kwargs["cleaned_args"])
         return {
             "id": "chatcmpl-explicit-model",
             "choices": [{"message": {"role": "assistant", "content": "ok"}}],
         }
 
-    async def execute_stream(**kwargs):
+    async def execute_stream(**kwargs: Any) -> StreamingResponse:
+        """Capture the outgoing provider payload and return a completed SSE stream."""
         captured.update(kwargs["cleaned_args"])
 
-        async def body():
+        async def body() -> AsyncIterator[str]:
+            """Yield one provider delta followed by the completion marker."""
             yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
             yield "data: [DONE]\n\n"
 

--- a/tldw_Server_API/tests/Chat/integration/test_chat_endpoint_simplified.py
+++ b/tldw_Server_API/tests/Chat/integration/test_chat_endpoint_simplified.py
@@ -36,7 +36,11 @@ from tldw_Server_API.app.core.AuthNZ.provider_credential_runtime import (
     ProviderCredentialRuntime,
 )
 from tldw_Server_API.app.core.Chat import bounded_daemon as bounded_daemon_module
-from tldw_Server_API.app.core.Chat import chat_service, streaming_utils
+from tldw_Server_API.app.core.Chat import (
+    chat_service,
+    chat_target_resolution,
+    streaming_utils,
+)
 from tldw_Server_API.app.core.Chat.Chat_Deps import (
     ChatAPIError,
     ChatAuthenticationError,
@@ -1006,6 +1010,175 @@ def test_chat_completion_default_model_tracks_model(authenticated_client, mock_c
 
         assert response.status_code == status.HTTP_200_OK
         assert captured.get("model") == "default-model"
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("request_model", [None, "", "   "])
+@pytest.mark.parametrize(
+    ("provider", "snapshot", "expected_model"),
+    [
+        ("local-llm", {"local_llm": {"model": "local-env-model"}}, "local-env-model"),
+        ("ollama", {"ollama_api": {"model": "ollama-config-model"}}, "ollama-config-model"),
+    ],
+)
+def test_chat_completion_omitted_model_uses_provider_configuration_in_payload(
+    authenticated_client,
+    mock_chacha_db,
+    setup_dependencies,
+    monkeypatch,
+    streaming,
+    provider,
+    snapshot,
+    expected_model,
+    request_model,
+):
+    captured: dict[str, object] = {}
+    runtime_type = _credential_runtime_double(api_keys={provider: None})
+    provider_manager = MagicMock()
+    provider_manager.circuit_breakers = {
+        provider: SimpleNamespace(can_attempt_call=lambda: True)
+    }
+
+    async def execute_non_stream(**kwargs):
+        captured.update(kwargs["cleaned_args"])
+        return {
+            "id": "chatcmpl-default-model",
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+        }
+
+    async def execute_stream(**kwargs):
+        captured.update(kwargs["cleaned_args"])
+
+        async def body():
+            yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.delenv(
+        f"DEFAULT_MODEL_{provider.replace('-', '_').upper()}",
+        raising=False,
+    )
+
+    def default_model(target_provider):
+        return chat_target_resolution.get_default_model_for_provider(
+            target_provider,
+            config_loader=lambda: None,
+            provider_config_loader=lambda: snapshot,
+        )
+
+    with (
+        patch.object(chat_endpoint, "ProviderCredentialRuntime", runtime_type),
+        patch.object(chat_endpoint, "get_provider_manager", return_value=provider_manager),
+        patch.object(chat_endpoint, "ENABLE_PROVIDER_FALLBACK", False),
+        patch.object(
+            chat_endpoint,
+            "_get_default_model_for_provider_name",
+            side_effect=default_model,
+        ),
+        patch.object(chat_endpoint, "validate_provider_override", return_value=None),
+        patch.object(chat_endpoint, "execute_non_stream_call", side_effect=execute_non_stream),
+        patch.object(chat_endpoint, "execute_streaming_call", side_effect=execute_stream),
+    ):
+        response = authenticated_client.post(
+            "/api/v1/chat/completions",
+            json={
+                "api_provider": provider,
+                "model": request_model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": streaming,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert captured["model"] == expected_model
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("request_model", [None, "", "   "])
+def test_chat_completion_omitted_model_without_configuration_fails_before_dispatch(
+    authenticated_client,
+    mock_chacha_db,
+    setup_dependencies,
+    streaming,
+    request_model,
+):
+    provider_call = AsyncMock()
+    with (
+        patch.object(chat_endpoint, "_get_default_model_for_provider_name", return_value=None),
+        patch.object(chat_endpoint, "execute_non_stream_call", provider_call),
+        patch.object(chat_endpoint, "execute_streaming_call", provider_call),
+    ):
+        response = authenticated_client.post(
+            "/api/v1/chat/completions",
+            json={
+                "api_provider": "local-llm",
+                "model": request_model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": streaming,
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Model is required for provider 'local-llm'" in response.json()["detail"]
+    provider_call.assert_not_awaited()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_chat_completion_explicit_model_precedes_provider_configuration(
+    authenticated_client,
+    mock_chacha_db,
+    setup_dependencies,
+    streaming,
+):
+    captured: dict[str, object] = {}
+    runtime_type = _credential_runtime_double(api_keys={"ollama": None})
+    provider_manager = MagicMock()
+    provider_manager.circuit_breakers = {
+        "ollama": SimpleNamespace(can_attempt_call=lambda: True)
+    }
+
+    async def execute_non_stream(**kwargs):
+        captured.update(kwargs["cleaned_args"])
+        return {
+            "id": "chatcmpl-explicit-model",
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+        }
+
+    async def execute_stream(**kwargs):
+        captured.update(kwargs["cleaned_args"])
+
+        async def body():
+            yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    with (
+        patch.object(chat_endpoint, "ProviderCredentialRuntime", runtime_type),
+        patch.object(chat_endpoint, "get_provider_manager", return_value=provider_manager),
+        patch.object(chat_endpoint, "ENABLE_PROVIDER_FALLBACK", False),
+        patch.object(
+            chat_endpoint,
+            "_get_default_model_for_provider_name",
+            side_effect=AssertionError("provider default consulted for explicit model"),
+        ),
+        patch.object(chat_endpoint, "validate_provider_override", return_value=None),
+        patch.object(chat_endpoint, "execute_non_stream_call", side_effect=execute_non_stream),
+        patch.object(chat_endpoint, "execute_streaming_call", side_effect=execute_stream),
+    ):
+        response = authenticated_client.post(
+            "/api/v1/chat/completions",
+            json={
+                "api_provider": "ollama",
+                "model": "explicit-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": streaming,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert captured["model"] == "explicit-model"
 
 
 def test_chat_completion_downgrades_structured_response_format_before_provider_call(

--- a/tldw_Server_API/tests/Chat/test_chat_target_resolution.py
+++ b/tldw_Server_API/tests/Chat/test_chat_target_resolution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import configparser
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -7,6 +8,107 @@ import pytest
 
 from tldw_Server_API.app.api.v1.endpoints import sharing
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
+
+
+def _empty_override(_provider: str):
+    return None
+
+
+@pytest.mark.unit
+def test_local_llm_environment_supplies_omitted_chat_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ import byok_helpers
+    from tldw_Server_API.app.core.Chat.chat_target_resolution import (
+        get_default_model_for_provider,
+    )
+
+    monkeypatch.delenv("DEFAULT_MODEL_LOCAL_LLM", raising=False)
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "local-env-model")
+    monkeypatch.setattr(byok_helpers, "load_and_log_configs", lambda **_kwargs: {})
+
+    assert (
+        get_default_model_for_provider(
+            "local-llm",
+            override_default_resolver=_empty_override,
+            override_resolver=_empty_override,
+            config_loader=configparser.ConfigParser,
+            provider_config_loader=byok_helpers.load_server_config_snapshot,
+        )
+        == "local-env-model"
+    )
+
+
+@pytest.mark.unit
+def test_ollama_local_api_configuration_supplies_omitted_chat_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core import config as config_module
+    from tldw_Server_API.app.core.AuthNZ import byok_helpers
+    from tldw_Server_API.app.core.Chat.chat_target_resolution import (
+        get_default_model_for_provider,
+    )
+
+    parser = configparser.ConfigParser()
+    parser["Local-API"] = {"ollama_model": "ollama-config-model"}
+    monkeypatch.delenv("DEFAULT_MODEL_OLLAMA", raising=False)
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    monkeypatch.setattr(config_module, "load_comprehensive_config", lambda: parser)
+
+    assert (
+        get_default_model_for_provider(
+            "ollama",
+            override_default_resolver=_empty_override,
+            override_resolver=_empty_override,
+            config_loader=configparser.ConfigParser,
+            provider_config_loader=byok_helpers.load_server_config_snapshot,
+        )
+        == "ollama-config-model"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("override_default", "allowed_models", "environment", "chat_default", "expected"),
+    [
+        ("admin-default", ["admin-allowed"], "env-default", "chat-default", "admin-default"),
+        (None, ["admin-allowed"], "env-default", "chat-default", "admin-allowed"),
+        (None, None, "env-default", "chat-default", "env-default"),
+        (None, None, None, "chat-default", "chat-default"),
+        (None, None, None, None, "provider-default"),
+    ],
+)
+def test_default_model_precedence_preserves_existing_server_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    override_default: str | None,
+    allowed_models: list[str] | None,
+    environment: str | None,
+    chat_default: str | None,
+    expected: str,
+) -> None:
+    from tldw_Server_API.app.core.Chat.chat_target_resolution import (
+        get_default_model_for_provider,
+    )
+
+    if environment is None:
+        monkeypatch.delenv("DEFAULT_MODEL_OLLAMA", raising=False)
+    else:
+        monkeypatch.setenv("DEFAULT_MODEL_OLLAMA", environment)
+    config = configparser.ConfigParser()
+    if chat_default is not None:
+        config["Chat-Module"] = {"default_model_ollama": chat_default}
+    override = SimpleNamespace(allowed_models=allowed_models)
+
+    assert (
+        get_default_model_for_provider(
+            "ollama",
+            override_default_resolver=lambda _provider: override_default,
+            override_resolver=lambda _provider: override,
+            config_loader=lambda: config,
+            provider_config_loader=lambda: {"ollama_api": {"model": "provider-default"}},
+        )
+        == expected
+    )
 
 
 class _Registry:

--- a/tldw_Server_API/tests/Chat/test_chat_target_resolution.py
+++ b/tldw_Server_API/tests/Chat/test_chat_target_resolution.py
@@ -1,3 +1,5 @@
+"""Provider and model resolution across server defaults and configuration failures."""
+
 from __future__ import annotations
 
 import configparser
@@ -5,13 +7,58 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
+from loguru import logger
 
 from tldw_Server_API.app.api.v1.endpoints import sharing
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
 
 
-def _empty_override(_provider: str):
+def _empty_override(_provider: str) -> None:
+    """Represent an absent administrator override for provider-default regressions."""
     return None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("source", ["Chat-Module", "provider snapshot"])
+def test_model_configuration_failure_is_logged_without_leaking_exception_text(
+    monkeypatch: pytest.MonkeyPatch, source: str
+) -> None:
+    """Failed default lookups remain diagnosable without exposing configuration secrets."""
+    from tldw_Server_API.app.core.Chat.chat_target_resolution import get_default_model_for_provider
+
+    monkeypatch.delenv("DEFAULT_MODEL_OLLAMA", raising=False)
+    messages: list[str] = []
+    # Synthetic diagnostic content verifies that configuration secrets stay out of logs.
+    exception_secret = "private-value-from-broken-provider-config"  # nosec B105
+
+    def fail_config_load() -> configparser.ConfigParser:
+        """Simulate a parsing failure whose message contains sensitive config text."""
+        raise ValueError(exception_secret)
+
+    def fail_snapshot_load() -> dict[str, object]:
+        """Simulate a provider snapshot failure with sensitive diagnostic details."""
+        raise RuntimeError(exception_secret)
+
+    handler = logger.add(lambda message: messages.append(str(message)), format="{message}", level="WARNING")
+    try:
+        result = get_default_model_for_provider(
+            " OLLAMA ",
+            override_default_resolver=_empty_override,
+            override_resolver=_empty_override,
+            config_loader=fail_config_load if source == "Chat-Module" else configparser.ConfigParser,
+            provider_config_loader=(
+                fail_snapshot_load
+                if source == "provider snapshot"
+                else lambda: {"ollama_api": {"model": "fallback-model"}}
+            ),
+        )
+    finally:
+        logger.remove(handler)
+
+    assert result == ("fallback-model" if source == "Chat-Module" else None)
+    assert any(source in message and "ollama" in message for message in messages)
+    assert any(("ValueError" if source == "Chat-Module" else "RuntimeError") in message for message in messages)
+    assert all(exception_secret not in message for message in messages)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Chat_NEW/integration/test_chat_completions_api.py
+++ b/tldw_Server_API/tests/Chat_NEW/integration/test_chat_completions_api.py
@@ -5,19 +5,30 @@ Tests the full request/response flow with real database and minimal mocking.
 Only external LLM APIs are mocked to avoid actual API calls.
 """
 
+import asyncio
+import configparser
+import json
 import os
+from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi import status
+from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import DEFAULT_CHARACTER_NAME, get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import try_get_job_manager
+from tldw_Server_API.app.core.Chat_Macros.branch_runner import ChatMacroLLMBranchRunner
+from tldw_Server_API.app.core.Chat_Macros.context_snapshot import snapshot_from_mapping
 from tldw_Server_API.app.core.Chat_Macros.repository import ChatMacroRepository
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.tests.chat_macros_test_helpers import FakeJobManager
 
 
-def _install_isolated_chat_db(test_client, tmp_path, monkeypatch):
+def _install_isolated_chat_db(
+    test_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> CharactersRAGDB:
+    """Install a real per-user database for durable chat-macro acceptance checks."""
     user_base = tmp_path / "user_databases" / "1"
     user_base.mkdir(parents=True)
     monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_databases"))
@@ -218,6 +229,130 @@ class TestChatCompletionsEndpoint:
             assert queued["job_type"] == "chat_macro_run"
             assert queued["payload"]["macro_run_id"] == macro_meta["run_id"]
             assert queued["payload"]["normalized_args"]["question"] == ["What changed?"]
+        finally:
+            test_client.app.dependency_overrides.pop(get_chacha_db_for_user, None)
+            test_client.app.dependency_overrides.pop(try_get_job_manager, None)
+            db.close_all_connections()
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("request_model", [None, "   ", "explicit-model"])
+    @pytest.mark.parametrize("default_source", ["environment", "chat-config", "administrator"])
+    def test_queued_macro_preserves_request_time_model_after_default_changes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        tmp_path: Path,
+        streaming: bool,
+        request_model: str | None,
+        default_source: str,
+    ) -> None:
+        """Queued branches use the persisted effective model, including omitted defaults."""
+        from tldw_Server_API.app.api.v1.endpoints import chat as chat_endpoint
+
+        monkeypatch.setenv("CHAT_COMMANDS_ENABLED", "1")
+        monkeypatch.delenv("DEFAULT_MODEL_LOCAL_LLM", raising=False)
+        config = configparser.ConfigParser()
+        administrator: dict[str, str | None] = {"model": None}
+        monkeypatch.setattr(chat_endpoint, "_config", config)
+        monkeypatch.setattr(chat_endpoint, "get_override_default_model", lambda _provider: administrator["model"])
+        monkeypatch.setattr(chat_endpoint, "get_llm_provider_override", lambda _provider: None)
+        if default_source == "environment":
+            monkeypatch.setenv("DEFAULT_MODEL_LOCAL_LLM", "request-time-model")
+        elif default_source == "chat-config":
+            config["Chat-Module"] = {"default_model_local_llm": "request-time-model"}
+        else:
+            administrator["model"] = "request-time-model"
+
+        db = _install_isolated_chat_db(test_client, tmp_path, monkeypatch)
+        job_manager = FakeJobManager()
+        test_client.app.dependency_overrides[try_get_job_manager] = lambda: job_manager
+        expected_model = "explicit-model" if request_model == "explicit-model" else "request-time-model"
+
+        async def model_echo(**kwargs: Any) -> dict[str, Any]:
+            """Return the selected model as the provider's observable branch response."""
+            return {"choices": [{"message": {"content": kwargs.get("model", "later-model")}}]}
+
+        try:
+            response = test_client.post(
+                "/api/v1/chat/completions",
+                json={
+                    "api_provider": "local-llm",
+                    "model": request_model,
+                    "messages": [{"role": "user", "content": "/wrapup"}],
+                    "stream": streaming,
+                },
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_200_OK, response.text
+            if streaming:
+                frames = [line[6:] for line in response.text.splitlines() if line.startswith("data: ")]
+                assert frames[-1] == "[DONE]"
+                body = json.loads(frames[0])
+                message = body["choices"][0]["delta"]
+            else:
+                body = response.json()
+                message = body["choices"][0]["message"]
+            run_id = message["metadata"]["chat_macro"]["run_id"]
+
+            # Change every possible request-time source before reading/executing the run.
+            monkeypatch.setenv("DEFAULT_MODEL_LOCAL_LLM", "later-model")
+            config["Chat-Module"] = {"default_model_local_llm": "later-model"}
+            administrator["model"] = "later-model"
+            run = ChatMacroRepository(db).get_run(run_id)
+            assert run is not None
+            assert run.model_selection == {"api_provider": "local-llm", "model": expected_model}
+            assert run.context_snapshot["model_selection"] == run.model_selection
+            assert body["model"] == expected_model
+            result = asyncio.run(
+                ChatMacroLLMBranchRunner(chat_call=model_echo).run_branch(
+                    prompt="Summarize the conversation.",
+                    snapshot=snapshot_from_mapping(run.context_snapshot),
+                    model_selection=run.model_selection,
+                )
+            )
+            assert result.text == expected_model
+        finally:
+            test_client.app.dependency_overrides.pop(get_chacha_db_for_user, None)
+            test_client.app.dependency_overrides.pop(try_get_job_manager, None)
+            db.close_all_connections()
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("streaming", [False, True])
+    @pytest.mark.parametrize("request_model", [None, "   "])
+    def test_macro_without_configured_model_rejected_before_persistence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        tmp_path: Path,
+        streaming: bool,
+        request_model: str | None,
+    ) -> None:
+        """A macro without an execution model returns 400 without creating queued work."""
+        from tldw_Server_API.app.api.v1.endpoints import chat as chat_endpoint
+
+        monkeypatch.setenv("CHAT_COMMANDS_ENABLED", "1")
+        monkeypatch.setattr(chat_endpoint, "_get_default_model_for_provider_name", lambda _provider: None)
+        db = _install_isolated_chat_db(test_client, tmp_path, monkeypatch)
+        job_manager = FakeJobManager()
+        test_client.app.dependency_overrides[try_get_job_manager] = lambda: job_manager
+        try:
+            response = test_client.post(
+                "/api/v1/chat/completions",
+                json={
+                    "api_provider": "local-llm",
+                    "model": request_model,
+                    "messages": [{"role": "user", "content": "/wrapup"}],
+                    "stream": streaming,
+                },
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
+            assert "Model is required" in response.json()["detail"]
+            assert db.execute_query("SELECT COUNT(*) FROM chat_macro_runs").fetchone()[0] == 0
+            assert job_manager.created == []
         finally:
             test_client.app.dependency_overrides.pop(get_chacha_db_for_user, None)
             test_client.app.dependency_overrides.pop(try_get_job_manager, None)

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py
@@ -1,14 +1,82 @@
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import ChatCompletionRequest
 from tldw_Server_API.app.core.Chat import chat_service
 from tldw_Server_API.app.core.Chat.chat_service import (
-    resolve_provider_and_model,
+    build_call_params_from_request,
     invalidate_model_alias_caches,
+    resolve_provider_and_model,
 )
 from tldw_Server_API.app.core.LLM_Calls.routing.models import RoutingDecision
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("request_model", [None, "", "   "])
+def test_omitted_model_keeps_metrics_placeholder_out_of_outgoing_payload(
+    request_model: str | None,
+) -> None:
+    request = ChatCompletionRequest(
+        api_provider="local-llm",
+        model=request_model,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    metrics_provider, metrics_model, selected_provider, selected_model, _ = resolve_provider_and_model(
+        request_data=request,
+        metrics_default_provider="openai",
+        normalize_default_provider="openai",
+    )
+    params = build_call_params_from_request(
+        request_data=request,
+        target_api_provider=selected_provider,
+        provider_api_key=None,
+        templated_llm_payload=[{"role": "user", "content": "Hello"}],
+        final_system_message=None,
+        resolved_model=selected_model,
+    )
+
+    assert (metrics_provider, metrics_model) == ("local-llm", "unknown")
+    assert selected_model is None
+    assert "model" not in params
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("request_model", [None, "", "   "])
+def test_blank_model_stays_omitted_during_execution_resolution(
+    request_model: str | None,
+) -> None:
+    request = ChatCompletionRequest(
+        api_provider="local-llm",
+        model=request_model,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    _, _, _, selected_model, _ = resolve_provider_and_model(
+        request_data=request,
+        metrics_default_provider="openai",
+        normalize_default_provider="openai",
+    )
+
+    assert selected_model is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("request_model", [None, "", "   "])
+def test_messages_shared_resolver_does_not_promote_metrics_placeholder(
+    request_model: str | None,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import messages
+
+    request = SimpleNamespace(api_provider="local-llm", model=request_model)
+
+    with pytest.raises(HTTPException) as exc_info:
+        messages._resolve_provider_and_model_for_request(request)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Model is required for provider 'local-llm'."
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
+++ b/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
@@ -1,0 +1,158 @@
+"""Regress array binding at repository -> DatabasePool -> driver boundaries."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, _flatten_params
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+from tldw_Server_API.app.core.AuthNZ.settings import Settings
+from tldw_Server_API.app.core.UserProfiles.overrides_repo import (
+    OrgProfileOverridesRepo,
+    TeamProfileOverridesRepo,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def postgres_pool(monkeypatch: pytest.MonkeyPatch):
+    """Keep DatabasePool binding real and replace only the external driver."""
+    pool = DatabasePool(Settings(AUTH_MODE="single_user", DATABASE_URL="sqlite:///:memory:"))
+    pool.pool = object()
+    connection = AsyncMock()
+
+    @asynccontextmanager
+    async def acquire():
+        yield connection
+
+    monkeypatch.setattr(pool, "acquire", acquire)
+    return pool, connection
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("repo_type", "scope"),
+    [(OrgProfileOverridesRepo, "org"), (TeamProfileOverridesRepo, "team")],
+)
+@pytest.mark.parametrize("ids", [[], [7], [7, 11]])
+async def test_override_lists_bind_one_array(postgres_pool, repo_type, scope, ids):
+    """A one-element ID list must not become a scalar query argument."""
+    pool, connection = postgres_pool
+    updated_at = datetime(2026, 1, 2, 3, 4, 5)
+    connection.fetch.return_value = [
+        {
+            f"{scope}_id": 7,
+            "key": "theme",
+            "value_json": '"dark"',
+            "updated_at": updated_at,
+            "updated_by": 3,
+        }
+    ]
+    result = await getattr(repo_type(pool), f"list_overrides_for_{scope}s")(ids)
+
+    if not ids:
+        assert result == []
+        connection.fetch.assert_not_awaited()
+        return
+    assert connection.fetch.await_args.args[1:] == (ids,)
+    assert result == [
+        {
+            f"{scope}_id": 7,
+            "key": "theme",
+            "value": "dark",
+            "updated_at": updated_at,
+            "updated_by": 3,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("repo_type", "scope"),
+    [(OrgProfileOverridesRepo, "org"), (TeamProfileOverridesRepo, "team")],
+)
+@pytest.mark.parametrize("ids", [[], [7], [7, 11]])
+async def test_override_update_versions_bind_one_array(postgres_pool, repo_type, scope, ids):
+    """Profile version queries preserve arrays for one or many memberships."""
+    pool, connection = postgres_pool
+    updated_at = datetime(2026, 1, 2, 3, 4, 5)
+    connection.fetchrow.return_value = {"updated_at": updated_at}
+
+    result = await getattr(repo_type(pool), f"get_latest_update_for_{scope}s")(ids)
+
+    if not ids:
+        assert result is None
+        connection.fetchrow.assert_not_awaited()
+        return
+    assert connection.fetchrow.await_args.args[1:] == (ids,)
+    assert result == updated_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_revoked", [False, True])
+@pytest.mark.parametrize("ids, expected_ids", [([], []), ([7], [7]), ([11, 7, 7, 0], [7, 11])])
+async def test_managed_secret_refs_bind_one_normalized_array(postgres_pool, include_revoked, ids, expected_ids):
+    """Bulk credential lookup must preserve its deduplicated ID array."""
+    pool, connection = postgres_pool
+    connection.fetch.return_value = [{"id": 7, "metadata_json": '{"region":"local"}'}]
+
+    result = await ManagedSecretRefsRepo(pool).list_refs_by_ids(ids, include_revoked=include_revoked)
+
+    if not expected_ids:
+        assert result == {}
+        connection.fetch.assert_not_awaited()
+        return
+    assert connection.fetch.await_args.args[1:] == (expected_ids,)
+    assert result[7]["metadata"] == {"region": "local"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("repo_type", [AuthnzUsersRepo, AuthnzOrgsTeamsRepo])
+@pytest.mark.parametrize("ids", [None, [], [7], [7, 11]])
+async def test_scoped_listing_counts_preserve_an_array_as_the_only_filter(postgres_pool, repo_type, ids):
+    """Pagination adds scalars to page queries, but their count still needs an array."""
+    pool, connection = postgres_pool
+    connection.fetch.return_value = []
+    connection.fetchval.return_value = 2
+    repo = repo_type(pool)
+
+    if repo_type is AuthnzUsersRepo:
+        rows, total = await repo.list_users(offset=0, limit=10, org_ids=ids)
+    else:
+        rows, total = await repo.list_organizations(offset=0, limit=10, org_ids=ids, with_total=True)
+
+    assert rows == []
+    if ids == []:
+        assert total == 0
+        connection.fetchval.assert_not_awaited()
+        return
+    assert total == 2
+    assert connection.fetchval.await_args.args[1:] == (() if ids is None else (ids,))
+
+
+@given(st.lists(st.integers(min_value=1, max_value=2**31 - 1), max_size=100))
+def test_explicit_single_array_parameter_preserves_values(ids):
+    """Nested parameter sequences distinguish an array from variadic arguments."""
+    assert _flatten_params(((ids,),)) == (ids,)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("args", [(7, "active"), ([7, "active"],), ((7, "active"),)])
+async def test_pool_retains_variadic_and_sequence_argument_compatibility(postgres_pool, args):
+    """Document the existing convention that the caller fixes must preserve."""
+    pool, connection = postgres_pool
+    connection.fetchrow.return_value = {"id": 7}
+
+    assert await pool.fetchone("SELECT id FROM sessions WHERE id = $1 AND status = $2", *args) == {"id": 7}
+    assert connection.fetchrow.await_args.args[1:] == (7, "active")

--- a/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
+++ b/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock
 
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, _flatten_params
@@ -141,6 +141,8 @@ async def test_scoped_listing_counts_preserve_an_array_as_the_only_filter(postgr
     assert connection.fetchval.await_args.args[1:] == (() if ids is None else (ids,))
 
 
+# Allow Hypothesis's one-time scan of imported module constants in large suites.
+@settings(deadline=1000)
 @given(st.lists(st.integers(min_value=1, max_value=2**31 - 1), max_size=100))
 def test_explicit_single_array_parameter_preserves_values(ids):
     """Nested parameter sequences distinguish an array from variadic arguments."""

--- a/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
+++ b/tldw_Server_API/tests/UserProfile/test_postgres_array_parameters.py
@@ -1,16 +1,18 @@
-"""Regress array binding at repository -> DatabasePool -> driver boundaries."""
+"""Regress array-bound query results through repositories and the real DatabasePool."""
 
 from __future__ import annotations
 
+import re
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
-from unittest.mock import AsyncMock
+from typing import Any, Literal
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, _flatten_params
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
     ManagedSecretRefsRepo,
 )
@@ -25,19 +27,75 @@ from tldw_Server_API.app.core.UserProfiles.overrides_repo import (
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture
-def postgres_pool(monkeypatch: pytest.MonkeyPatch):
+class _ArrayQueryDriver:
+    """Select fixture rows while enforcing PostgreSQL's scalar/array argument boundary."""
+
+    def __init__(self) -> None:
+        """Start with an empty relation whose array filter selects the id column."""
+        self.rows: list[dict[str, Any]] = []
+        self.id_column = "id"
+
+    @staticmethod
+    def _integer_array(value: object) -> list[int]:
+        """Accept integer sequences and reject a scalar bound to an integer array."""
+        if not isinstance(value, (list, tuple)) or not all(isinstance(item, int) for item in value):
+            raise TypeError("An integer array query parameter must be an integer sequence")
+        return list(value)
+
+    async def fetch(self, query: str, *params: object) -> list[dict[str, Any]]:
+        """Evaluate the array filters and pagination used by these repository queries."""
+        parameter_count = max((int(index) for index in re.findall(r"\$(\d+)", query)), default=0)
+        if len(params) != parameter_count:
+            raise ValueError("Query parameter count does not match its placeholders")
+        if query == "SELECT $1::int[] AS ids":
+            return [{"ids": self._integer_array(params[0])}]
+
+        rows = self.rows
+        if "ANY(" in query:
+            ids = self._integer_array(params[0])
+            rows = [row for row in rows if row[self.id_column] in ids]
+        elif "WHERE id = $1 AND status = $2" in query:
+            rows = [row for row in rows if row["id"] == params[0] and row["status"] == params[1]]
+        if "revoked_at IS NULL" in query:
+            rows = [row for row in rows if row["revoked_at"] is None]
+        if "LIMIT" in query:
+            limit, offset = params[-2:]
+            if not isinstance(limit, int) or not isinstance(offset, int):
+                raise TypeError("Pagination parameters must be integers")
+            rows = rows[offset : offset + limit]
+        return rows
+
+    async def fetchrow(self, query: str, *params: object) -> dict[str, Any] | None:
+        """Return a selected row or the maximum activity among selected overrides."""
+        rows = await self.fetch(query, *params)
+        if "MAX(updated_at)" in query:
+            return {"updated_at": max((row["updated_at"] for row in rows), default=None)}
+        return rows[0] if rows else None
+
+    async def fetchval(self, query: str, *params: object) -> int:
+        """Count the rows selected by the repository's organization filter."""
+        return len(await self.fetch(query, *params))
+
+
+def _make_postgres_pool(monkeypatch: pytest.MonkeyPatch) -> tuple[DatabasePool, _ArrayQueryDriver]:
     """Keep DatabasePool binding real and replace only the external driver."""
     pool = DatabasePool(Settings(AUTH_MODE="single_user", DATABASE_URL="sqlite:///:memory:"))
     pool.pool = object()
-    connection = AsyncMock()
+    driver = _ArrayQueryDriver()
 
     @asynccontextmanager
-    async def acquire():
-        yield connection
+    async def acquire() -> AsyncIterator[_ArrayQueryDriver]:
+        """Provide the seeded driver for a public DatabasePool query."""
+        yield driver
 
     monkeypatch.setattr(pool, "acquire", acquire)
-    return pool, connection
+    return pool, driver
+
+
+@pytest.fixture
+def postgres_pool(monkeypatch: pytest.MonkeyPatch) -> tuple[DatabasePool, _ArrayQueryDriver]:
+    """Provide independent rows and a real pool for each repository test."""
+    return _make_postgres_pool(monkeypatch)
 
 
 @pytest.mark.asyncio
@@ -46,34 +104,38 @@ def postgres_pool(monkeypatch: pytest.MonkeyPatch):
     [(OrgProfileOverridesRepo, "org"), (TeamProfileOverridesRepo, "team")],
 )
 @pytest.mark.parametrize("ids", [[], [7], [7, 11]])
-async def test_override_lists_bind_one_array(postgres_pool, repo_type, scope, ids):
-    """A one-element ID list must not become a scalar query argument."""
-    pool, connection = postgres_pool
+async def test_override_lists_select_requested_memberships(
+    postgres_pool: tuple[DatabasePool, _ArrayQueryDriver],
+    repo_type: type[OrgProfileOverridesRepo] | type[TeamProfileOverridesRepo],
+    scope: Literal["org", "team"],
+    ids: list[int],
+) -> None:
+    """Empty, single, and multiple membership arrays select only their overrides."""
+    pool, driver = postgres_pool
+    driver.id_column = f"{scope}_id"
     updated_at = datetime(2026, 1, 2, 3, 4, 5)
-    connection.fetch.return_value = [
+    driver.rows = [
         {
-            f"{scope}_id": 7,
+            f"{scope}_id": member_id,
             "key": "theme",
             "value_json": '"dark"',
             "updated_at": updated_at,
             "updated_by": 3,
         }
+        for member_id in [7, 11, 19]
     ]
+
     result = await getattr(repo_type(pool), f"list_overrides_for_{scope}s")(ids)
 
-    if not ids:
-        assert result == []
-        connection.fetch.assert_not_awaited()
-        return
-    assert connection.fetch.await_args.args[1:] == (ids,)
     assert result == [
         {
-            f"{scope}_id": 7,
+            f"{scope}_id": member_id,
             "key": "theme",
             "value": "dark",
             "updated_at": updated_at,
             "updated_by": 3,
         }
+        for member_id in ids
     ]
 
 
@@ -82,79 +144,106 @@ async def test_override_lists_bind_one_array(postgres_pool, repo_type, scope, id
     ("repo_type", "scope"),
     [(OrgProfileOverridesRepo, "org"), (TeamProfileOverridesRepo, "team")],
 )
-@pytest.mark.parametrize("ids", [[], [7], [7, 11]])
-async def test_override_update_versions_bind_one_array(postgres_pool, repo_type, scope, ids):
-    """Profile version queries preserve arrays for one or many memberships."""
-    pool, connection = postgres_pool
-    updated_at = datetime(2026, 1, 2, 3, 4, 5)
-    connection.fetchrow.return_value = {"updated_at": updated_at}
+@pytest.mark.parametrize(
+    ("ids", "expected_update"),
+    [([], None), ([7], datetime(2026, 1, 7)), ([7, 11], datetime(2026, 1, 11))],
+)
+async def test_override_versions_select_latest_requested_membership(
+    postgres_pool: tuple[DatabasePool, _ArrayQueryDriver],
+    repo_type: type[OrgProfileOverridesRepo] | type[TeamProfileOverridesRepo],
+    scope: Literal["org", "team"],
+    ids: list[int],
+    expected_update: datetime | None,
+) -> None:
+    """The latest profile version excludes updates from unrelated memberships."""
+    pool, driver = postgres_pool
+    driver.id_column = f"{scope}_id"
+    driver.rows = [
+        {f"{scope}_id": 7, "updated_at": datetime(2026, 1, 7)},
+        {f"{scope}_id": 11, "updated_at": datetime(2026, 1, 11)},
+        {f"{scope}_id": 19, "updated_at": datetime(2026, 1, 19)},
+    ]
 
     result = await getattr(repo_type(pool), f"get_latest_update_for_{scope}s")(ids)
 
-    if not ids:
-        assert result is None
-        connection.fetchrow.assert_not_awaited()
-        return
-    assert connection.fetchrow.await_args.args[1:] == (ids,)
-    assert result == updated_at
+    assert result == expected_update
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("include_revoked", [False, True])
-@pytest.mark.parametrize("ids, expected_ids", [([], []), ([7], [7]), ([11, 7, 7, 0], [7, 11])])
-async def test_managed_secret_refs_bind_one_normalized_array(postgres_pool, include_revoked, ids, expected_ids):
-    """Bulk credential lookup must preserve its deduplicated ID array."""
-    pool, connection = postgres_pool
-    connection.fetch.return_value = [{"id": 7, "metadata_json": '{"region":"local"}'}]
+@pytest.mark.parametrize("ids, expected_ids", [([], []), ([7], [7]), ([11, 7, 7, 0, -1], [7, 11])])
+async def test_managed_secret_refs_select_normalized_identifiers(
+    postgres_pool: tuple[DatabasePool, _ArrayQueryDriver],
+    include_revoked: bool,
+    ids: list[int],
+    expected_ids: list[int],
+) -> None:
+    """Bulk lookup removes invalid IDs and respects revocation and metadata decoding."""
+    pool, driver = postgres_pool
+    driver.rows = [
+        {"id": -1, "metadata_json": '{"region":"invalid"}', "revoked_at": None},
+        {"id": 0, "metadata_json": '{"region":"invalid"}', "revoked_at": None},
+        {"id": 7, "metadata_json": '{"region":"local"}', "revoked_at": None},
+        {"id": 11, "metadata_json": '{"region":"remote"}', "revoked_at": datetime(2026, 1, 1)},
+        {"id": 19, "metadata_json": '{"region":"unrelated"}', "revoked_at": None},
+    ]
 
     result = await ManagedSecretRefsRepo(pool).list_refs_by_ids(ids, include_revoked=include_revoked)
 
-    if not expected_ids:
-        assert result == {}
-        connection.fetch.assert_not_awaited()
-        return
-    assert connection.fetch.await_args.args[1:] == (expected_ids,)
-    assert result[7]["metadata"] == {"region": "local"}
+    expected_metadata = {7: {"region": "local"}, 11: {"region": "remote"}}
+    assert {ref_id: ref["metadata"] for ref_id, ref in result.items()} == {
+        ref_id: expected_metadata[ref_id] for ref_id in expected_ids if include_revoked or ref_id != 11
+    }
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("repo_type", [AuthnzUsersRepo, AuthnzOrgsTeamsRepo])
-@pytest.mark.parametrize("ids", [None, [], [7], [7, 11]])
-async def test_scoped_listing_counts_preserve_an_array_as_the_only_filter(postgres_pool, repo_type, ids):
-    """Pagination adds scalars to page queries, but their count still needs an array."""
-    pool, connection = postgres_pool
-    connection.fetch.return_value = []
-    connection.fetchval.return_value = 2
+@pytest.mark.parametrize(
+    ("ids", "expected_ids"),
+    [(None, [19, 11, 7]), ([], []), ([7], [7]), ([7, 11], [11, 7])],
+)
+async def test_scoped_listing_count_matches_selected_rows(
+    postgres_pool: tuple[DatabasePool, _ArrayQueryDriver],
+    repo_type: type[AuthnzUsersRepo] | type[AuthnzOrgsTeamsRepo],
+    ids: list[int] | None,
+    expected_ids: list[int],
+) -> None:
+    """The count and paginated rows apply the same optional organization array."""
+    pool, driver = postgres_pool
+    driver.rows = [{"id": member_id, "is_active": True} for member_id in [19, 11, 7]]
     repo = repo_type(pool)
 
-    if repo_type is AuthnzUsersRepo:
-        rows, total = await repo.list_users(offset=0, limit=10, org_ids=ids)
+    if isinstance(repo, AuthnzUsersRepo):
+        rows, total = await repo.list_users(offset=0, limit=2, org_ids=ids)
     else:
-        rows, total = await repo.list_organizations(offset=0, limit=10, org_ids=ids, with_total=True)
+        rows, total = await repo.list_organizations(offset=0, limit=2, org_ids=ids, with_total=True)
 
-    assert rows == []
-    if ids == []:
-        assert total == 0
-        connection.fetchval.assert_not_awaited()
-        return
-    assert total == 2
-    assert connection.fetchval.await_args.args[1:] == (() if ids is None else (ids,))
+    assert ([row["id"] for row in rows], total) == (expected_ids[:2], len(expected_ids))
 
 
+@pytest.mark.asyncio
 # Allow Hypothesis's one-time scan of imported module constants in large suites.
 @settings(deadline=1000)
 @given(st.lists(st.integers(min_value=1, max_value=2**31 - 1), max_size=100))
-def test_explicit_single_array_parameter_preserves_values(ids):
-    """Nested parameter sequences distinguish an array from variadic arguments."""
-    assert _flatten_params(((ids,),)) == (ids,)
+async def test_public_fetchone_round_trips_generated_integer_arrays(ids: list[int]) -> None:
+    """Explicit array parameters retain every value through the public pool API."""
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        pool, _driver = _make_postgres_pool(monkeypatch)
+
+        assert await pool.fetchone("SELECT $1::int[] AS ids", (ids,)) == {"ids": ids}
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("args", [(7, "active"), ([7, "active"],), ((7, "active"),)])
-async def test_pool_retains_variadic_and_sequence_argument_compatibility(postgres_pool, args):
-    """Document the existing convention that the caller fixes must preserve."""
-    pool, connection = postgres_pool
-    connection.fetchrow.return_value = {"id": 7}
+async def test_pool_retains_variadic_and_sequence_argument_compatibility(
+    postgres_pool: tuple[DatabasePool, _ArrayQueryDriver],
+    args: tuple[int | str | list[int | str] | tuple[int | str, ...], ...],
+) -> None:
+    """Variadic arguments and complete parameter sequences select the same session."""
+    pool, driver = postgres_pool
+    driver.rows = [{"id": 7, "status": "active"}, {"id": 11, "status": "inactive"}]
 
-    assert await pool.fetchone("SELECT id FROM sessions WHERE id = $1 AND status = $2", *args) == {"id": 7}
-    assert connection.fetchrow.await_args.args[1:] == (7, "active")
+    assert await pool.fetchone("SELECT id, status FROM sessions WHERE id = $1 AND status = $2", *args) == {
+        "id": 7,
+        "status": "active",
+    }


### PR DESCRIPTION
## Summary

Fixes issues reported by Lawrence908

Addresses #2935, #2936, #2937, and #2938, plus related failures found while tracing the same paths.

- Preserve the existing JWT `Uint8Array` handoff to WebCrypto and add real middleware regressions for the old buffer failure. Malformed signature encoding and non-string algorithm headers now fail closed.
- Add and backfill `sessions.last_activity` through DB-owned helpers used by production PostgreSQL bootstrap and SQLite upgrades, retaining caller transaction boundaries. Initialize new SQLite sessions explicitly after legacy upgrades, where adding a timestamp default is restricted.
- Keep PostgreSQL ID arrays intact in profile override queries, managed-secret lookups, and organization/user scoped counts. Fix the callers while preserving the shared DatabasePool parameter conventions.
- Keep the metrics label `unknown` out of execution-model selection. Omitted or blank chat models use existing configured defaults after explicit/admin defaults; missing configuration returns HTTP 400 before dispatch. Shared Messages and payload paths retain normalized values. Queued macros now resolve and persist the same effective model before enqueueing, so later configuration changes cannot alter execution.
- Repair the unrelated custom-users migration test. Migration 93 intentionally appends seven fields, so the test now checks preservation of the original column prefix and existing data, constraints, indexes, triggers, defaults, sequence, and foreign keys. It exercises both migration 91 alone and the complete startup upgrade.

- Live UAT exposed another PostgreSQL full-profile failure in audio quota date binding. Keep native dates for PostgreSQL and ISO text for SQLite in quota reads, legacy backfill, and job counts; add real database regressions.
- Live WebUI retries also exposed synchronous RBAC reads blocking the event loop behind schema locks. Run complete RBAC enrichment on worker threads for JWT/API-key authentication and serialize shared database initialization; cover actual PostgreSQL lock contention and concurrent cold startup.

- Repair the inherited admin webhook status contract mismatch exposed by required frontend CI. Preserve strict validation of UI-consumed status fields while ignoring the new unused delivery metadata; test actual backend response shapes.

Regression coverage includes production-created PostgreSQL schemas, public DatabasePool query behavior, generated ID arrays, actual provider configuration parsing, and streaming/non-streaming chat requests. The implementation reuses existing configuration and database abstractions.

## Validation

The latest rebase includes `dev` at `9da94ebcb41ba45d279ab707ec92a285d31ba5c7`. All original patches were preserved by range-diff. Fresh local verification after Qodo remediation:

| Scope | Result |
| --- | --- |
| Auth/Profile, real PostgreSQL sessions/arrays/quotas/locks, SQLite custom-schema migrations, concurrent cache initialization | 76 passed; no skips |
| Full simplified-chat endpoint file and target/provider model resolution | 260 passed; 1 existing skip |
| Durable macro defaults, missing-model rejection, and existing macro cases | 28 passed |
| Admin JWT/auth middleware and navigation | 28 passed on Node 20.19.5 |
| Webhook API/page/URL regressions | 73 passed |
| Unchanged real-backend webhook browser acceptance | 3 passed; no retries |
| CI workflow contracts and shard coverage | 57 passed; guard passed |
| Bandit across all 16 changed backend production files | No new findings; no scan errors |

Macro and configuration-diagnostic regressions failed before their fixes and pass afterward. The public array tests also detect an intentional mutation removing the production array wrapper. PostgreSQL checks used the standard isolated fixtures with PostgreSQL required. All completed test processes exited successfully. Compilation, scoped lint, test security scans, and whitespace checks introduce no findings; inherited import-order and test/credential-literal findings are documented. Independent review found no remaining correctness issues in the Qodo fixes.

All seven Qodo comments have a verified fix or supported disposition. New session SQL lives in `DB_Management`; existing repository array changes retain established public DatabasePool conventions. Configuration fallback logs identify provider/source/error type without exposing raw diagnostic text. Required CI shard assignments were repaired consistently in all five matrices. The inherited webhook E2E failure is also repaired: the admin client discards only new, unused `delivery` metadata before applying its existing strict status validation. New canonical/legacy cases failed before repair, and the unchanged real-backend acceptance spec now passes against a fresh production build. Scoped ESLint, full admin type checking, and independent review pass. Qodo independently reviewed both the rebased backend commit and final webhook head `c26b30c5cb`, reporting zero bugs and zero rule violations; all review threads are resolved. All seven required checks now pass on final head `c26b30c5cb`: backend, security, coverage, frontend, end-to-end, container build, and trusted license policy. The branch contains current `dev` at `9da94ebcb4`, and GitHub reports a clean merge state. The requester subsequently overrode the separate human-written-summary requirement and directed merge; the verified final head has been merged into dev.

Full backend/UI suites were not run locally. The existing skipped chat test hangs with TestClient; all new streaming regressions ran. Large production-table migration duration and locking were not measured. UI layout, Flashcards, and Watchlists checklist items do not apply.

See the [Qodo remediation and rebase record](https://github.com/rmusser01/tldw_server/blob/c26b30c5cb652cf47e139231923eabdb465fbac5/Docs/Reviews/PR_2939_QODO_REBASE_2026_09_10.md) and [original design and related-pattern audit](https://github.com/rmusser01/tldw_server/blob/c26b30c5cb652cf47e139231923eabdb465fbac5/Docs/Design/ISSUES_2935_2938_REGRESSION_REPAIR.md). Work is tracked in TASK-13235 through TASK-13241.

## Live UAT — September 10, 2026 UTC

Acceptance checks used running services and real browser/API requests:

- Production admin UI: browser login and reload succeed on Node 20.19.5. The same artifact also passes the HTTP JWT matrix on the exact Node 20.20.2 runtime: valid login JWT 200; all five missing/invalid-token cases redirect 307 to login without 500.
- PostgreSQL 18.6: full profiles return 200 through Bearer and API key with zero, one, and two org/team memberships; overrides, session activity, refresh, and newly registered users work.
- WebUI API-key Save returns profile 200 and displays success; saved server URL/key survive reload.
- 24 streaming/non-streaming chat cases cover environment defaults, file defaults, Ollama's configured model, explicit selection, and missing defaults. Invalid configuration returns 400 before provider dispatch.
- A live role-table lock leaves authentication waiting while `/health` responds 200 in 7 ms; the authenticated request returns 200 after unlocking. A fresh API handles four simultaneous authenticated requests with exactly one shared database construction; profile and health remain 200.

UAT found and repaired the audio DATE failure and RBAC event-loop stall described above; independent review also hardened shared-cache initialization and reset. Thirteen new regression cases reproduce the failures before their corresponding fixes. Quota validation passed 5 PostgreSQL and 49 existing tests; RBAC validation passed 7 PostgreSQL and 53 existing tests; cache validation included 42 related tests, a repeat of all four lock regressions, and 26 affected tests after the final reset repair. All batches exited successfully. Scoped lint/compilation/security checks pass with no new Bandit findings, and independent review has no remaining findings. The disposable database, servers, and browsers were cleaned up. Chat used the repository's controlled HTTP provider to verify exact outgoing models; real LLM inference and the previously published Docker image were not tested. The admin UI used a production build; WebUI used its development build.

See the [live UAT report and sanitized evidence](https://github.com/rmusser01/tldw_server/blob/c26b30c5cb652cf47e139231923eabdb465fbac5/Docs/Reviews/ISSUES_2935_2938_LIVE_UAT_2026_09_10.md).

## Risk & Rollback

- Risk level: Medium, because schema upgrades and shared auth/chat paths are affected. Existing session activity values and model-selection precedence are preserved.
- Rollback: revert the application changes. The additive `last_activity` column can remain; do not remove session data to roll back the code.

## Change summary

The requester explicitly directed merging the fixes for the issues listed in this PR and overrode the separate human-written-summary requirement for this merge. This records that override; it does not represent an AI-written rationale as human-authored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes regressions in JWT verification, session schema, PostgreSQL array binding, chat model defaults, audio quota date encoding, synchronous RBAC lookups, and webhook status validation, plus issues found during live UAT and Qodo review.

**Bug Fixes**
- JWT middleware rejects malformed signatures and non-string algorithm headers without exceptions.
- `sessions.last_activity` is added and backfilled for PostgreSQL and SQLite; new sessions initialize it explicitly.
- PostgreSQL array binding preserves single arrays in profile overrides, managed-secret lookups, and scoped counts.
- Audio quota queries pass native PostgreSQL dates while SQLite continues storing text.
- Omitted or blank chat models resolve to configured provider defaults, with a 400 when none exist; the effective model is resolved before macro persistence.
- RBAC role and permission enrichment runs off the event loop, and concurrent auth config initialization is serialized.
- Webhook status validation discards additive delivery metadata instead of failing on the extra field.
- Diagnostics for missing model configuration no longer leak exception text.
- Session DDL moved into DB-owned helpers.
- Required CI shard assignments updated for new test files.

**Migration**
- Adds `sessions.last_activity` with backfill for existing rows on PostgreSQL and SQLite.
- SQLite migration test updated to allow intentional columns from migration 93.

<sup>Written for commit c26b30c5cb652cf47e139231923eabdb465fbac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

