### PR TITLE
fix(buddy): retain artwork credits through imports and exports

### DIFF
--- a/Docs/API/Buddies.md
+++ b/Docs/API/Buddies.md
@@ -40,3 +40,25 @@ Schema version 66 adds independent profile, asset, attachment, exact-acknowledge
 The profile deletion flag uses a boolean schema and bound boolean update values on both backends. This matches the ChaCha PostgreSQL adapter, which converts literal deletion comparisons to `FALSE` and `TRUE`.
 
 An explicit provider/model selection in ordinary neutral workspace Chat is merged into that conversation's settings for later replies. This applies only when Chat requests persistence, both values were explicit, and the authenticated principal owns the conversation. Frozen Persona/character behavior keeps its existing policy. Temporary Buddy reply overrides never replace these saved defaults.
+
+
+## Imported artwork credits
+
+Native `source_context.artwork` is a canonical JSON string containing the
+version-1 `creator`, `license`, `source_url` and `notices` record. Import validates
+and stores it in the pack's existing manifest JSON under `tldw/artwork`.
+Independent copies retain it in `attribution.artwork` and their owned manifest,
+including after deletion of the source Persona. These fields are untrusted data;
+source URLs are never fetched and notices do not grant tool permissions.
+
+Native export removes the internal manifest field from an exported copy and
+restores `source_context.artwork`, preserving Chatbook's strict animation schema.
+Credits participate in the export fingerprint. Invalid or conflicting carriers
+are rejected; credit-free packs retain their existing behavior. Field and byte
+limits are recorded in [ADR-006](../../backlog/decisions/006-buddy-artwork-credit-portability.md).
+
+Earlier imports may already have lost their credits. Re-import the credited
+original archive and create a new independent Buddy; existing immutable copies
+are not silently rewritten. Keep original notice files for archives which did
+not embed credits. The existing import-job repository supports SQLite only;
+PostgreSQL artwork snapshot and native export paths preserve the same credits.

--- a/Docs/Reviews/2026-09-10-buddy-followup.md
+++ b/Docs/Reviews/2026-09-10-buddy-followup.md
@@ -98,3 +98,32 @@ Installed-extension and native-terminal fresh/upgraded journeys remain open.
 Physical voice qualification also remains open; no capture was started here.
 The direct downloaded-pack upload option in independent Buddy management is a
 remaining UX opportunity; this repair documents the current supported API route.
+
+
+## PR #2940 review follow-up
+
+Qodo requested explicit helper contracts and typed/documented credit tests. Those
+are now present. A framework-neutral central `PersonaArtworkValidationError`
+retains `ValueError` compatibility and stable messages; it is re-exported from
+central exceptions without importing FastAPI into the artwork validator. Nine
+invalid-record cases first failed when required to raise the domain type, then
+all 44 SQLite portability cases passed after the change. Ruff, Black and touched
+Bandit checks passed with no findings.
+
+Qodo's task-marker report exposed mixed Backlog implementations: the installed
+JavaScript CLI emits `SECTION:NOTES`; the Python MCP/CLI accepts that alias and
+emits `SECTION:IMPLEMENTATION_NOTES`. The supported Python editor normalized the
+two actually damaged tasks (13211/13227), and every historical notes line was
+verified retained. Task13242's original single NOTES section was already valid.
+
+The docs CI failure was a relative link to an API page excluded from the curated
+site. The link now uses its existing public GitHub destination. Local exact docs
+gate retries hit a macOS multiprocessing semaphore allocation failure before
+building pages (`SemLock: ENOSPC`, with 290 GiB disk available), including outside
+the sandbox. This is not evidence of a passing strict build; the Linux CI gate
+must verify it. The cancelled license-audit run had no executable steps/log, so
+no license policy was weakened or changed.
+
+The earlier source-hashed HTTP/native receipt remains tied to its recorded
+implementation. These review changes preserve successful data/animation behavior
+and tighten exception typing; they do not retroactively replace its source hashes.

--- a/Docs/Reviews/2026-09-10-buddy-followup.md
+++ b/Docs/Reviews/2026-09-10-buddy-followup.md
@@ -1,0 +1,100 @@
+# Buddy follow-up: import credits and lifecycle evidence
+
+Tasks: TASK-13242 (credit repair), TASK-13211 (open lifecycle investigation),
+TASK-13227 (open native qualification). Architecture: [ADR-006](../../backlog/decisions/006-buddy-artwork-credit-portability.md), extending ADR-005.
+
+## Findings and repair
+
+On dev `50c1f689575b1bc21ed3e78cdb193b03fe968cdd`, the published Trenchcoat
+archive imported successfully through the real authenticated HTTP worker, but
+the import discarded its embedded creator/source/license record. Independent
+Buddy creation returned 201 without those credits, and a native export returned
+200 without them. This is separate from Chatbook's already-merged path-import fix.
+
+The repair stores bounded artwork credits in existing manifest JSON, snapshots
+them into independent Buddy attribution, and restores the supported native
+carrier on export. It copies no unrelated source context. Export strips the
+internal manifest field from a copy because Chatbook strictly validates animation
+root keys; credits are explicitly included in the export fingerprint.
+
+PostgreSQL testing also exposed native export passing `datetime` values to JSON.
+Only exported pack/asset timestamp fields now normalize those values to ISO text;
+SQLite strings remain unchanged. PostgreSQL import-job metadata remains explicitly
+unsupported by its existing repository. No migration or import-job backend expansion.
+
+Already-imported missing credits cannot be reconstructed. Re-import the original
+credited archive and make a new independent copy. Originals without embedded
+credits still require their accompanying notice files.
+
+## Verification
+
+- RED: 10 credit-focused SQLite cases failed before implementation, including
+  missing imported credits and invalid metadata being ignored.
+- An intermediate focused run passed 111 cases and exposed the PostgreSQL
+  timestamp failure. After the fix, the final portability file passed **45 tests**,
+  including PostgreSQL snapshot/export/preview. The adjacent independent-Buddy,
+  visual-manifest and asset-remapping files supplied **72 passing cases** in the
+  earlier focused run. No full suite was run.
+- Ruff, Black and Bandit passed on touched code; Bandit reported zero findings.
+- Independent review found native export incompatibility and a new rejection of
+  legacy credit-free source context. Both received regression coverage and were
+  resolved; final review reported no blockers.
+- Real HTTP on a disposable SQLite server: preview → worker commit → independent
+  Buddy copy → worker export → downloaded archive → worker re-import all completed.
+  The exact creator, source URL, license and **11,654 UTF-8 bytes of notices**
+  survived. Every original PNG byte hash matched.
+- The final exported archive passed Chatbook's actual native importer and draft
+  validation: one asset, 18 states, activatable, exact credits, staging cleanup.
+  Code came from Chatbook `fc7e0a0c2a3c2f03a2b5c7670a50c680760e9daf`; its complete
+  Persona_Visual package has no diff from fetched dev `02374bf66a`.
+
+The [machine-readable receipt](artifacts/buddy-credits-13242/verification.json)
+records source file hashes and the exact archive hashes. Runtime source was the
+pinned server base plus the recorded repair files. No provider credentials,
+physical microphone or external model account were used. Service-level native
+import is not a terminal UI walkthrough.
+
+Reproduction command for focused storage verification (using a disposable local
+PostgreSQL fixture with its test connection environment):
+
+```sh
+source .venv/bin/activate
+TLDW_TEST_NO_DOCKER=1 TLDW_TEST_POSTGRES_REQUIRED=1 python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_portability.py -q
+```
+
+## Legacy request-loop investigation
+
+A clean frozen-lock WebUI archive of server dev `50c1f68957` ran in webpack
+development mode on loopback 18180 against the disposable backend on 18181.
+Temporary console probes recorded legacy host mount/cleanup, pack-list effect
+inputs, session-list inputs and context publications. Probes were confined to
+the disposable frontend, not shipped as a production change.
+
+In the actual in-app browser on `/persona`:
+
+| UTC | Explicit viewport/action | Observed diagnostic |
+| --- | --- | --- |
+| 14:17:05.212 | 1280 × 800 | Pack list, development cleanup/remount, second pack list; one session list at .216 |
+| 14:17:20.447 | 1023 × 800 | Legacy host cleanup; dock removed |
+| 14:17:27.347 | 1024 × 800 | Host mount, development cleanup/remount, two pack lists; one session list at .351 |
+
+This establishes breakpoint-driven remounts as one source of paired reloads. It
+does **not** reproduce the historical ~250 ms loop or establish its initiating
+trigger. No rate-limit failure was observed during these transitions. Later
+context-null logs coincide with deliberate backend restarts for credit testing
+and do not count as spontaneous loop evidence. The viewport override was reset.
+
+Source review confirms pack-list dependencies are Persona identity, target
+availability and refresh nonce. A surface-only change reloads sessions, not
+packs. A normal readiness poll has no 250 ms retry. The original incident's
+frontend SHA was unavailable locally, so no exact-source historical diagnosis is
+claimed. TASK-13211 remains open; do not apply a speculative lifecycle fix.
+
+## Remaining qualification
+
+Native Chrome control returned **Computer Use permissions are not granted**.
+Installed-extension and native-terminal fresh/upgraded journeys remain open.
+Physical voice qualification also remains open; no capture was started here.
+The direct downloaded-pack upload option in independent Buddy management is a
+remaining UX opportunity; this repair documents the current supported API route.

--- a/Docs/Reviews/artifacts/buddy-credits-13242/verification.json
+++ b/Docs/Reviews/artifacts/buddy-credits-13242/verification.json
@@ -1,0 +1,49 @@
+{
+  "base_revision": "50c1f689575b1bc21ed3e78cdb193b03fe968cdd",
+  "source_sha256": "620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f",
+  "export_sha256": "7ed134899859103e72296cae08bdf5d67c5177f70ad156175938b3c2c35dc001",
+  "import_completed": true,
+  "independent_copy_created": true,
+  "exact_artwork_record_preserved": true,
+  "asset_bytes_unchanged": true,
+  "export_reimport_completed": true,
+  "creator": "tldw-project",
+  "license": "Apache-2.0",
+  "notice_utf8_bytes": 11654,
+  "backend": "SQLite",
+  "physical_microphone": false,
+  "external_provider": false,
+  "persona_id": "124028a5-aaff-4ddf-810a-07e95c2765d3",
+  "pack_id": "e1a7d366-ed14-4267-b67b-e365ee2c1357",
+  "buddy_id": "5958b3e8bbba426ca5d0e9df991caa5f",
+  "restored_pack_id": "2640bd21-0268-4ca6-af32-587d1ec058eb",
+  "chatbook": {
+    "chatbook_revision": "fc7e0a0c2a3c2f03a2b5c7670a50c680760e9daf",
+    "export_sha256": "7ed134899859103e72296cae08bdf5d67c5177f70ad156175938b3c2c35dc001",
+    "native_import_passed": true,
+    "activatable": true,
+    "asset_count": 1,
+    "state_count": 18,
+    "exact_credits_retained": true,
+    "cleanup_passed": true,
+    "native_terminal_ui": false
+  },
+  "chatbook_visual_package_matches_dev": "02374bf66af4e6a594d1a63f7f2d559554714fa8",
+  "source_files_sha256": {
+    "tldw_Server_API/app/core/Persona/visual_artwork.py": "abed02ee92f55189d4d28fac072ecb1881701192a9056e3b4d022833be97e491",
+    "tldw_Server_API/app/core/Persona/visuals.py": "c090c399b00c11f3be6a29c3f9370d68fb5a2fd4575ee87f4f1c0b47eb815317",
+    "tldw_Server_API/app/core/Persona/visual_portability/preview.py": "47c6a45ed86d6c5d8f79ba9d38b4f98dc1cda08ad456e6e3a3c3b0fd9df75a18",
+    "tldw_Server_API/app/core/Persona/visual_portability/importer.py": "2e71135567e7f7160983734bea2221cd26b5c4dbea0b4bd52604390d0d6f46dc",
+    "tldw_Server_API/app/core/Persona/visual_portability/exporter.py": "316719b0b639c310bcb6e967672db1e6cb26713db524919f8391ce94aa5935ef",
+    "tldw_Server_API/app/core/Buddy/service.py": "1007b0e424f8431e112877cae5a76b3ea1aaf7403f3502a9a5e55e90438f2098"
+  },
+  "automated_tests": {
+    "final_portability_passed": 45,
+    "adjacent_ownership_manifest_asset_passed": 72,
+    "postgresql_snapshot_export_passed": true,
+    "postgresql_import_jobs_supported": false,
+    "ruff": "passed",
+    "black": "passed",
+    "bandit_findings": 0
+  }
+}

--- a/Docs/User_Guides/WebUI/Buddy_And_Persona_Management.md
+++ b/Docs/User_Guides/WebUI/Buddy_And_Persona_Management.md
@@ -61,7 +61,7 @@ The full Persona Live session remains available in Persona Garden for its existi
 Downloaded `.tldw-persona-vpack` files currently use the Persona import API;
 the Buddy manager offers existing Buddies and ready-made artwork, without a
 file-upload control. After importing and reviewing a pack, create an independent
-copy through the [Buddy API](../../API/Buddies.md), leave the optional Persona
+copy through the [Buddy API](https://github.com/rmusser01/tldw_server/blob/dev/Docs/API/Buddies.md), leave the optional Persona
 unset if desired, then select the new Buddy and apply its target in management.
 
 Credited packs keep their embedded creator, license, source URL and notices

--- a/Docs/User_Guides/WebUI/Buddy_And_Persona_Management.md
+++ b/Docs/User_Guides/WebUI/Buddy_And_Persona_Management.md
@@ -54,3 +54,18 @@ The full Persona Live session remains available in Persona Garden for its existi
 - [Speech setup](../WebUI_Extension/Getting-Started-STT_and_TTS.md)
 - [Independent Buddy API](https://github.com/rmusser01/tldw_server/blob/dev/Docs/API/Buddies.md)
 - [Accepted Buddy turns: operation, failures, and restart](https://github.com/rmusser01/tldw_server/blob/dev/Docs/Operations/Buddy_Turns.md)
+
+
+## Downloaded Buddy packs and credits
+
+Downloaded `.tldw-persona-vpack` files currently use the Persona import API;
+the Buddy manager offers existing Buddies and ready-made artwork, without a
+file-upload control. After importing and reviewing a pack, create an independent
+copy through the [Buddy API](../../API/Buddies.md), leave the optional Persona
+unset if desired, then select the new Buddy and apply its target in management.
+
+Credited packs keep their embedded creator, license, source URL and notices
+through new imports, independent copies and native exports. Older imports may
+have lost those fields; recover them by re-importing the original download and
+making a new Buddy copy. Keep the accompanying license files when the original
+archive did not embed notices. Import jobs currently require SQLite storage.

--- a/backlog/decisions/006-buddy-artwork-credit-portability.md
+++ b/backlog/decisions/006-buddy-artwork-credit-portability.md
@@ -1,0 +1,56 @@
+# ADR-006: Buddy artwork credit portability
+
+Status: Accepted
+Date: 2026-09-10
+Task: TASK-13242
+Extends: [ADR-005](005-independent-buddy-bindings-and-work-ownership.md)
+
+## Context
+
+A live import of the published Trenchcoat pack on dev 50c1f68957 discarded
+`metadata/pack.json`'s `source_context.artwork` record. Independent copies and
+native exports consequently lost the creator, source URL and license notices.
+ADR-005 already requires Buddy-owned artwork attribution.
+
+## Decision
+
+Store the optional version-1 artwork record as `visual_manifest["tldw/artwork"]`
+inside the existing manifest JSON. This travels with the artwork and asset
+remapping, and needs no database
+migration. Native imports accept the existing canonical JSON string in
+`source_context.artwork`; exports restore that carrier and remove the internal
+manifest field from the exported copy for Chatbook's strict manifest compatibility.
+Export fingerprints include the optional artwork carrier explicitly. Credit-free
+fingerprints retain their existing shape.
+If both carriers are present, they must agree. Independent Buddy creation copies
+the record into its owned `attribution.artwork` as well as its manifest.
+
+The record contains only `version`, `creator`, `license`, `source_url`, and
+`notices`. Reject unsupported versions, unknown fields, invalid text, malformed
+carriers and conflicting claims. Bound the encoded record to 512 KiB, notices
+to 64 KiB, creator to 512 bytes, license to 4096 bytes, and URL to 2048 bytes.
+Source URLs must be credential-free public HTTPS references. They are never
+fetched. Credits and notices are untrusted data, never instructions, execution
+policy or authorization. Do not copy unrelated `source_context` properties.
+
+Packs without credits retain their existing behavior. Do not invent attribution
+for earlier imports: lost records can only be recovered by re-importing a
+credited original and creating a new independent copy. Existing copies remain
+independent and are not silently rewritten.
+
+## Alternatives
+
+- A Persona-level reference would break independent ownership after deletion.
+- New database columns and migrations add backend work for optional structured
+  metadata already supported by the manifest JSON storage contract.
+- Preserving arbitrary source context would retain unrelated or sensitive data.
+- A credits sidecar outside manifest fingerprints would let credit changes escape
+  existing content identity checks.
+
+## Verification
+
+Exercise real preview, commit, copy, source removal, export and re-import; check
+exact notices and original asset bytes. Cover malformed and conflicting records,
+credit-free compatibility and the existing PostgreSQL storage adapter when
+available. Record the published Trenchcoat HTTP round trip separately from unit
+test evidence.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -330,3 +330,15 @@ resolver while replacing only credential/network/model-weight I/O. A retained
 async-generator reference also exposed error cleanup running after credential
 disposal; asserting cleanup order before returning catches what eventual-GC
 checks miss.
+
+
+## Native portability needs the destination importer (TASK-13242, 2026-09-10)
+
+A server-to-server Trenchcoat credit round trip passed while the export still
+contained an internal manifest extension that Chatbook rejects. Read-only review
+caught the strict-root mismatch; after moving credits back to the native carrier,
+the actual Chatbook importer accepted the same HTTP-exported archive with all
+18 states and exact notices. A source host's own re-import is insufficient evidence
+of cross-host portability. The same task's PostgreSQL run first exposed datetime
+export serialization and then the explicit SQLite-only import-job boundary;
+qualify supported storage paths separately instead of claiming backend parity.

--- a/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
+++ b/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
@@ -3,12 +3,12 @@ id: TASK-13211
 title: Investigate repeated Buddy visual pack loads during live UAT
 status: In Progress
 assignee: []
-created_date: '2026-09-06 16:57'
-updated_date: '2026-09-10 14:42'
+created_date: 2026-09-06 16:57
+updated_date: 2026-09-10 14:58
 labels: []
 dependencies: []
 references:
-  - Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md
+- Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md
 ---
 
 ## Description
@@ -35,28 +35,21 @@ ADR required: no. Reason: investigation and routine lifecycle repair within exis
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-09-06 physical visual check: repeated authenticated pack list/detail and live-session list requests every ~250 ms, ending in HTTP 429 and a visible 'Visual pack did not load — rate_limited' error. Source review could not establish the initiating trigger. Pack effect dependencies are persona identity, target availability and refresh nonce; local sprite frame cycling alone cannot explain the session-list requests. After rebase/HMR reload and reconnect, screenshot sampling and one real text provider reply did not reproduce the request loop. No speculative repair applied. Targeted BuddyShellHost + Persona route suites passed 129 tests. Remaining work: instrument host mount/dependency/event counts during an actual reproduced failure, then add a failing regression and repair. Bandit not applicable: this task changes only investigation documentation.
 Voice follow-up PR created against dev: https://github.com/rmusser01/tldw_server/pull/2927 . This task remains open; PR creation does not qualify the outstanding floating visual acceptance. UAT session disconnected and temporary browser viewport restored.
 2026-09-09 qualification on pinned merged dev 1fc19c7: independent Buddy artwork remained visible through fresh setup, Static/Dynamic changes, Watchlists/Research Workspace navigation and scoped replies. A current-process aggregate recorded no HTTP 429; detailed receipts and analysis are retained in Docs/Reviews/2026-09-09-buddy-v1-qualification.md and artifacts/buddy-v1-13227. Source investigation confirms no 250 ms loader retry; paired legacy pack/session reloads require host remount or normalized Persona/surface change. IndependentBuddyHost landed after the 2026-09-06 incident and is excluded as its original cause. Existing BuddyShellHost/usePersonaLiveControl/IndependentBuddyHost checks passed 81 tests. The legacy initiating trigger remains unreproduced; integrated legacy lifecycle instrumentation during the real failure is still needed. No speculative repair; all original AC remain open. Bandit not applicable to this investigation-only update.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 2026-09-10 follow-up: investigate current dev 50c1f68957 in isolated branch codex/buddy-v1-followup. Review real route/host/service boundaries and instrument disposable live UI before choosing a fix. Existing ADR005 applies; no new architecture or speculative repair. Official MCP task_view was unresponsive; using CLI fallback.
 
 2026-09-10 controlled browser diagnostics: 1280px mount, 1023px cleanup, 1024px remount with two development pack-list calls and one session-list call. Confirms breakpoint source of paired reloads, not original rapid loop. No initiating trigger or 429 reproduced; all original AC remain open. Source-bound details/timestamps in Docs/Reviews/2026-09-10-buddy-followup.md. Temporary probes not shipped; viewport restored.
-<!-- SECTION:NOTES:END -->
 
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed

--- a/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
+++ b/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
@@ -2,10 +2,13 @@
 id: TASK-13211
 title: Investigate repeated Buddy visual pack loads during live UAT
 status: In Progress
-created_date: 2026-09-06 16:57
+assignee: []
+created_date: '2026-09-06 16:57'
+updated_date: '2026-09-10 14:42'
+labels: []
+dependencies: []
 references:
-- Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md
-updated_date: 2026-09-09 05:26
+  - Docs/Reviews/MIGU_VOICE_FOLLOWUP_2026_09_06.md
 ---
 
 ## Description
@@ -32,14 +35,25 @@ ADR required: no. Reason: investigation and routine lifecycle repair within exis
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-09-06 physical visual check: repeated authenticated pack list/detail and live-session list requests every ~250 ms, ending in HTTP 429 and a visible 'Visual pack did not load — rate_limited' error. Source review could not establish the initiating trigger. Pack effect dependencies are persona identity, target availability and refresh nonce; local sprite frame cycling alone cannot explain the session-list requests. After rebase/HMR reload and reconnect, screenshot sampling and one real text provider reply did not reproduce the request loop. No speculative repair applied. Targeted BuddyShellHost + Persona route suites passed 129 tests. Remaining work: instrument host mount/dependency/event counts during an actual reproduced failure, then add a failing regression and repair. Bandit not applicable: this task changes only investigation documentation.
 Voice follow-up PR created against dev: https://github.com/rmusser01/tldw_server/pull/2927 . This task remains open; PR creation does not qualify the outstanding floating visual acceptance. UAT session disconnected and temporary browser viewport restored.
 2026-09-09 qualification on pinned merged dev 1fc19c7: independent Buddy artwork remained visible through fresh setup, Static/Dynamic changes, Watchlists/Research Workspace navigation and scoped replies. A current-process aggregate recorded no HTTP 429; detailed receipts and analysis are retained in Docs/Reviews/2026-09-09-buddy-v1-qualification.md and artifacts/buddy-v1-13227. Source investigation confirms no 250 ms loader retry; paired legacy pack/session reloads require host remount or normalized Persona/surface change. IndependentBuddyHost landed after the 2026-09-06 incident and is excluded as its original cause. Existing BuddyShellHost/usePersonaLiveControl/IndependentBuddyHost checks passed 81 tests. The legacy initiating trigger remains unreproduced; integrated legacy lifecycle instrumentation during the real failure is still needed. No speculative repair; all original AC remain open. Bandit not applicable to this investigation-only update.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-09-10 follow-up: investigate current dev 50c1f68957 in isolated branch codex/buddy-v1-followup. Review real route/host/service boundaries and instrument disposable live UI before choosing a fix. Existing ADR005 applies; no new architecture or speculative repair. Official MCP task_view was unresponsive; using CLI fallback.
+
+2026-09-10 controlled browser diagnostics: 1280px mount, 1023px cleanup, 1024px remount with two development pack-list calls and one session-list call. Confirms breakpoint source of paired reloads, not original rapid loop. No initiating trigger or 429 reproduced; all original AC remain open. Source-bound details/timestamps in Docs/Reviews/2026-09-10-buddy-followup.md. Temporary probes not shipped; viewport restored.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-13227 - Qualify-merged-Buddy-v1-setup-and-navigation-in-WebUI-and-extension.md
+++ b/backlog/tasks/task-13227 - Qualify-merged-Buddy-v1-setup-and-navigation-in-WebUI-and-extension.md
@@ -3,17 +3,17 @@ id: TASK-13227
 title: Qualify merged Buddy v1 setup and navigation in WebUI and extension
 status: In Progress
 assignee:
-  - '@codex'
-created_date: '2026-09-09 04:32'
-updated_date: '2026-09-10 14:42'
+- '@codex'
+created_date: 2026-09-09 04:32
+updated_date: 2026-09-10 14:58
 labels: []
 dependencies: []
 references:
-  - TASK-13226
-  - TASK-13211
-  - TASK-13202
+- TASK-13226
+- TASK-13211
+- TASK-13202
 documentation:
-  - Docs/superpowers/plans/2026-09-09-buddy-v1-live-qualification.md
+- Docs/superpowers/plans/2026-09-09-buddy-v1-live-qualification.md
 priority: high
 ---
 
@@ -46,7 +46,6 @@ PR2934 Qodo findings 1, 3 and 5 follow-up: move optional catalog generation meta
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Fresh WebUI selected Pixel Migu without Persona, attached New Research workspace, retained the visible Buddy on Watchlists, opened scoped interaction there, saved Static mode, and verified Cancel preserves None before saving Research Assistant for future conversations. Provider catalog failure traced to blank optional *_max_tokens in shipped defaults; scoped repair added to acceptance before implementation.
 Qualification reconciled in Docs/Reviews/2026-09-09-buddy-v1-qualification.md with curated receipts/source hashes. Fresh WebUI: independent Pixel Migu, None/Research Assistant workspace defaults and inheritance, Static/Dynamic artwork, exact conversation Buddy reply completed after Watchlists-to-Workspace navigation, selected workspace conversation increased from 5 to 7 messages while sibling stayed at 5, and one acknowledged result left the sibling unread. Original blank-config catalog defect repaired with 5 focused/adjacent tests; assistant-only readable error rendering repaired with 8 component/decoder tests and quoted-user-envelope preservation. Backend 51 passed/1 unavailable-PostgreSQL skip; frontend artwork/lifecycle 81 passed. Bandit and touched regression formatting passed; unchanged source lint debt recorded. Final Chrome production build, shared-token sync, manifest targets and ZIP integrity passed. TASK-13211 investigation reconciled without speculative repair. AC2 covers typed reply and result receipt/acknowledgement semantics; real audible queue playback remains unqualified. AC1 remains open: native Chrome permissions unavailable, Terminal explicitly prohibited by Computer Use, upgraded-profile WebUI journey and native Chatbook interaction incomplete. No full suite or human-voice pass claimed. ADR-005 remains the governing contract.
@@ -54,7 +53,6 @@ Before finalization, independent review identified that a newly arriving saved a
 Final review correction complete: private assistant-only formatter is shared by visual history and read-aloud after its authorized transcript read, preserving the conversation-name prefix. Activity-to-speech regression failed first with raw JSON/detail, then final component/decoder gate passed9/9; independent re-review has no remaining findings. Final Chrome build includes this source and passed in43s; ZIP SHA2561375a51f13cb851ca3e12c277b0da2b7e6da19f510038382fe3c6d6c778048e8. Final catalog gate passed5/5 and Bandit reported no findings; raw final logs and curated manifest retained. Original catalog RED and81-test artwork raw logs were not separately retained, so their worker summaries are labeled accordingly. Owned disposable WebUI/backend/mock processes stopped; profiles and artifacts retained. AC1/native acceptance remains open.
 Published draft PR https://github.com/rmusser01/tldw_server/pull/2934 against dev with the reviewed fixes and qualified evidence. Native/upgrade acceptance and the human-written summary gate for any future merge remain open; no merge performed.
 Follow-up PR #2934 now implements TASK-13228/13229/13230. Final evidence: 94 focused UI tests, 58 backend passes with one PostgreSQL availability skip, 12 Persona compatibility passes; reviewed Chrome build, manifest and ZIP checks passed. Live desktop composer hit-testing and explicit model recovery completed against copied disposable data. Final null-timestamp and pinned-transport review corrections have focused regressions and clean re-review. Native/voice/upgraded-profile coverage remains open; the further new-workspace browser handoff was limited by disposable connection reconfiguration. Qualification remains In Progress. Follow-up artifacts: Docs/Reviews/artifacts/buddy-ux-followups-13228-13230.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 PR2934 Qodo follow-up (2026-09-09): verify and resolve seven findings, preserving the original qualification bundle. Backend owner moves new catalog/persistence policy to core and supplies public/test contracts plus explicit test markers/types; UI owner completes duplicate-title setup labels and stable speech dependencies. Root will review combined deltas, run the focused integration gate, retain separate current-source test/static/build receipts, regenerate the Chrome package after final UI changes, and publish review dispositions. The new reply-settings endpoint also requires canonical OpenAPI fingerprint/client-type regeneration before CI can pass. Existing ADR005 applies; native/upgrade/voice acceptance remains open. Official Backlog MCP calls were unavailable, so the documented CLI fallback is used.
 
@@ -63,18 +61,13 @@ PR2934 review follow-up started after verifying Qodo findings against source. Of
 PR2934 Qodo backend findings 1, 3 and 5 follow-up completed. Catalog generation metadata policy now lives in the existing core LLM_Calls/provider_config_resolution.py seam, covering adjacent temperature/streaming fields together with blank-token omission; llm_providers.py delegates the projection. Invalid nonblank limits preserve the existing sanitized error behavior. The optional-metadata test module now has module/function contracts, typed helpers and pytest.mark.unit. The marker negative control selected 0 of 3 tests before the fix; after the fix all 3 pass, including valid temperature/streaming projection. One existing adjacent env-only numbered-provider catalog test also passes, covering missing config sections through the same path. Logs: /private/tmp/server-pr2934-catalog-marker-before.log, server-pr2934-catalog-marker-after.log, server-pr2934-provider-config-adjacent.log. The full scoped follow-up also has 36 Buddy/adjacent and 12 Persona passes, without rerunning a full suite. Scoped Black/compile/whitespace pass, zero new Ruff findings against the exact HEAD baseline, and zero production Bandit findings/errors; existing lint and test-assertion findings are distinguished in server-pr2934-backend-static-summary.log and server-pr2934-contract-and-bandit-summary.log. Original evidence remains historical; root will retain a separate review receipt. No production behavior expansion, provider invocation, commit or push. Native qualification remains open; existing ADR-005 boundary unchanged.
 
 2026-09-10 follow-up published Trenchcoat imported via real authenticated HTTP worker, activated in WebUI, and copied independently by API. This exposed and repaired lost credits in TASK13242. Final HTTP export/reimport and actual Chatbook native importer pass. Native Chrome control blocked by Computer Use permissions; no installed-extension/terminal or physical voice qualification claimed. See Docs/Reviews/2026-09-10-buddy-followup.md; task remains open.
-<!-- SECTION:NOTES:END -->
 
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed

--- a/backlog/tasks/task-13227 - Qualify-merged-Buddy-v1-setup-and-navigation-in-WebUI-and-extension.md
+++ b/backlog/tasks/task-13227 - Qualify-merged-Buddy-v1-setup-and-navigation-in-WebUI-and-extension.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-09 04:32'
-updated_date: '2026-09-09 07:04'
+updated_date: '2026-09-10 14:42'
 labels: []
 dependencies: []
 references:
@@ -61,6 +61,8 @@ PR2934 Qodo follow-up (2026-09-09): verify and resolve seven findings, preservin
 PR2934 review follow-up started after verifying Qodo findings against source. Official MCP task reads were unresponsive and terminated; using the explicitly documented CLI fallback. Historical completion and qualification receipts remain attributed to their original source.
 
 PR2934 Qodo backend findings 1, 3 and 5 follow-up completed. Catalog generation metadata policy now lives in the existing core LLM_Calls/provider_config_resolution.py seam, covering adjacent temperature/streaming fields together with blank-token omission; llm_providers.py delegates the projection. Invalid nonblank limits preserve the existing sanitized error behavior. The optional-metadata test module now has module/function contracts, typed helpers and pytest.mark.unit. The marker negative control selected 0 of 3 tests before the fix; after the fix all 3 pass, including valid temperature/streaming projection. One existing adjacent env-only numbered-provider catalog test also passes, covering missing config sections through the same path. Logs: /private/tmp/server-pr2934-catalog-marker-before.log, server-pr2934-catalog-marker-after.log, server-pr2934-provider-config-adjacent.log. The full scoped follow-up also has 36 Buddy/adjacent and 12 Persona passes, without rerunning a full suite. Scoped Black/compile/whitespace pass, zero new Ruff findings against the exact HEAD baseline, and zero production Bandit findings/errors; existing lint and test-assertion findings are distinguished in server-pr2934-backend-static-summary.log and server-pr2934-contract-and-bandit-summary.log. Original evidence remains historical; root will retain a separate review receipt. No production behavior expansion, provider invocation, commit or push. Native qualification remains open; existing ADR-005 boundary unchanged.
+
+2026-09-10 follow-up published Trenchcoat imported via real authenticated HTTP worker, activated in WebUI, and copied independently by API. This exposed and repaired lost credits in TASK13242. Final HTTP export/reimport and actual Chatbook native importer pass. Native Chrome control blocked by Computer Use permissions; no installed-extension/terminal or physical voice qualification claimed. See Docs/Reviews/2026-09-10-buddy-followup.md; task remains open.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
+++ b/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
@@ -3,13 +3,13 @@ id: TASK-13242
 title: Preserve imported Buddy artwork credits through server copies and exports
 status: In Progress
 assignee:
-  - '@codex'
-created_date: '2026-09-10 14:16'
-updated_date: '2026-09-10 14:45'
+- '@codex'
+created_date: 2026-09-10 14:16
+updated_date: 2026-09-10 15:01
 labels:
-  - buddy
-  - persona
-  - portability
+- buddy
+- persona
+- portability
 dependencies: []
 priority: high
 ---
@@ -45,7 +45,7 @@ Reason: Optional bounded metadata bridge extends ADR-005 ownership, with no migr
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Reproduced 2026-09-10 using authenticated HTTP plus the standard Persona portability worker in a disposable profile. Original archive SHA256620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f. Import preview and commit completed; independent POST /api/v1/buddies returned201; exported archive downloaded200. Creator absent in copied attribution and all exported metadata. Evidence under /private/tmp/buddy-v1-followup-n4shbp3q/attribution-result.json. Related ADR005 requires independent artwork attribution ownership; persistence design must be checked before implementation.
 
 Focused run: 111 passed; PostgreSQL journey reproduced a pre-existing native export failure because metadata pack/asset timestamp values are datetime objects. Repair will normalize only the exported timestamp fields to ISO text, preserving SQLite string behavior and the existing storage schema. SQLite published Trenchcoat HTTP import/copy/export/re-import now preserves the exact 11,654-byte notices and original PNG bytes.
@@ -55,8 +55,8 @@ PostgreSQL portability import-job storage explicitly raises NotImplementedError 
 Implemented ADR-006: native credit validation/storage, independent attribution snapshots, native-compatible export with credit-sensitive fingerprints, and narrow PostgreSQL timestamp normalization. Resolved both independent-review findings (Chatbook strict-root compatibility and legacy credit-free context). Final portability:45 passed including supported PostgreSQL copy/export; adjacent ownership/manifest/asset tests:72 passed. Ruff/Black passed; Bandit zero findings. Final published Trenchcoat HTTP roundtrip and actual Chatbook importer preserve exact credits and PNG bytes. See Docs/Reviews/2026-09-10-buddy-followup.md and its source-hashed receipt. PostgreSQL import jobs remain unsupported; native terminal/installed extension and physical voice qualification stay open. PR review/merge pending.
 
 Published PR https://github.com/rmusser01/tldw_server/pull/2940 against freshly fetched dev50c1f68957. Implementation commit0e72f25515, no behind-dev commits at publication. Collection installation guidance in tldw-stuff PR18 links the source-bound verification and recovery instructions. Task remains In Progress pending PR review/merge.
-<!-- SECTION:NOTES:END -->
-
+PR2940 Qodo follow-up: documented helper contracts, typed/documented tests, central ValueError-compatible artwork exception, repaired mixed-CLI nested task markers without losing notes. Nine invalid-record tests RED on generic exceptions;44 SQLite portability cases pass after domain type. Ruff/Black/Bandit pass. Fixed curated-site API link from actual docs CI failure; local exact docs gate blocked before build by macOS SemLock ENOSPC, Linux CI pending. Collection PR18 merged75a800815f51aa220c82da7778d17f8a1e292a42.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed

--- a/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
+++ b/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
@@ -1,0 +1,66 @@
+---
+id: TASK-13242
+title: Preserve imported Buddy artwork credits through server copies and exports
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-10 14:16'
+updated_date: '2026-09-10 14:42'
+labels:
+  - buddy
+  - persona
+  - portability
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live Trenchcoat import on dev 50c1f68957 succeeds but discards embedded creator, source URL and Apache-2.0 notices. Both the independent Buddy copy and a native re-export lose this metadata. Preserve authored artwork credits while treating them as untrusted content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A native pack import retains validated bounded artwork creator, source and license notices from the supported source_context.artwork carrier.
+- [x] #2 Independent Buddy copying and native export/re-import preserve the artwork metadata without depending on the source Persona.
+- [x] #3 Malformed, oversized and unknown metadata cannot become executable policy or leak unrelated source context; existing packs without artwork metadata remain compatible.
+- [x] #4 A failing regression reproduces the observed loss, and real Trenchcoat import/copy/export verifies the repair on SQLite and supported PostgreSQL storage paths.
+- [x] #5 PostgreSQL native export serializes stored timestamp values so the credited import/copy/export journey can complete on both supported database backends.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/006-buddy-artwork-credit-portability.md
+Reason: Optional bounded metadata bridge extends ADR-005 ownership, with no migration.
+
+1. Reproduce credit loss with real SQLite preview/import/copy/export and invalid metadata cases (done red).
+2. Retain validated credits in existing manifest storage. Restore only the native carrier on export, remove the internal key from the exported copy, and include artwork in export fingerprints. Copy independent attribution; ignore unrelated context.
+3. Verify the full SQLite journey and supported PostgreSQL snapshot/export paths. PostgreSQL import-job metadata is explicitly unsupported by the existing repository; do not expand that boundary. Normalize exported datetime fields uncovered by the PostgreSQL regression.
+4. Run focused regression, lint/format and Bandit. Repeat public Trenchcoat through the authenticated HTTP worker and validate its export with actual Chatbook native code.
+5. Record source-bound evidence, native/voice qualification gaps, review findings and resolution, and re-import recovery guidance; publish the focused dev PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced 2026-09-10 using authenticated HTTP plus the standard Persona portability worker in a disposable profile. Original archive SHA256620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f. Import preview and commit completed; independent POST /api/v1/buddies returned201; exported archive downloaded200. Creator absent in copied attribution and all exported metadata. Evidence under /private/tmp/buddy-v1-followup-n4shbp3q/attribution-result.json. Related ADR005 requires independent artwork attribution ownership; persistence design must be checked before implementation.
+
+Focused run: 111 passed; PostgreSQL journey reproduced a pre-existing native export failure because metadata pack/asset timestamp values are datetime objects. Repair will normalize only the exported timestamp fields to ISO text, preserving SQLite string behavior and the existing storage schema. SQLite published Trenchcoat HTTP import/copy/export/re-import now preserves the exact 11,654-byte notices and original PNG bytes.
+
+PostgreSQL portability import-job storage explicitly raises NotImplementedError (SQLite-only). Revised qualification separates SQLite full import/commit journey from supported PostgreSQL Buddy snapshot/export/preview. Review also found strict native Chatbook manifest rejection of the internal credit key; export now strips that key from a copy, restores source_context.artwork, and explicitly fingerprints credits. No storage/runtime boundary expansion.
+
+Implemented ADR-006: native credit validation/storage, independent attribution snapshots, native-compatible export with credit-sensitive fingerprints, and narrow PostgreSQL timestamp normalization. Resolved both independent-review findings (Chatbook strict-root compatibility and legacy credit-free context). Final portability:45 passed including supported PostgreSQL copy/export; adjacent ownership/manifest/asset tests:72 passed. Ruff/Black passed; Bandit zero findings. Final published Trenchcoat HTTP roundtrip and actual Chatbook importer preserve exact credits and PNG bytes. See Docs/Reviews/2026-09-10-buddy-followup.md and its source-hashed receipt. PostgreSQL import jobs remain unsupported; native terminal/installed extension and physical voice qualification stay open. PR review/merge pending.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
+++ b/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-10 14:16'
-updated_date: '2026-09-10 14:42'
+updated_date: '2026-09-10 14:45'
 labels:
   - buddy
   - persona
@@ -53,6 +53,8 @@ Focused run: 111 passed; PostgreSQL journey reproduced a pre-existing native exp
 PostgreSQL portability import-job storage explicitly raises NotImplementedError (SQLite-only). Revised qualification separates SQLite full import/commit journey from supported PostgreSQL Buddy snapshot/export/preview. Review also found strict native Chatbook manifest rejection of the internal credit key; export now strips that key from a copy, restores source_context.artwork, and explicitly fingerprints credits. No storage/runtime boundary expansion.
 
 Implemented ADR-006: native credit validation/storage, independent attribution snapshots, native-compatible export with credit-sensitive fingerprints, and narrow PostgreSQL timestamp normalization. Resolved both independent-review findings (Chatbook strict-root compatibility and legacy credit-free context). Final portability:45 passed including supported PostgreSQL copy/export; adjacent ownership/manifest/asset tests:72 passed. Ruff/Black passed; Bandit zero findings. Final published Trenchcoat HTTP roundtrip and actual Chatbook importer preserve exact credits and PNG bytes. See Docs/Reviews/2026-09-10-buddy-followup.md and its source-hashed receipt. PostgreSQL import jobs remain unsupported; native terminal/installed extension and physical voice qualification stay open. PR review/merge pending.
+
+Published PR https://github.com/rmusser01/tldw_server/pull/2940 against freshly fetched dev50c1f68957. Implementation commit0e72f25515, no behind-dev commits at publication. Collection installation guidance in tldw-stuff PR18 links the source-bound verification and recovery instructions. Task remains In Progress pending PR review/merge.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Buddy/service.py
+++ b/tldw_Server_API/app/core/Buddy/service.py
@@ -15,6 +15,7 @@ from tldw_Server_API.app.core.DB_Management.Buddy_DB import BuddyRepository
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, NotFoundError
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.exceptions import BuddyNotFoundError
+from tldw_Server_API.app.core.Persona.visual_artwork import ARTWORK_MANIFEST_KEY
 from tldw_Server_API.app.core.Persona.visual_asset_constraints import VISUAL_MIME_EXTENSIONS
 from tldw_Server_API.app.core.Persona.visual_manifest_assets import remap_visual_manifest_assets
 from tldw_Server_API.app.core.Persona.visual_service import MAX_VISUAL_UPLOAD_BYTES, PersonaVisualService
@@ -192,6 +193,8 @@ class BuddyService:
             available_asset_dimensions={asset["id"]: (asset["width"], asset["height"]) for asset in assets},
             require_activatable=True,
         )
+        if ARTWORK_MANIFEST_KEY in validation.manifest:
+            attribution["artwork"] = validation.manifest[ARTWORK_MANIFEST_KEY]
         directory: Path | None = None
         try:
             for asset, (_, content, _) in zip(assets, source_assets, strict=True):

--- a/tldw_Server_API/app/core/Persona/visual_artwork.py
+++ b/tldw_Server_API/app/core/Persona/visual_artwork.py
@@ -1,0 +1,96 @@
+"""Bounded, inert artwork credits shared by native packs and Buddy snapshots."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+ARTWORK_MANIFEST_KEY = "tldw/artwork"
+MAX_ARTWORK_BYTES = 512 * 1024
+_TEXT_LIMITS = {"creator": 512, "license": 4096, "source_url": 2048, "notices": 64 * 1024}
+
+
+def validate_artwork_record(value: object) -> dict[str, Any]:
+    """Validate a version-1 credit record without interpreting or fetching it."""
+    if not isinstance(value, dict) or set(value) != {"version", *_TEXT_LIMITS}:
+        raise ValueError("artwork_attribution_invalid")
+    if type(value["version"]) is not int or value["version"] != 1:
+        raise ValueError("artwork_attribution_invalid")
+    for field, limit in _TEXT_LIMITS.items():
+        text = value[field]
+        if text is None and field != "notices":
+            continue
+        if not isinstance(text, str) or len(text) > limit:
+            raise ValueError("artwork_attribution_invalid")
+        try:
+            valid = len(text.encode("utf-8")) <= limit and not any(
+                (ord(char) < 32 and char not in "\t\r\n") or 127 <= ord(char) <= 159 for char in text
+            )
+        except UnicodeError:
+            valid = False
+        if not valid:
+            raise ValueError("artwork_attribution_invalid")
+    url = value["source_url"]
+    if url is not None:
+        _validate_source_url(url)
+    return dict(value)
+
+
+def _validate_source_url(url: str) -> None:
+    # A display-only public reference, compatible with native Chatbook carriers.
+    try:
+        parsed = urlsplit(url)
+        host = parsed.hostname or ""
+        labels = host.split(".")
+        valid = (
+            parsed.scheme == "https"
+            and parsed.netloc.lower() == host
+            and len(labels) > 1
+            and all(re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", label) for label in labels)
+            and re.fullmatch(r"[a-z][a-z0-9-]*", labels[-1]) is not None
+            and not host.endswith((".local", ".localhost", ".internal", ".lan", ".home"))
+            and not any(char.isspace() or char in "\\?#" for char in url)
+        )
+    except ValueError:
+        valid = False
+    if not valid:
+        raise ValueError("artwork_attribution_invalid")
+
+
+def encode_native_artwork(value: object) -> str:
+    """Return the canonical native source_context.artwork string."""
+    record = validate_artwork_record(value)
+    encoded = json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    if len(encoded.encode("utf-8")) > MAX_ARTWORK_BYTES:
+        raise ValueError("artwork_attribution_invalid")
+    return encoded
+
+
+def artwork_manifest_for_import(pack: dict[str, Any]) -> dict[str, Any]:
+    """Merge agreeing native credit carriers, excluding unrelated source context."""
+    manifest = pack.get("visual_manifest")
+    if not isinstance(manifest, dict):
+        raise ValueError("malformed_metadata: metadata/pack.json")
+    manifest = dict(manifest)
+    if ARTWORK_MANIFEST_KEY in manifest:
+        manifest[ARTWORK_MANIFEST_KEY] = validate_artwork_record(manifest[ARTWORK_MANIFEST_KEY])
+    context = pack.get("source_context", {})
+    if not isinstance(context, dict):
+        return manifest
+    if "artwork" not in context:
+        return manifest
+    carrier = context["artwork"]
+    try:
+        if not isinstance(carrier, str) or len(carrier.encode("utf-8")) > MAX_ARTWORK_BYTES:
+            raise ValueError("artwork_attribution_invalid")
+        record = validate_artwork_record(json.loads(carrier))
+        if encode_native_artwork(record) != carrier:
+            raise ValueError("artwork_attribution_invalid")
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise ValueError("artwork_attribution_invalid") from exc
+    if ARTWORK_MANIFEST_KEY in manifest and manifest[ARTWORK_MANIFEST_KEY] != record:
+        raise ValueError("artwork_attribution_conflict")
+    manifest[ARTWORK_MANIFEST_KEY] = record
+    return manifest

--- a/tldw_Server_API/app/core/Persona/visual_artwork.py
+++ b/tldw_Server_API/app/core/Persona/visual_artwork.py
@@ -7,23 +7,36 @@ import re
 from typing import Any
 from urllib.parse import urlsplit
 
+from tldw_Server_API.app.core.exception_types import PersonaArtworkValidationError
+
 ARTWORK_MANIFEST_KEY = "tldw/artwork"
 MAX_ARTWORK_BYTES = 512 * 1024
 _TEXT_LIMITS = {"creator": 512, "license": 4096, "source_url": 2048, "notices": 64 * 1024}
 
 
 def validate_artwork_record(value: object) -> dict[str, Any]:
-    """Validate a version-1 credit record without interpreting or fetching it."""
+    """Validate a version-1 credit record without interpreting or fetching it.
+
+    Args:
+        value: External object containing exactly the five native credit fields.
+
+    Returns:
+        A new dictionary retaining the original validated strings and nulls.
+
+    Raises:
+        PersonaArtworkValidationError: Fields, version, text bounds or URL syntax
+            violate the supported artwork contract.
+    """
     if not isinstance(value, dict) or set(value) != {"version", *_TEXT_LIMITS}:
-        raise ValueError("artwork_attribution_invalid")
+        raise PersonaArtworkValidationError("artwork_attribution_invalid")
     if type(value["version"]) is not int or value["version"] != 1:
-        raise ValueError("artwork_attribution_invalid")
+        raise PersonaArtworkValidationError("artwork_attribution_invalid")
     for field, limit in _TEXT_LIMITS.items():
         text = value[field]
         if text is None and field != "notices":
             continue
         if not isinstance(text, str) or len(text) > limit:
-            raise ValueError("artwork_attribution_invalid")
+            raise PersonaArtworkValidationError("artwork_attribution_invalid")
         try:
             valid = len(text.encode("utf-8")) <= limit and not any(
                 (ord(char) < 32 and char not in "\t\r\n") or 127 <= ord(char) <= 159 for char in text
@@ -31,7 +44,7 @@ def validate_artwork_record(value: object) -> dict[str, Any]:
         except UnicodeError:
             valid = False
         if not valid:
-            raise ValueError("artwork_attribution_invalid")
+            raise PersonaArtworkValidationError("artwork_attribution_invalid")
     url = value["source_url"]
     if url is not None:
         _validate_source_url(url)
@@ -39,7 +52,15 @@ def validate_artwork_record(value: object) -> dict[str, Any]:
 
 
 def _validate_source_url(url: str) -> None:
-    # A display-only public reference, compatible with native Chatbook carriers.
+    """Validate a display-only HTTPS reference without DNS or network access.
+
+    Args:
+        url: A bounded source URL from an artwork record.
+
+    Raises:
+        PersonaArtworkValidationError: The URL has credentials, a port, query,
+            fragment, invalid public hostname syntax or a local-domain suffix.
+    """
     try:
         parsed = urlsplit(url)
         host = parsed.hostname or ""
@@ -56,23 +77,46 @@ def _validate_source_url(url: str) -> None:
     except ValueError:
         valid = False
     if not valid:
-        raise ValueError("artwork_attribution_invalid")
+        raise PersonaArtworkValidationError("artwork_attribution_invalid")
 
 
 def encode_native_artwork(value: object) -> str:
-    """Return the canonical native source_context.artwork string."""
+    """Return the canonical native source_context.artwork string.
+
+    Args:
+        value: External version-1 artwork record to validate and serialize.
+
+    Returns:
+        Sorted, compact Unicode JSON suitable for the native archive carrier.
+
+    Raises:
+        PersonaArtworkValidationError: The record or encoded byte size is invalid.
+    """
     record = validate_artwork_record(value)
     encoded = json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
     if len(encoded.encode("utf-8")) > MAX_ARTWORK_BYTES:
-        raise ValueError("artwork_attribution_invalid")
+        raise PersonaArtworkValidationError("artwork_attribution_invalid")
     return encoded
 
 
 def artwork_manifest_for_import(pack: dict[str, Any]) -> dict[str, Any]:
-    """Merge agreeing native credit carriers, excluding unrelated source context."""
+    """Merge agreeing native credit carriers, excluding unrelated source context.
+
+    Args:
+        pack: Native metadata/pack.json pack object with a visual manifest and
+            optional canonical source_context.artwork string.
+
+    Returns:
+        A shallow manifest copy with validated credits under tldw/artwork when
+        present. Unrelated source context is ignored and the input is unchanged.
+
+    Raises:
+        PersonaArtworkValidationError: The manifest is not an object, a credit
+            carrier is malformed or oversized, or supported carriers disagree.
+    """
     manifest = pack.get("visual_manifest")
     if not isinstance(manifest, dict):
-        raise ValueError("malformed_metadata: metadata/pack.json")
+        raise PersonaArtworkValidationError("malformed_metadata: metadata/pack.json")
     manifest = dict(manifest)
     if ARTWORK_MANIFEST_KEY in manifest:
         manifest[ARTWORK_MANIFEST_KEY] = validate_artwork_record(manifest[ARTWORK_MANIFEST_KEY])
@@ -84,13 +128,13 @@ def artwork_manifest_for_import(pack: dict[str, Any]) -> dict[str, Any]:
     carrier = context["artwork"]
     try:
         if not isinstance(carrier, str) or len(carrier.encode("utf-8")) > MAX_ARTWORK_BYTES:
-            raise ValueError("artwork_attribution_invalid")
+            raise PersonaArtworkValidationError("artwork_attribution_invalid")
         record = validate_artwork_record(json.loads(carrier))
         if encode_native_artwork(record) != carrier:
-            raise ValueError("artwork_attribution_invalid")
+            raise PersonaArtworkValidationError("artwork_attribution_invalid")
     except (ValueError, UnicodeError, RecursionError) as exc:
-        raise ValueError("artwork_attribution_invalid") from exc
+        raise PersonaArtworkValidationError("artwork_attribution_invalid") from exc
     if ARTWORK_MANIFEST_KEY in manifest and manifest[ARTWORK_MANIFEST_KEY] != record:
-        raise ValueError("artwork_attribution_conflict")
+        raise PersonaArtworkValidationError("artwork_attribution_conflict")
     manifest[ARTWORK_MANIFEST_KEY] = record
     return manifest

--- a/tldw_Server_API/app/core/Persona/visual_portability/exporter.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/exporter.py
@@ -11,6 +11,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Persona.visual_artwork import ARTWORK_MANIFEST_KEY, encode_native_artwork
 from tldw_Server_API.app.core.Persona.visual_service import VISUAL_STORAGE_PREFIX
 
 from .archive import (
@@ -271,22 +272,27 @@ class PersonaVisualPackExporter:
         return self.staging_root / (f"{safe_title}-{uuid.uuid4().hex[:12]}{PERSONA_VISUAL_PACK_EXTENSION}")
 
     def _export_pack_row(self, row: Mapping[str, Any]) -> dict[str, Any]:
-        return {
+        result = {
             "source_pack_id": row["id"],
             "source_persona_id": row["persona_id"],
             "title": row["title"],
             "renderer_type": row["renderer_type"],
             "status": row["status"],
             "manifest_version": row["manifest_version"],
-            "visual_manifest": row.get("manifest") if isinstance(row.get("manifest"), dict) else {},
+            "visual_manifest": dict(row["manifest"]) if isinstance(row.get("manifest"), dict) else {},
             "parent_pack_id": row.get("parent_pack_id"),
             "revision_number": row.get("revision_number"),
             "provenance": row.get("provenance"),
-            "active_at": row.get("active_at"),
-            "created_at": row.get("created_at"),
-            "last_modified": row.get("last_modified"),
+            "active_at": _export_timestamp(row.get("active_at")),
+            "created_at": _export_timestamp(row.get("created_at")),
+            "last_modified": _export_timestamp(row.get("last_modified")),
             "version": row.get("version"),
         }
+        if ARTWORK_MANIFEST_KEY in result["visual_manifest"]:
+            result["source_context"] = {
+                "artwork": encode_native_artwork(result["visual_manifest"].pop(ARTWORK_MANIFEST_KEY)),
+            }
+        return result
 
     def _export_asset_row(self, row: Mapping[str, Any]) -> dict[str, Any]:
         return {
@@ -303,14 +309,14 @@ class PersonaVisualPackExporter:
             "height": row.get("height"),
             "duration_ms": row.get("duration_ms"),
             "provenance": row.get("provenance"),
-            "created_at": row.get("created_at"),
-            "last_modified": row.get("last_modified"),
+            "created_at": _export_timestamp(row.get("created_at")),
+            "last_modified": _export_timestamp(row.get("last_modified")),
             "version": row.get("version"),
         }
 
     def _readme_payload(self, pack: Mapping[str, Any]) -> bytes:
         title = str(pack.get("title") or "Persona Visual Pack")
-        return (f"# {title}\n\n" "This archive contains a tldw persona visual pack export.\n").encode("utf-8")
+        return (f"# {title}\n\n" "This archive contains a tldw persona visual pack export.\n").encode()
 
     def _progress(
         self,
@@ -374,8 +380,13 @@ def _asset_extension(asset: Mapping[str, Any]) -> str:
     }.get(mime_type, ".bin")
 
 
+def _export_timestamp(value: Any) -> Any:
+    """Keep SQLite text stable and make PostgreSQL timestamps JSON-compatible."""
+    return value.isoformat() if isinstance(value, datetime) else value
+
+
 def _canonical_pack_for_fingerprint(row: Mapping[str, Any]) -> dict[str, Any]:
-    return {
+    result = {
         "title": row.get("title"),
         "renderer_type": row.get("renderer_type"),
         "manifest_version": row.get("manifest_version"),
@@ -383,3 +394,7 @@ def _canonical_pack_for_fingerprint(row: Mapping[str, Any]) -> dict[str, Any]:
         "revision_number": row.get("revision_number"),
         "provenance": row.get("provenance"),
     }
+    context = row.get("source_context")
+    if isinstance(context, dict) and "artwork" in context:
+        result["artwork"] = context["artwork"]
+    return result

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -12,7 +12,13 @@ from typing import Any
 from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
     PersonaVisualPortabilityRepository,
 )
+from tldw_Server_API.app.core.Persona.visual_artwork import artwork_manifest_for_import
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import remap_visual_manifest_assets
 from tldw_Server_API.app.core.Persona.visual_portability.archive import normalize_member_name
+from tldw_Server_API.app.core.Persona.visual_portability.codex_pet import (
+    CODEX_PET_SCHEMA_VERSION,
+    load_codex_pet_archive,
+)
 from tldw_Server_API.app.core.Persona.visual_portability.commit_eligibility import (
     import_preview_plan_from_stored_json,
     is_import_preview_plan_committable,
@@ -22,10 +28,6 @@ from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     TRUST_MODE_TRUSTED_RESTORE,
     TRUST_MODE_UNTRUSTED_IMPORT,
 )
-from tldw_Server_API.app.core.Persona.visual_portability.codex_pet import (
-    CODEX_PET_SCHEMA_VERSION,
-    load_codex_pet_archive,
-)
 from tldw_Server_API.app.core.Persona.visual_portability.fingerprints import sha256_file
 from tldw_Server_API.app.core.Persona.visual_portability.preview import (
     PersonaVisualPackImportPreviewer,
@@ -34,10 +36,8 @@ from tldw_Server_API.app.core.Persona.visual_portability.preview import (
     _section_list,
     _section_record,
 )
-from tldw_Server_API.app.core.Persona.visual_manifest_assets import remap_visual_manifest_assets
 from tldw_Server_API.app.core.Persona.visual_service import PersonaVisualService
 from tldw_Server_API.app.core.Persona.visuals import validate_visual_manifest
-
 
 _REPLACEABLE_IMPORT_TARGET_STATUSES = frozenset({"draft", "review", "failed"})
 
@@ -172,7 +172,7 @@ class PersonaVisualPackImporter:
                         id_maps["assets"][source_asset_id] = str(imported["id"])
                     imported_assets.append(imported)
 
-            visual_manifest = pack.get("visual_manifest") if isinstance(pack.get("visual_manifest"), dict) else {}
+            visual_manifest = artwork_manifest_for_import(pack)
             remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
             asset_ids = {str(asset["id"]) for asset in imported_assets}
             asset_dimensions = {
@@ -302,10 +302,14 @@ class PersonaVisualPackImporter:
                     id_maps["assets"][source_asset_id] = str(imported["id"])
                 imported_assets.append(imported)
 
-            visual_manifest = pack.get("visual_manifest") if isinstance(
-                pack.get("visual_manifest"),
-                dict,
-            ) else {}
+            visual_manifest = (
+                pack.get("visual_manifest")
+                if isinstance(
+                    pack.get("visual_manifest"),
+                    dict,
+                )
+                else {}
+            )
             remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
             asset_ids = {str(asset["id"]) for asset in imported_assets}
             asset_dimensions = {

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from tldw_Server_API.app.core.Persona.visual_artwork import artwork_manifest_for_import
 from tldw_Server_API.app.core.Persona.visual_import_preview_validators import (
     preview_renderer_import,
 )
@@ -24,6 +25,12 @@ from tldw_Server_API.app.core.Persona.visuals import (
 )
 
 from .archive import normalize_member_name, validate_archive_members
+from .codex_pet import (
+    CODEX_PET_ASSET_ID,
+    CODEX_PET_SCHEMA_VERSION,
+    is_codex_pet_archive,
+    load_codex_pet_archive,
+)
 from .constants import (
     ASSET_BYTES_STATUS_MISSING,
     ASSET_BYTES_STATUS_PRESENT,
@@ -32,12 +39,6 @@ from .constants import (
     PERSONA_VISUAL_PACK_SCHEMA_VERSION,
     TRUST_MODE_TRUSTED_RESTORE,
     TRUST_MODE_UNTRUSTED_IMPORT,
-)
-from .codex_pet import (
-    CODEX_PET_ASSET_ID,
-    CODEX_PET_SCHEMA_VERSION,
-    is_codex_pet_archive,
-    load_codex_pet_archive,
 )
 from .fingerprints import canonical_payload_fingerprint, sha256_file, sha256_stream
 
@@ -87,9 +88,7 @@ class PersonaVisualPackImportPreviewer:
 
             self._progress(progress, "validating_assets", {"asset_count": len(assets)})
             asset_summary = _validate_assets(archive, members, assets=assets)
-            visual_manifest = pack.get("visual_manifest")
-            if not isinstance(visual_manifest, dict):
-                raise ValueError("malformed_metadata: metadata/pack.json")
+            visual_manifest = artwork_manifest_for_import(pack)
             renderer_import_preview: dict[str, Any] | None = None
             resolved_required_states: Mapping[str, str] = {}
             if _uses_renderer_import_preview(visual_manifest):
@@ -99,9 +98,7 @@ class PersonaVisualPackImportPreviewer:
                 ).to_dict()
             else:
                 available_asset_ids = {
-                    str(asset["source_asset_id"])
-                    for asset in assets
-                    if asset.get("source_asset_id") not in (None, "")
+                    str(asset["source_asset_id"]) for asset in assets if asset.get("source_asset_id") not in (None, "")
                 }
                 available_dimensions = {
                     str(asset["source_asset_id"]): (int(asset["width"]), int(asset["height"]))
@@ -164,9 +161,7 @@ class PersonaVisualPackImportPreviewer:
         if renderer_import_preview is not None:
             proposed_plan["renderer_import_preview"] = renderer_import_preview
             proposed_plan["commit_eligible"] = bool(renderer_import_preview.get("can_commit"))
-            proposed_plan["activation_eligible"] = bool(
-                renderer_import_preview.get("activation_eligible")
-            )
+            proposed_plan["activation_eligible"] = bool(renderer_import_preview.get("activation_eligible"))
             proposed_plan["commit_blockers"] = list(renderer_import_preview.get("blockers") or [])
             if not proposed_plan["commit_eligible"]:
                 preview_status = "blocked"
@@ -490,9 +485,7 @@ def _bundle_asset_summary(
         "mime_type": asset.get("mime_type"),
         "width": asset.get("width"),
         "height": asset.get("height"),
-        "manifest_referenced": bool(
-            source_asset_id and source_asset_id in manifest_asset_references
-        ),
+        "manifest_referenced": bool(source_asset_id and source_asset_id in manifest_asset_references),
     }
 
 
@@ -511,10 +504,7 @@ def _validation_warnings(assets: list[Mapping[str, Any]]) -> list[str]:
     warnings: list[str] = []
     for asset in assets:
         if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_MISSING:
-            warnings.append(
-                "missing_asset_bytes:"
-                f"{asset.get('asset_role')}:{asset.get('source_asset_id')}"
-            )
+            warnings.append("missing_asset_bytes:" f"{asset.get('asset_role')}:{asset.get('source_asset_id')}")
     return warnings
 
 
@@ -548,10 +538,7 @@ def _target_pack_conflicts(
                 "conflict_id": f"target_pack_title_match:{pack_id}",
                 "type": "target_pack_title_match",
                 "severity": "warning",
-                "message": (
-                    f"Target persona already has a {pack_status} visual pack "
-                    f"named {incoming_title}."
-                ),
+                "message": (f"Target persona already has a {pack_status} visual pack " f"named {incoming_title}."),
                 "pack_id": pack_id,
                 "pack_title": target_title,
                 "pack_status": pack_status,
@@ -591,9 +578,7 @@ def _required_choices(
                     "reason": "target_pack_conflicts",
                     "default_target_mode": "create_new",
                     "allowed_target_modes": (
-                        ["create_new", "replace_draft"]
-                        if replaceable_pack_ids
-                        else ["create_new"]
+                        ["create_new", "replace_draft"] if replaceable_pack_ids else ["create_new"]
                     ),
                     "replaceable_pack_ids": list(replaceable_pack_ids),
                 }

--- a/tldw_Server_API/app/core/Persona/visuals.py
+++ b/tldw_Server_API/app/core/Persona/visuals.py
@@ -5,10 +5,10 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
+from tldw_Server_API.app.core.Persona.visual_artwork import ARTWORK_MANIFEST_KEY, validate_artwork_record
 from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
     get_persona_visual_renderer_capability,
 )
-
 
 VISUAL_STATE_IDS = {
     "idle",
@@ -111,25 +111,16 @@ def validate_visual_manifest(
         allowed_states=allowed_states,
     )
 
-    resolved_required = {
-        state: _resolve_state(state, normalized)
-        for state in REQUIRED_VISUAL_STATES
-    }
+    resolved_required = {state: _resolve_state(state, normalized) for state in REQUIRED_VISUAL_STATES}
     if require_activatable:
-        missing = sorted(
-            state for state, animation_id in resolved_required.items() if not animation_id
-        )
+        missing = sorted(state for state, animation_id in resolved_required.items() if not animation_id)
         if missing:
-            raise PersonaVisualManifestError(
-                "Required visual states do not resolve: " + ", ".join(missing)
-            )
+            raise PersonaVisualManifestError("Required visual states do not resolve: " + ", ".join(missing))
 
     return PersonaVisualManifestValidation(
         manifest=normalized,
         resolved_required_states={
-            state: animation_id
-            for state, animation_id in resolved_required.items()
-            if animation_id
+            state: animation_id for state, animation_id in resolved_required.items() if animation_id
         },
     )
 
@@ -143,21 +134,21 @@ def _normalize_manifest_shape(
         raise PersonaVisualManifestError("Manifest must be an object")
 
     normalized = deepcopy(manifest)
+    if ARTWORK_MANIFEST_KEY in normalized:
+        try:
+            normalized[ARTWORK_MANIFEST_KEY] = validate_artwork_record(normalized[ARTWORK_MANIFEST_KEY])
+        except ValueError as exc:
+            raise PersonaVisualManifestError("artwork_attribution_invalid") from exc
     renderer_type = normalized.get("renderer_type")
     renderer_type_for_error = _format_renderer_type_for_error(renderer_type)
     capability = get_persona_visual_renderer_capability(str(renderer_type or ""))
     if capability is None or not capability.can_validate:
-        raise PersonaVisualManifestError(
-            f"unsupported renderer_type: {renderer_type_for_error}"
-        )
+        raise PersonaVisualManifestError(f"unsupported renderer_type: {renderer_type_for_error}")
     if require_activatable and not capability.can_activate:
-        raise PersonaVisualManifestError(
-            f"unsupported renderer_type for activation: {renderer_type_for_error}"
-        )
+        raise PersonaVisualManifestError(f"unsupported renderer_type for activation: {renderer_type_for_error}")
     if normalized.get("manifest_version") not in capability.manifest_versions:
         raise PersonaVisualManifestError(
-            "manifest_version must be one of "
-            f"{', '.join(str(version) for version in capability.manifest_versions)}"
+            "manifest_version must be one of " f"{', '.join(str(version) for version in capability.manifest_versions)}"
         )
 
     states = normalized.setdefault("states", {})
@@ -191,12 +182,7 @@ def _normalize_manifest_shape(
 
 def _format_renderer_type_for_error(renderer_type: Any) -> str:
     value = str(renderer_type or "")
-    value = (
-        value.replace("\\", "\\\\")
-        .replace("\r", "\\r")
-        .replace("\n", "\\n")
-        .replace("\t", "\\t")
-    )
+    value = value.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
     if len(value) > MAX_RENDERER_TYPE_ERROR_LENGTH:
         return value[:MAX_RENDERER_TYPE_ERROR_LENGTH] + "..."
     return value or "<empty>"
@@ -210,13 +196,9 @@ def _normalize_animation_frames(
     asset_ids = animation.get("asset_ids")
     if frames is None:
         if asset_ids is None:
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} must define frames or asset_ids"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} must define frames or asset_ids")
         if not isinstance(asset_ids, list):
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} asset_ids must be a list"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} asset_ids must be a list")
         frames = [{"asset_id": asset_id} for asset_id in asset_ids]
     elif not isinstance(frames, list):
         raise PersonaVisualManifestError(f"Animation {animation_id} frames must be a list")
@@ -224,9 +206,7 @@ def _normalize_animation_frames(
     normalized_frames: list[dict[str, Any]] = []
     for index, frame in enumerate(frames):
         if not isinstance(frame, dict):
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} frame {index} must be an object"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} must be an object")
         normalized_frames.append(deepcopy(frame))
     return normalized_frames
 
@@ -240,9 +220,7 @@ def _validate_animation(
 ) -> None:
     frame_rate = animation.get("frame_rate", 1)
     if not isinstance(frame_rate, (int, float)) or not 1 <= frame_rate <= 60:
-        raise PersonaVisualManifestError(
-            f"Animation {animation_id} frame_rate must be between 1 and 60"
-        )
+        raise PersonaVisualManifestError(f"Animation {animation_id} frame_rate must be between 1 and 60")
 
     alignment = animation.get("alignment")
     if alignment is not None:
@@ -260,13 +238,9 @@ def _validate_animation(
     for index, frame in enumerate(frames):
         asset_id = frame.get("asset_id")
         if not isinstance(asset_id, str) or not asset_id:
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} frame {index} asset_id is required"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} asset_id is required")
         if asset_id not in available_asset_ids:
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} references unknown asset_id {asset_id}"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} references unknown asset_id {asset_id}")
         frame_asset_ids.add(asset_id)
         _validate_frame_duration(animation_id, index, frame)
         _validate_frame_region(
@@ -280,9 +254,7 @@ def _validate_animation(
     preview_frame = animation.get("preview_frame")
     if preview_frame is not None:
         if not isinstance(preview_frame, int) or not 0 <= preview_frame < len(frames):
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} preview_frame must be a valid frame index"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} preview_frame must be a valid frame index")
 
     preview_asset_id = animation.get("preview_asset_id")
     if preview_asset_id is not None:
@@ -298,9 +270,7 @@ def _validate_alignment(animation_id: str, alignment: Any) -> None:
     for axis in ("x", "y"):
         value = alignment.get(axis)
         if not isinstance(value, (int, float)) or not 0 <= value <= 1:
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} alignment.{axis} must be between 0 and 1"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} alignment.{axis} must be between 0 and 1")
 
 
 def _validate_frame_duration(
@@ -311,10 +281,7 @@ def _validate_frame_duration(
     duration_ms = frame.get("duration_ms")
     if duration_ms is None:
         return
-    if (
-        not isinstance(duration_ms, int)
-        or not MIN_FRAME_DURATION_MS <= duration_ms <= MAX_FRAME_DURATION_MS
-    ):
+    if not isinstance(duration_ms, int) or not MIN_FRAME_DURATION_MS <= duration_ms <= MAX_FRAME_DURATION_MS:
         raise PersonaVisualManifestError(
             f"Animation {animation_id} frame {index} duration_ms must be between "
             f"{MIN_FRAME_DURATION_MS} and {MAX_FRAME_DURATION_MS}"
@@ -333,51 +300,37 @@ def _validate_frame_region(
     if region is None:
         return
     if not isinstance(region, dict):
-        raise PersonaVisualManifestError(
-            f"Animation {animation_id} frame {index} region must be an object"
-        )
+        raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} region must be an object")
 
     for key in ("x", "y", "width", "height"):
         value = region.get(key)
         if not isinstance(value, int):
-            raise PersonaVisualManifestError(
-                f"Animation {animation_id} frame {index} region.{key} must be an integer"
-            )
+            raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} region.{key} must be an integer")
 
     if region["x"] < 0 or region["y"] < 0 or region["width"] <= 0 or region["height"] <= 0:
-        raise PersonaVisualManifestError(
-            f"Animation {animation_id} frame {index} region has invalid bounds"
-        )
+        raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} region has invalid bounds")
 
     dimensions = available_asset_dimensions.get(asset_id)
     if not dimensions:
         return
     width, height = dimensions
     if region["x"] + region["width"] > width or region["y"] + region["height"] > height:
-        raise PersonaVisualManifestError(
-            f"Animation {animation_id} frame {index} region exceeds asset bounds"
-        )
+        raise PersonaVisualManifestError(f"Animation {animation_id} frame {index} region exceeds asset bounds")
 
 
 def _validate_state_catalog(state_catalog: dict[str, Any]) -> None:
     """Validate optional custom visual states declared by a sprite manifest."""
     if len(state_catalog) > MAX_CUSTOM_VISUAL_STATES:
-        raise PersonaVisualManifestError(
-            f"state_catalog may define at most {MAX_CUSTOM_VISUAL_STATES} custom states"
-        )
+        raise PersonaVisualManifestError(f"state_catalog may define at most {MAX_CUSTOM_VISUAL_STATES} custom states")
 
     for state_id, entry in state_catalog.items():
         state_id_error = _custom_state_id_error(state_id)
         if state_id_error:
             raise PersonaVisualManifestError(state_id_error)
         if state_id in VISUAL_STATE_IDS:
-            raise PersonaVisualManifestError(
-                f"state_catalog custom state {state_id} is reserved"
-            )
+            raise PersonaVisualManifestError(f"state_catalog custom state {state_id} is reserved")
         if not isinstance(entry, dict):
-            raise PersonaVisualManifestError(
-                f"state_catalog[{state_id}] must be an object"
-            )
+            raise PersonaVisualManifestError(f"state_catalog[{state_id}] must be an object")
 
         label = entry.get("label")
         if (
@@ -394,8 +347,7 @@ def _validate_state_catalog(state_catalog: dict[str, Any]) -> None:
         kind = entry.get("kind")
         if kind not in SUPPORTED_STATE_CATALOG_KINDS:
             raise PersonaVisualManifestError(
-                f"state_catalog[{state_id}].kind must be one of "
-                f"{sorted(SUPPORTED_STATE_CATALOG_KINDS)}"
+                f"state_catalog[{state_id}].kind must be one of " f"{sorted(SUPPORTED_STATE_CATALOG_KINDS)}"
             )
 
         description = entry.get("description")
@@ -418,8 +370,7 @@ def _validate_state_catalog_tags(state_id: str, tags: Any) -> None:
     """Validate bounded user-facing tags for a custom visual state."""
     if not isinstance(tags, list) or len(tags) > MAX_STATE_CATALOG_TAGS:
         raise PersonaVisualManifestError(
-            f"state_catalog[{state_id}].tags must be a list of at most "
-            f"{MAX_STATE_CATALOG_TAGS} strings"
+            f"state_catalog[{state_id}].tags must be a list of at most " f"{MAX_STATE_CATALOG_TAGS} strings"
         )
     for index, tag in enumerate(tags):
         if (
@@ -444,10 +395,7 @@ def _custom_state_id_error(state_id: Any) -> str | None:
     if not isinstance(state_id, str):
         return "state_catalog custom state ids must be strings"
     if not CUSTOM_VISUAL_STATE_ID_PATTERN.fullmatch(state_id):
-        return (
-            "state_catalog custom state ids must match "
-            f"{CUSTOM_VISUAL_STATE_ID_PATTERN.pattern}"
-        )
+        return "state_catalog custom state ids must match " f"{CUSTOM_VISUAL_STATE_ID_PATTERN.pattern}"
     lowered = state_id.lower()
     if lowered.startswith(UNSAFE_CUSTOM_STATE_PREFIXES):
         return "state_catalog custom state ids must not use unsafe prefixes"
@@ -482,9 +430,7 @@ def _validate_state_references(
         if not isinstance(animation_id, str) or not animation_id:
             raise PersonaVisualManifestError(f"State {state} animation_id is required")
         if animation_id not in animations:
-            raise PersonaVisualManifestError(
-                f"State {state} references unknown animation_id {animation_id}"
-            )
+            raise PersonaVisualManifestError(f"State {state} references unknown animation_id {animation_id}")
 
 
 def _validate_fallbacks(
@@ -499,9 +445,7 @@ def _validate_fallbacks(
             raise PersonaVisualManifestError(f"Fallback {state} must be a list")
         for fallback_state in fallback_chain:
             if fallback_state not in allowed_states:
-                raise PersonaVisualManifestError(
-                    f"Fallback {state} references unknown state {fallback_state}"
-                )
+                raise PersonaVisualManifestError(f"Fallback {state} references unknown state {fallback_state}")
 
     visiting: set[str] = set()
     visited: set[str] = set()
@@ -509,13 +453,10 @@ def _validate_fallbacks(
     def visit(state: str, path: tuple[str, ...]) -> None:
         if len(path) >= MAX_FALLBACK_DEPTH:
             raise PersonaVisualManifestError(
-                f"Fallback chain depth exceeds {MAX_FALLBACK_DEPTH}: "
-                + " -> ".join((*path, state))
+                f"Fallback chain depth exceeds {MAX_FALLBACK_DEPTH}: " + " -> ".join((*path, state))
             )
         if state in visiting:
-            raise PersonaVisualManifestError(
-                "Fallback cycle detected: " + " -> ".join((*path, state))
-            )
+            raise PersonaVisualManifestError("Fallback cycle detected: " + " -> ".join((*path, state)))
         if state in visited:
             return
         visiting.add(state)
@@ -534,9 +475,7 @@ def _validate_authored_triggers(
     allowed_states: set[str],
 ) -> None:
     if len(triggers) > MAX_AUTHORED_TRIGGERS:
-        raise PersonaVisualManifestError(
-            f"authored_triggers may define at most {MAX_AUTHORED_TRIGGERS} triggers"
-        )
+        raise PersonaVisualManifestError(f"authored_triggers may define at most {MAX_AUTHORED_TRIGGERS} triggers")
     for index, trigger in enumerate(triggers):
         if not isinstance(trigger, dict):
             raise PersonaVisualManifestError(f"authored_triggers[{index}] must be an object")
@@ -546,31 +485,23 @@ def _validate_authored_triggers(
         source = trigger.get("source")
         if source not in SUPPORTED_TRIGGER_SOURCES:
             raise PersonaVisualManifestError(
-                f"authored_triggers[{index}].source must be one of "
-                f"{sorted(SUPPORTED_TRIGGER_SOURCES)}"
+                f"authored_triggers[{index}].source must be one of " f"{sorted(SUPPORTED_TRIGGER_SOURCES)}"
             )
         match = trigger.get("match")
         if not isinstance(match, str) or not match:
             raise PersonaVisualManifestError(f"authored_triggers[{index}].match is required")
         state = trigger.get("state")
         if state not in allowed_states:
-            raise PersonaVisualManifestError(
-                f"authored_triggers[{index}].state must be a known visual state"
-            )
+            raise PersonaVisualManifestError(f"authored_triggers[{index}].state must be a known visual state")
         duration_ms = trigger.get("duration_ms")
-        if (
-            not isinstance(duration_ms, int)
-            or not MIN_TRIGGER_DURATION_MS <= duration_ms <= MAX_TRIGGER_DURATION_MS
-        ):
+        if not isinstance(duration_ms, int) or not MIN_TRIGGER_DURATION_MS <= duration_ms <= MAX_TRIGGER_DURATION_MS:
             raise PersonaVisualManifestError(
                 f"authored_triggers[{index}].duration_ms must be between "
                 f"{MIN_TRIGGER_DURATION_MS} and {MAX_TRIGGER_DURATION_MS}"
             )
         priority = trigger.get("priority")
         if not isinstance(priority, int) or not 0 <= priority <= 100:
-            raise PersonaVisualManifestError(
-                f"authored_triggers[{index}].priority must be between 0 and 100"
-            )
+            raise PersonaVisualManifestError(f"authored_triggers[{index}].priority must be between 0 and 100")
 
 
 def _resolve_state(

--- a/tldw_Server_API/app/core/exception_types.py
+++ b/tldw_Server_API/app/core/exception_types.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 
+class PersonaArtworkValidationError(ValueError):
+    """A pack's artwork credit record or carrier violates the native contract.
+
+    The message is a stable metadata error code, without imported record contents.
+    ValueError compatibility preserves existing import and export error handling.
+    """
+
+
 class PromptCatalogError(Exception):
     """Sanitized prompt catalog error suitable for MCP protocol mapping."""
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -14,7 +14,10 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 
 from .AuthNZ.exceptions import DatabaseError as AuthNZDatabaseError
-from .exception_types import PromptCatalogError  # noqa: F401 - re-exported for compatibility.
+from .exception_types import (  # noqa: F401 - centralized compatibility exports.
+    PersonaArtworkValidationError,
+    PromptCatalogError,
+)
 
 if TYPE_CHECKING:
     from .Admin_Webhooks.domain import WebhookErrorCode

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -23,8 +23,8 @@ from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     REQUIRED_MEMBERS,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.exporter import (
-    PersonaVisualPackExportError,
     PersonaVisualPackExporter,
+    PersonaVisualPackExportError,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.fingerprints import (
     sha256_bytes,
@@ -39,6 +39,14 @@ from tldw_Server_API.app.core.Persona.visual_portability.preview import (
 from tldw_Server_API.app.core.Persona.visual_service import PersonaVisualService
 
 pytestmark = pytest.mark.unit
+
+ARTWORK_CREDITS = {
+    "version": 1,
+    "creator": "tldw-project",
+    "license": "Apache-2.0",
+    "source_url": "https://github.com/rmusser01/tldw-stuff/tree/main/buddy-packs/trenchcoat",
+    "notices": "Artwork credit: tldw-project\nLicense notice — retain on redistribution.\n",
+}
 
 
 def _png_bytes(width: int = 2, height: int = 3) -> bytes:
@@ -518,7 +526,7 @@ def test_validate_archive_members_allows_zip_directory_entries(tmp_path: Path) -
 
     members = validate_archive_members(archive_path)
 
-    assert REQUIRED_MEMBERS <= set(members)  # nosec B101
+    assert set(members) >= REQUIRED_MEMBERS  # nosec B101
     assert "metadata/" not in members  # nosec B101
 
 
@@ -550,7 +558,7 @@ def test_export_pack_writes_manifest_metadata_checksums_and_asset_bytes(
 
     with zipfile.ZipFile(result.archive_path) as archive:
         names = set(archive.namelist())
-        assert REQUIRED_MEMBERS <= names  # nosec B101
+        assert names >= REQUIRED_MEMBERS  # nosec B101
 
         archive_manifest = json.loads(archive.read(MANIFEST_PATH))
         assert archive_manifest["schema_version"] == PERSONA_VISUAL_PACK_SCHEMA_VERSION  # nosec B101
@@ -1350,3 +1358,252 @@ def test_import_preview_rejects_unsupported_renderer_type_in_visual_manifest(
             owner_user_id="user-1",
             target_persona_id=persona_id,
         )
+
+
+def _credited_archive(db, tmp_path, monkeypatch, artwork, *, extension=None, carrier=None, context=...):
+    """Build a native archive with the same credit carrier as collection packs."""
+    persona_id, pack, _ = _create_pack_with_asset(
+        db,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    exported = PersonaVisualPackExporter(
+        db=db,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    ).export_pack(persona_id=persona_id, pack_id=pack["id"], options=PersonaVisualPackExportOptions())
+    with zipfile.ZipFile(exported.archive_path) as archive:
+        entries = {name: archive.read(name) for name in archive.namelist()}
+    payload = json.loads(entries["metadata/pack.json"])
+    payload["pack"]["source_context"] = {
+        "artwork": _json_bytes(artwork).decode() if carrier is None else carrier,
+        "unrelated_private_context": "must not be copied",
+    }
+    if extension is not None:
+        payload["pack"]["visual_manifest"]["tldw/artwork"] = extension
+    if context is not Ellipsis:
+        payload["pack"]["source_context"] = context
+    entries["metadata/pack.json"] = _json_bytes(payload)
+    entries[CHECKSUMS_PATH] = _json_bytes(
+        {name: sha256_bytes(content) for name, content in entries.items() if name != CHECKSUMS_PATH}
+    )
+    path = tmp_path / "credited.tldw-persona-vpack"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return path
+
+
+def _commit_archive(db, archive_path, persona_id):
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import PersonaVisualPortabilityRepository
+    from tldw_Server_API.app.core.Persona.visual_portability.importer import PersonaVisualPackImporter
+
+    result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id=persona_id,
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="credits-preview",
+        status="completed",
+        stage="completed",
+        archive_path=str(archive_path),
+        target_persona_id=persona_id,
+        **{
+            key: result[key]
+            for key in (
+                "archive_sha256",
+                "canonical_payload_fingerprint",
+                "schema_version",
+                "bundle_summary",
+                "proposed_plan",
+                "required_choices",
+            )
+        },
+    )
+    return PersonaVisualPackImporter(db=db, repo=repo, user_id="user-1").import_preview(
+        preview_id=preview["id"],
+        target_persona_id=persona_id,
+        trust_mode="untrusted_import",
+    )["pack"]
+
+
+def test_artwork_credits_survive_import_copy_source_deletion_and_export(
+    db_instance,
+    tmp_path,
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.schemas.buddies import BuddyCreate
+    from tldw_Server_API.app.core.Buddy.service import BuddyService
+
+    db = db_instance
+    monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda user_id: tmp_path))
+    archive = _credited_archive(db, tmp_path, monkeypatch, ARTWORK_CREDITS)
+    target = db.create_persona_profile({"user_id": "user-1", "name": "Imported credits"})
+    pack = _commit_archive(db, archive, target)
+    assert pack["manifest"].get("tldw/artwork") == ARTWORK_CREDITS
+    service = BuddyService(db, "user-1")
+    buddy = service.create(
+        BuddyCreate(
+            name="Independent credited art",
+            optional_persona_id=None,
+            source={"kind": "persona_pack", "persona_id": target, "pack_id": pack["id"]},
+        )
+    )
+    assert buddy["attribution"]["artwork"] == ARTWORK_CREDITS
+    exported = PersonaVisualPackExporter(
+        db=db,
+        user_id="user-1",
+        staging_root=tmp_path / "roundtrip",
+    ).export_pack(persona_id=target, pack_id=pack["id"], options=PersonaVisualPackExportOptions())
+    with zipfile.ZipFile(exported.archive_path) as archive:
+        payload = json.loads(archive.read("metadata/pack.json"))["pack"]
+        assert payload["source_context"] == {"artwork": _json_bytes(ARTWORK_CREDITS).decode()}
+        assert "tldw/artwork" not in payload["visual_manifest"]
+        assert b"must not be copied" not in archive.read("metadata/pack.json")
+    assert (
+        db.get_persona_visual_pack(pack_id=pack["id"], persona_id=target, user_id="user-1")["manifest"]["tldw/artwork"]
+        == ARTWORK_CREDITS
+    )
+    restored_target = db.create_persona_profile({"user_id": "user-1", "name": "Round trip"})
+    restored = _commit_archive(db, exported.archive_path, restored_target)
+    assert restored["manifest"]["tldw/artwork"] == ARTWORK_CREDITS
+    profile = db.get_persona_profile(target, user_id="user-1")
+    db.soft_delete_persona_profile(persona_id=target, user_id="user-1", expected_version=profile["version"])
+    assert service.get(buddy["id"])["attribution"]["artwork"] == ARTWORK_CREDITS
+    assert service.read_asset(buddy["id"], buddy["assets"][0]["id"])[0] == _png_bytes()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"version": True},
+        {"version": 2},
+        {"policy": "execute this"},
+        {"notices": "x" * (64 * 1024 + 1)},
+        {"creator": "x" * 513},
+        {"creator": "bad\u0000credit"},
+        {"source_url": "https://user:password@example.com/art"},
+        {"source_url": "file:///private/art"},
+        {"source_url": "https://127.0.0.1/art"},
+    ],
+)
+def test_import_preview_rejects_invalid_artwork_credits(db_instance, tmp_path, monkeypatch, changes):
+    archive = _credited_archive(db_instance, tmp_path, monkeypatch, {**ARTWORK_CREDITS, **changes})
+    with pytest.raises(ValueError, match="artwork"):
+        PersonaVisualPackImportPreviewer().create_preview(
+            archive_path=archive,
+            owner_user_id="user-1",
+            target_persona_id="target",
+        )
+
+
+@pytest.mark.parametrize(
+    "carrier", ["{}", "not JSON", "[]", " " + _json_bytes(ARTWORK_CREDITS).decode(), "x" * (512 * 1024 + 1)]
+)
+def test_import_preview_rejects_malformed_artwork_carrier(db_instance, tmp_path, monkeypatch, carrier):
+    archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS, carrier=carrier)
+    with pytest.raises(ValueError, match="artwork"):
+        PersonaVisualPackImportPreviewer().create_preview(
+            archive_path=archive,
+            owner_user_id="user-1",
+            target_persona_id="target",
+        )
+
+
+def test_import_preview_rejects_conflicting_artwork_carriers(db_instance, tmp_path, monkeypatch):
+    archive = _credited_archive(
+        db_instance,
+        tmp_path,
+        monkeypatch,
+        ARTWORK_CREDITS,
+        extension={**ARTWORK_CREDITS, "creator": "different creator"},
+    )
+    with pytest.raises(ValueError, match="artwork_attribution_conflict"):
+        PersonaVisualPackImportPreviewer().create_preview(
+            archive_path=archive,
+            owner_user_id="user-1",
+            target_persona_id="target",
+        )
+
+
+def test_manifest_edits_cannot_bypass_artwork_validation():
+    from tldw_Server_API.app.core.Persona.visuals import PersonaVisualManifestError, validate_visual_manifest
+
+    manifest = {**_valid_manifest("asset"), "tldw/artwork": {**ARTWORK_CREDITS, "policy": "run"}}
+    with pytest.raises(PersonaVisualManifestError, match="artwork"):
+        validate_visual_manifest(manifest, available_asset_ids={"asset"}, require_activatable=True)
+
+
+@pytest.mark.parametrize("context", [None, [], "legacy context", {"unrelated": "context"}])
+def test_credit_free_legacy_source_context_remains_importable(db_instance, tmp_path, monkeypatch, context):
+    archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS, context=context)
+    target = db_instance.create_persona_profile({"user_id": "user-1", "name": "Credit-free import"})
+    pack = _commit_archive(db_instance, archive, target)
+    assert "tldw/artwork" not in pack["manifest"]
+
+
+def test_export_fingerprint_includes_artwork_credits(db_instance, tmp_path, monkeypatch):
+    archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS)
+    target = db_instance.create_persona_profile({"user_id": "user-1", "name": "Credited fingerprint"})
+    pack = _commit_archive(db_instance, archive, target)
+    exporter = PersonaVisualPackExporter(db=db_instance, user_id="user-1", staging_root=tmp_path / "exports")
+    first = exporter.export_pack(persona_id=target, pack_id=pack["id"], options=PersonaVisualPackExportOptions())
+    manifest = {**pack["manifest"], "tldw/artwork": {**ARTWORK_CREDITS, "creator": "Updated attribution"}}
+    db_instance.update_persona_visual_pack_manifest(
+        pack_id=pack["id"],
+        persona_id=target,
+        user_id="user-1",
+        manifest=manifest,
+    )
+    second = exporter.export_pack(persona_id=target, pack_id=pack["id"], options=PersonaVisualPackExportOptions())
+    assert first.canonical_payload_fingerprint != second.canonical_payload_fingerprint
+
+
+@pytest.mark.integration
+def test_postgres_artwork_snapshot_and_native_export(pg_database_config, tmp_path, monkeypatch):
+    from tldw_Server_API.app.api.v1.schemas.buddies import BuddyCreate
+    from tldw_Server_API.app.core.Buddy.service import BuddyService
+    from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", "artwork-pg-test", backend=backend)
+    try:
+        monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda user_id: tmp_path))
+        persona, pack, asset = _create_pack_with_asset(db, visuals_root=tmp_path / "visuals", monkeypatch=monkeypatch)
+        manifest = {**_valid_manifest(asset["id"]), "tldw/artwork": ARTWORK_CREDITS}
+        db.update_persona_visual_pack_manifest(
+            pack_id=pack["id"], persona_id=persona, user_id="user-1", manifest=manifest
+        )
+        buddy = BuddyService(db, "user-1").create(
+            BuddyCreate(
+                name="PostgreSQL credited art",
+                source={"kind": "persona_pack", "persona_id": persona, "pack_id": pack["id"]},
+            )
+        )
+        assert buddy["attribution"]["artwork"] == ARTWORK_CREDITS
+        exported = PersonaVisualPackExporter(db=db, user_id="user-1", staging_root=tmp_path / "exports").export_pack(
+            persona_id=persona,
+            pack_id=pack["id"],
+            options=PersonaVisualPackExportOptions(),
+        )
+        with zipfile.ZipFile(exported.archive_path) as archive:
+            payload = json.loads(archive.read("metadata/pack.json"))["pack"]
+            assets = json.loads(archive.read("metadata/assets.json"))["assets"]
+            assert payload["source_context"] == {"artwork": _json_bytes(ARTWORK_CREDITS).decode()}
+            assert "tldw/artwork" not in payload["visual_manifest"]
+            assert isinstance(payload["created_at"], str)
+            assert isinstance(assets[0]["created_at"], str)
+            assert archive.read(assets[0]["asset_path"]) == _png_bytes()
+        assert (
+            PersonaVisualPackImportPreviewer().create_preview(
+                archive_path=exported.archive_path,
+                owner_user_id="user-1",
+                target_persona_id="target",
+            )["validation_warnings"]
+            == []
+        )
+    finally:
+        db.close_connection()

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -4,12 +4,15 @@ import io
 import json
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from PIL import Image
 
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.exception_types import PersonaArtworkValidationError
 from tldw_Server_API.app.core.Persona.visual_portability.archive import (
     DEFAULT_MAX_MEMBER_SIZE_BYTES,
     validate_archive_members,
@@ -1360,7 +1363,16 @@ def test_import_preview_rejects_unsupported_renderer_type_in_visual_manifest(
         )
 
 
-def _credited_archive(db, tmp_path, monkeypatch, artwork, *, extension=None, carrier=None, context=...):
+def _credited_archive(
+    db: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    artwork: dict[str, Any],
+    *,
+    extension: dict[str, Any] | None = None,
+    carrier: str | None = None,
+    context: object = ...,
+) -> Path:
     """Build a native archive with the same credit carrier as collection packs."""
     persona_id, pack, _ = _create_pack_with_asset(
         db,
@@ -1394,7 +1406,8 @@ def _credited_archive(db, tmp_path, monkeypatch, artwork, *, extension=None, car
     return path
 
 
-def _commit_archive(db, archive_path, persona_id):
+def _commit_archive(db: CharactersRAGDB, archive_path: Path, persona_id: str) -> dict[str, Any]:
+    """Preview and commit a credited native archive into a new SQLite draft pack."""
     from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import PersonaVisualPortabilityRepository
     from tldw_Server_API.app.core.Persona.visual_portability.importer import PersonaVisualPackImporter
 
@@ -1431,10 +1444,11 @@ def _commit_archive(db, archive_path, persona_id):
 
 
 def test_artwork_credits_survive_import_copy_source_deletion_and_export(
-    db_instance,
-    tmp_path,
-    monkeypatch,
-):
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserve exact credits and bytes across import, owned copy and native export."""
     from tldw_Server_API.app.api.v1.schemas.buddies import BuddyCreate
     from tldw_Server_API.app.core.Buddy.service import BuddyService
 
@@ -1490,9 +1504,12 @@ def test_artwork_credits_survive_import_copy_source_deletion_and_export(
         {"source_url": "https://127.0.0.1/art"},
     ],
 )
-def test_import_preview_rejects_invalid_artwork_credits(db_instance, tmp_path, monkeypatch, changes):
+def test_import_preview_rejects_invalid_artwork_credits(
+    db_instance: CharactersRAGDB, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, changes: dict[str, Any]
+) -> None:
+    """Reject unsupported or unsafe records before a pack can be imported."""
     archive = _credited_archive(db_instance, tmp_path, monkeypatch, {**ARTWORK_CREDITS, **changes})
-    with pytest.raises(ValueError, match="artwork"):
+    with pytest.raises(PersonaArtworkValidationError, match="artwork"):
         PersonaVisualPackImportPreviewer().create_preview(
             archive_path=archive,
             owner_user_id="user-1",
@@ -1503,9 +1520,12 @@ def test_import_preview_rejects_invalid_artwork_credits(db_instance, tmp_path, m
 @pytest.mark.parametrize(
     "carrier", ["{}", "not JSON", "[]", " " + _json_bytes(ARTWORK_CREDITS).decode(), "x" * (512 * 1024 + 1)]
 )
-def test_import_preview_rejects_malformed_artwork_carrier(db_instance, tmp_path, monkeypatch, carrier):
+def test_import_preview_rejects_malformed_artwork_carrier(
+    db_instance: CharactersRAGDB, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, carrier: str
+) -> None:
+    """Reject malformed and oversized canonical credit carriers."""
     archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS, carrier=carrier)
-    with pytest.raises(ValueError, match="artwork"):
+    with pytest.raises(PersonaArtworkValidationError, match="artwork"):
         PersonaVisualPackImportPreviewer().create_preview(
             archive_path=archive,
             owner_user_id="user-1",
@@ -1513,7 +1533,10 @@ def test_import_preview_rejects_malformed_artwork_carrier(db_instance, tmp_path,
         )
 
 
-def test_import_preview_rejects_conflicting_artwork_carriers(db_instance, tmp_path, monkeypatch):
+def test_import_preview_rejects_conflicting_artwork_carriers(
+    db_instance: CharactersRAGDB, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject contradictory credit claims in otherwise valid carriers."""
     archive = _credited_archive(
         db_instance,
         tmp_path,
@@ -1521,7 +1544,7 @@ def test_import_preview_rejects_conflicting_artwork_carriers(db_instance, tmp_pa
         ARTWORK_CREDITS,
         extension={**ARTWORK_CREDITS, "creator": "different creator"},
     )
-    with pytest.raises(ValueError, match="artwork_attribution_conflict"):
+    with pytest.raises(PersonaArtworkValidationError, match="artwork_attribution_conflict"):
         PersonaVisualPackImportPreviewer().create_preview(
             archive_path=archive,
             owner_user_id="user-1",
@@ -1529,7 +1552,8 @@ def test_import_preview_rejects_conflicting_artwork_carriers(db_instance, tmp_pa
         )
 
 
-def test_manifest_edits_cannot_bypass_artwork_validation():
+def test_manifest_edits_cannot_bypass_artwork_validation() -> None:
+    """Apply the artwork contract to direct visual-manifest edits as well as imports."""
     from tldw_Server_API.app.core.Persona.visuals import PersonaVisualManifestError, validate_visual_manifest
 
     manifest = {**_valid_manifest("asset"), "tldw/artwork": {**ARTWORK_CREDITS, "policy": "run"}}
@@ -1538,14 +1562,20 @@ def test_manifest_edits_cannot_bypass_artwork_validation():
 
 
 @pytest.mark.parametrize("context", [None, [], "legacy context", {"unrelated": "context"}])
-def test_credit_free_legacy_source_context_remains_importable(db_instance, tmp_path, monkeypatch, context):
+def test_credit_free_legacy_source_context_remains_importable(
+    db_instance: CharactersRAGDB, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, context: object
+) -> None:
+    """Keep unrelated legacy source context from preventing credit-free imports."""
     archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS, context=context)
     target = db_instance.create_persona_profile({"user_id": "user-1", "name": "Credit-free import"})
     pack = _commit_archive(db_instance, archive, target)
     assert "tldw/artwork" not in pack["manifest"]
 
 
-def test_export_fingerprint_includes_artwork_credits(db_instance, tmp_path, monkeypatch):
+def test_export_fingerprint_includes_artwork_credits(
+    db_instance: CharactersRAGDB, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Change export identity when only the authored credits change."""
     archive = _credited_archive(db_instance, tmp_path, monkeypatch, ARTWORK_CREDITS)
     target = db_instance.create_persona_profile({"user_id": "user-1", "name": "Credited fingerprint"})
     pack = _commit_archive(db_instance, archive, target)
@@ -1563,7 +1593,12 @@ def test_export_fingerprint_includes_artwork_credits(db_instance, tmp_path, monk
 
 
 @pytest.mark.integration
-def test_postgres_artwork_snapshot_and_native_export(pg_database_config, tmp_path, monkeypatch):
+def test_postgres_artwork_snapshot_and_native_export(
+    pg_database_config: DatabaseConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retain PostgreSQL snapshot credits and export JSON-compatible timestamps."""
     from tldw_Server_API.app.api.v1.schemas.buddies import BuddyCreate
     from tldw_Server_API.app.core.Buddy.service import BuddyService
     from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory


### PR DESCRIPTION
## Summary

Importing the published Trenchcoat pack succeeded but dropped its embedded creator, source URL and license notices; independent Buddy copies and native exports then lost that information. Preserve validated credits with the artwork and restore the existing native carrier on export so the same file remains importable in Chatbook. Existing independent copies remain immutable; recovering previously lost credits requires re-importing the original.

The repair uses existing manifest JSON without a migration, rejects invalid/conflicting credit records, excludes unrelated source context, and includes credits in export fingerprints. It also fixes PostgreSQL native exports serializing database timestamps. PostgreSQL import-job storage remains explicitly unsupported.

## Validation

- 45 final portability tests passed, including PostgreSQL copy/export and SQLite import/copy/source deletion/export/re-import.
- 72 adjacent independent-Buddy, visual-manifest and asset-remapping cases passed in the focused regression run.
- Ruff and Black passed; Bandit reported zero findings.
- Published Trenchcoat passed the actual authenticated HTTP worker round trip, retaining its exact 11,654-byte notices and all PNG bytes. The resulting export passed Chatbook's native importer with 18 activatable states and exact credits.
- Independent review findings were fixed and re-reviewed with no remaining blockers.
- Source hashes, archive hashes and qualification limits: `Docs/Reviews/2026-09-10-buddy-followup.md` and its linked receipt. ADR-006 records the metadata contract.

## Scope and remaining work

No production frontend change. Temporary browser diagnostics confirmed breakpoint-driven legacy host remounts but did not reproduce TASK-13211's historical rapid request loop. Native terminal, installed-extension and physical voice qualification remain open. Import guidance is tracked separately in tldw-stuff PR #18.

## Change summary

User-provided workstream summary: “Bugfixes+ux fixes for buddy mgmt and usage”.

Task: TASK-13242. No changes to Buddy attachment, reply execution or Persona ownership boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Buddy artwork credits being dropped on native pack import, independent Buddy copy, and native export. Validated creator, license, source URL, and notices now survive the round trip, and exports remain importable in Chatbook (TASK-13242).

**Bug Fixes**
- Imports preserve credits from `source_context.artwork` in the existing manifest JSON, and independent Buddy copies retain them after source deletion.
- Exports restore the native credit carrier, remove the internal `tldw/artwork` key, and include credits in the fingerprint.
- Invalid, oversized, conflicting, or credential-bearing credit records raise a central `PersonaArtworkValidationError` with stable messages; credit-free packs keep existing behavior.
- PostgreSQL native exports now serialize datetime values as ISO text; PostgreSQL import-job storage remains unsupported.

**Migration**
- Earlier imports may have already lost credits; re-import the original credited archive and create a new independent Buddy.
- Existing independent copies remain immutable, and credit-free archives still need their original notice files.

<sup>Written for commit 8131c21fff5ba2fcca215a39f5bf897035fb3db3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

