### PR TITLE
test(buddy): cover bounded loads through live route updates

### DIFF
--- a/Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md
+++ b/Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md
@@ -12,7 +12,7 @@ voice-controller output fields are overridden. The host uses `root="sidepanel"`
 without WebLayout, ServerReadinessGate or Fast Refresh. It verifies that all
 five voice states and the tool signal actually reach the published route context.
 
-Across 24 state transitions at 250 ms intervals, plus transcript updates and
+Across 24 state transitions at controlled 250 ms intervals, plus transcript updates and
 runtime diagnostic changes, requests remain at one pack list, one pack detail and
 one session list. The host remains present and its pack remains loaded. The
 positive control explicitly takes the route offline and back: the host disappears,
@@ -30,8 +30,12 @@ installation. No physical microphone, provider, installed extension or native
 terminal acceptance is claimed. DOM host/pack assertions do not prove rendered
 image pixels or real audio playback.
 
-Final focused run passed one test in 8.20 seconds; the corrected historical replay
-passed in 7.98 seconds, and all four current source files were restored byte-for-byte.
+The initial focused run passed one test in 8.20 seconds; the corrected historical
+replay passed in 7.98 seconds, and all four current source files were restored
+byte-for-byte. Qodo review then replaced the repeated-update loop's real sleeps
+with a fixed Vitest clock and explicit timer advancement. The check asserts exactly
+six seconds of simulated updates and restores real timers before reconnect checks
+and in failure cleanup. The revised focused test passed in 0.97 seconds.
 Review corrected the WebSocket fixture to use the real URL/protocol envelope and
 ready-state transitions, plus cleanup on failure. ESLint reported no code findings;
 its shared-package invocation emitted the existing Next pages-directory diagnostic.

--- a/Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md
+++ b/Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md
@@ -1,0 +1,68 @@
+# Buddy route lifecycle regression — 2026-09-10
+
+TASK-13211 remains an open investigation. This check covers its bounded-loading
+criterion; it does not establish the historical initiating trigger.
+
+## Executable evidence
+
+The shared-UI test `sidepanel-persona.buddy-lifecycle.test.tsx` mounts the real
+Persona route, Buddy context, Buddy host and live-control hook together. HTTP
+responses and online/connection/capability hook outputs are controlled; selected
+voice-controller output fields are overridden. The host uses `root="sidepanel"`
+without WebLayout, ServerReadinessGate or Fast Refresh. It verifies that all
+five voice states and the tool signal actually reach the published route context.
+
+Across 24 state transitions at 250 ms intervals, plus transcript updates and
+runtime diagnostic changes, requests remain at one pack list, one pack detail and
+one session list. The host remains present and its pack remains loaded. The
+positive control explicitly takes the route offline and back: the host disappears,
+then exactly one new request set loads. This distinguishes ordinary state updates
+from an actual availability-driven remount.
+
+```sh
+cd apps/packages/ui
+bun run test src/routes/__tests__/sidepanel-persona.buddy-lifecycle.test.tsx --maxWorkers=1
+```
+
+The source is dev `50c1f68957`; the relevant frontend files are unchanged in the
+credit-repair merge `f45bdca7b0`. Execution used a disposable frozen-lock frontend
+installation. No physical microphone, provider, installed extension or native
+terminal acceptance is claimed. DOM host/pack assertions do not prove rendered
+image pixels or real audio playback.
+
+Final focused run passed one test in 8.20 seconds; the corrected historical replay
+passed in 7.98 seconds, and all four current source files were restored byte-for-byte.
+Review corrected the WebSocket fixture to use the real URL/protocol envelope and
+ready-state transitions, plus cleanup on failure. ESLint reported no code findings;
+its shared-package invocation emitted the existing Next pages-directory diagnostic.
+Node emitted its localStorage experimental warning. No Python production code
+changed, so Bandit is not applicable to this test/documentation change.
+
+## Historical source recovered
+
+The original frontend commit `73640bbb89aed7d878d254bd622ca68f79923ad8` was found
+in a separate local checkout after the first clone and GitHub lookup failed.
+Replaying its route, Buddy host/context and live-control hook in the same test
+harness also held all three request counts at one across the 24 updates. That is
+a controlled four-file replay, not a complete historical application build.
+
+Context, live-control, WebLayout, readiness, connection, media-query, capability
+and Next configuration files are identical between the two revisions. The route
+now pins connected-session identity and the WebUI passes its explicit shell;
+neither difference supplies a recurring 250 ms trigger. Connected health polling
+preserves its interactive state while checking; normal poll/retry intervals are
+30 seconds, 5 seconds and 2 seconds.
+
+Development Fast Refresh can rerun both effects while ignoring unchanged dependency
+arrays. It remains a possible mechanism, not a proven cause. The earlier UAT log
+does not record refresh/effect lifetime events at the failing timestamps. A future
+reproduction must capture refresh events, effect setup/cleanup, route availability
+and Persona identity together with request timing. No speculative retry, debounce
+or lifecycle change is included.
+
+## Related completion
+
+PR #2940 merged the separate artwork-credit repair after all CI checks passed and
+Qodo resolved its six findings. TASK-13242 is complete. TASK-13211's initiating
+trigger and real-browser failure reproduction remain open; native/physical
+qualification continues in the existing dedicated tasks.

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.buddy-lifecycle.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.buddy-lifecycle.test.tsx
@@ -1,0 +1,630 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor
+} from "@testing-library/react"
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest"
+import {
+  BuddyShellHost,
+  BuddyShellRenderContextProvider,
+  useBuddyShellRenderContext
+} from "@/components/Common/PersonaBuddy"
+import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
+
+const mocks = vi.hoisted(() => ({
+  voiceState: "idle",
+  toolName: "",
+  isOnline: true,
+  uxState: "connected_ok" as
+    | "connected_ok"
+    | "configuring_url"
+    | "configuring_auth"
+    | "error_auth"
+    | "error_unreachable"
+    | "unconfigured",
+  hasCompletedFirstRun: true,
+  capabilitiesState: {
+    capabilities: { hasPersona: true, hasPersonalization: true },
+    loading: false
+  } as {
+    capabilities: {
+      hasPersona: boolean
+      hasPersonalization?: boolean
+      hasPersonaLiveControl?: boolean
+    } | null
+    loading: boolean
+  },
+  navigate: vi.fn(),
+  location: {
+    pathname: "/persona",
+    search: "",
+    hash: "",
+    state: null,
+    key: "persona-route"
+  },
+  useBlocker: vi.fn(),
+  blocker: {
+    state: "unblocked" as "unblocked" | "blocked" | "proceeding",
+    proceed: vi.fn(),
+    reset: vi.fn()
+  },
+  getConfig: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  buildPersonaWebSocketUrl: vi.fn(() => ({
+    url: "ws://persona.test/api/v1/persona/stream",
+    protocols: ["bearer", "test"]
+  })),
+  fetchCompanionConversationPrompts: vi.fn(),
+  buddyShellContextSnapshots: [] as Array<Record<string, unknown> | null>
+}))
+
+vi.mock("@/hooks/usePersonaLiveVoiceController", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/usePersonaLiveVoiceController")
+  >("@/hooks/usePersonaLiveVoiceController")
+  return {
+    ...actual,
+    usePersonaLiveVoiceController: (
+      ...args: Parameters<typeof actual.usePersonaLiveVoiceController>
+    ) => ({
+      ...actual.usePersonaLiveVoiceController(...args),
+      state: mocks.voiceState,
+      isListening: mocks.voiceState === "listening",
+      activeToolName: mocks.toolName,
+      activeToolStatus: mocks.toolName ? "Running search" : ""
+    })
+  }
+})
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () => [null, vi.fn(), { isLoading: false }]
+}))
+vi.mock("@/hooks/useSetting", () => ({
+  useSetting: (setting: { defaultValue: unknown }) => [
+    setting.defaultValue,
+    vi.fn(),
+    { isLoading: false }
+  ]
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => mocks.isOnline
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionUxState: () => ({
+    uxState: mocks.uxState,
+    hasCompletedFirstRun: mocks.hasCompletedFirstRun
+  })
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => mocks.capabilitiesState
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return {
+    ...actual,
+    UNSAFE_DataRouterContext: React.createContext({ router: {} }),
+    useNavigate: () => mocks.navigate,
+    useLocation: () => mocks.location,
+    useBlocker: (...args: unknown[]) =>
+      (mocks.useBlocker as (...args: unknown[]) => unknown)(...args)
+  }
+})
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getConfig: (...args: unknown[]) =>
+      (mocks.getConfig as (...args: unknown[]) => unknown)(...args),
+    fetchWithAuth: (...args: unknown[]) =>
+      (mocks.fetchWithAuth as (...args: unknown[]) => unknown)(...args)
+  }
+}))
+
+vi.mock("@/services/persona-stream", () => ({
+  buildPersonaWebSocketUrl: (...args: unknown[]) =>
+    (mocks.buildPersonaWebSocketUrl as (...args: unknown[]) => unknown)(...args)
+}))
+
+vi.mock("@/services/companion", () => ({
+  isCompanionConsentRequiredResponse: (
+    response:
+      | {
+          status?: number
+          error?: string | null
+        }
+      | null
+      | undefined
+  ) =>
+    response?.status === 409 &&
+    String(response?.error || "").includes(
+      "Enable personalization before using companion."
+    ),
+  fetchCompanionConversationPrompts: (...args: unknown[]) =>
+    (
+      mocks.fetchCompanionConversationPrompts as (...args: unknown[]) => unknown
+    )(...args)
+}))
+
+vi.mock("@/components/Common/FeatureEmptyState", () => ({
+  default: ({
+    title,
+    description,
+    primaryActionLabel,
+    onPrimaryAction
+  }: {
+    title: string
+    description?: string
+    primaryActionLabel?: string
+    onPrimaryAction?: () => void
+  }) => (
+    <div data-testid="feature-empty-state">
+      <div>{title}</div>
+      {description ? <div>{description}</div> : null}
+      {primaryActionLabel ? (
+        <button type="button" onClick={onPrimaryAction}>
+          {primaryActionLabel}
+        </button>
+      ) : null}
+    </div>
+  )
+}))
+
+vi.mock("@/components/Option/MCPHub", () => ({
+  PersonaPolicySummary: ({ personaId }: { personaId?: string | null }) => (
+    <div data-testid="persona-policy-summary">{personaId || "none"}</div>
+  )
+}))
+
+vi.mock("~/components/Sidepanel/Chat/SidepanelHeaderSimple", () => ({
+  SidepanelHeaderSimple: ({ activeTitle }: { activeTitle?: string }) => (
+    <div data-testid="sidepanel-header">{activeTitle || "header"}</div>
+  )
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string")
+        return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue)
+        return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("antd", async () => {
+  const actual = await vi.importActual<typeof import("antd")>("antd")
+  const Input = {
+    ...actual.Input,
+    TextArea: ({
+      autoSize: _autoSize,
+      onPressEnter,
+      onKeyDown,
+      value,
+      onChange,
+      ...rest
+    }: React.ComponentProps<"textarea"> & {
+      autoSize?: unknown
+      onPressEnter?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void
+    }) => (
+      <textarea
+        {...rest}
+        value={value ?? ""}
+        onChange={(event) => onChange?.(event)}
+        onKeyDown={(event) => {
+          onKeyDown?.(event)
+          if (event.key === "Enter") {
+            onPressEnter?.(event)
+          }
+        }}
+      />
+    )
+  }
+  return {
+    ...actual,
+    Input
+  }
+})
+
+import SidepanelPersona from "../sidepanel-persona"
+
+// Real route, context, host and live-control lifecycle; transport and voice
+// device signals are controlled. This does not claim physical voice qualification.
+vi.setConfig({ testTimeout: 30_000 })
+
+const BuddyShellContextProbe = () => {
+  const context = useBuddyShellRenderContext()
+
+  React.useEffect(() => {
+    mocks.buddyShellContextSnapshots.push(
+      context ? JSON.parse(JSON.stringify(context)) : null
+    )
+  }, [context])
+
+  return <pre data-testid="buddy-shell-context">{JSON.stringify(context)}</pre>
+}
+
+const queryClients: QueryClient[] = []
+const portalRoots: HTMLElement[] = []
+
+const render = (ui: React.ReactNode) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  })
+
+  queryClients.push(queryClient)
+  const wrappedUi = (child: React.ReactNode) => (
+    <QueryClientProvider client={queryClient}>
+      <BuddyShellRenderContextProvider>
+        {child}
+        <BuddyShellContextProbe />
+        <BuddyShellHost root="sidepanel" />
+      </BuddyShellRenderContextProvider>
+    </QueryClientProvider>
+  )
+
+  const view = rtlRender(wrappedUi(ui))
+  return {
+    ...view,
+    rerender: (nextUi: React.ReactNode) => view.rerender(wrappedUi(nextUi))
+  }
+}
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  readyState = MockWebSocket.CONNECTING
+  static instances: MockWebSocket[] = []
+
+  url: string
+  binaryType = "blob"
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  send = vi.fn<(payload: string) => void>()
+  close = vi.fn<() => void>()
+
+  constructor(
+    url: string,
+    readonly protocols?: string | string[]
+  ) {
+    this.url = new URL(url).toString()
+    MockWebSocket.instances.push(this)
+    this.send.mockImplementation(() => {
+      if (this.readyState !== MockWebSocket.OPEN)
+        throw new Error("WebSocket is not open")
+    })
+    this.close.mockImplementation(() => {
+      this.readyState = MockWebSocket.CLOSED
+      this.onclose?.({} as CloseEvent)
+    })
+  }
+
+  emitOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event("open"))
+  }
+
+  emitMessage(data: string | ArrayBuffer) {
+    this.onmessage?.({ data } as MessageEvent)
+  }
+}
+
+describe("SidepanelPersona", () => {
+  const originalWebSocket = globalThis.WebSocket
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  beforeAll(() => {
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    class MockResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    cleanup()
+    for (const client of queryClients.splice(0)) client.clear()
+    for (const portal of portalRoots.splice(0)) portal.remove()
+  })
+
+  afterAll(() => {
+    globalThis.WebSocket = originalWebSocket
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver
+    } else {
+      delete (globalThis as { ResizeObserver?: typeof ResizeObserver })
+        .ResizeObserver
+    }
+  })
+
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    window.localStorage.clear()
+    mocks.isOnline = true
+    mocks.uxState = "connected_ok"
+    mocks.hasCompletedFirstRun = true
+    mocks.capabilitiesState.capabilities = {
+      hasPersona: true,
+      hasPersonalization: true
+    }
+    mocks.capabilitiesState.loading = false
+    mocks.navigate.mockReset()
+    mocks.location.pathname = "/persona"
+    mocks.location.search = ""
+    mocks.location.hash = ""
+    mocks.location.state = null
+    mocks.location.key = "persona-route"
+    mocks.useBlocker.mockReset()
+    mocks.blocker.state = "unblocked"
+    mocks.blocker.proceed.mockReset()
+    mocks.blocker.reset.mockReset()
+    mocks.useBlocker.mockImplementation(() => mocks.blocker)
+    mocks.getConfig.mockReset()
+    mocks.fetchWithAuth.mockReset()
+    mocks.buildPersonaWebSocketUrl.mockReset()
+    mocks.fetchCompanionConversationPrompts.mockReset()
+    mocks.buddyShellContextSnapshots = []
+    usePersonaVisualRuntimeStore.setState({
+      override: null,
+      runtimeDiagnostics: null
+    })
+    mocks.buildPersonaWebSocketUrl.mockReturnValue({
+      url: "ws://persona.test/api/v1/persona/stream",
+      protocols: ["bearer", "test"]
+    })
+    mocks.fetchCompanionConversationPrompts.mockResolvedValue({
+      prompt_source_kind: "reflection",
+      prompt_source_id: "reflection-1",
+      prompts: [
+        {
+          prompt_id: "prompt-1",
+          label: "Next concrete step",
+          prompt_text: "What is the next concrete step for project alpha?",
+          prompt_type: "clarify_priority",
+          source_reflection_id: "reflection-1",
+          source_evidence_ids: ["activity-1"]
+        }
+      ]
+    })
+  })
+
+  it("TASK13211 integrated route retains bounded Buddy loads during live updates", async () => {
+    const portal = document.createElement("div")
+    portal.id = "tldw-portal-root"
+    document.body.appendChild(portal)
+    portalRoots.push(portal)
+    const personaId = "research_assistant"
+    const buddy = {
+      has_buddy: true,
+      persona_name: "Research Buddy",
+      role_summary: "Research",
+      visual: { species_id: "owl", silhouette_id: "perch", palette_id: "dawn" }
+    }
+    const pack = {
+      id: "pack-1",
+      persona_id: personaId,
+      title: "Lifecycle buddy",
+      renderer_type: "sprite_frames",
+      status: "active",
+      manifest: {
+        manifest_version: 1,
+        renderer_type: "sprite_frames",
+        states: {
+          idle: { animation_id: "idle" },
+          thinking: { animation_id: "idle" },
+          tool_running: { animation_id: "idle" },
+          error: { animation_id: "idle" }
+        },
+        animations: {
+          idle: { frames: [{ asset_id: "frame-1", duration_ms: 100 }] }
+        }
+      },
+      assets_by_id: {
+        "frame-1": {
+          id: "frame-1",
+          url: "/assets/lifecycle.png",
+          mime_type: "image/png",
+          asset_role: "frame",
+          width: 24,
+          height: 24
+        }
+      }
+    }
+    const calls: string[] = []
+    mocks.location.search = "?persona_id=research_assistant&tab=live"
+    mocks.capabilitiesState.capabilities = {
+      hasPersona: true,
+      hasPersonalization: true,
+      hasPersonaLiveControl: true
+    }
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test"
+    })
+    mocks.fetchWithAuth.mockImplementation(
+      async (path: string, options: { method?: string; body?: unknown }) => {
+        calls.push(path)
+        let data: unknown = []
+        if (path.endsWith("/visual-packs"))
+          data = {
+            packs: [{ ...pack, assets_by_id: undefined }],
+            active_pack: { ...pack, assets_by_id: undefined }
+          }
+        else if (path.endsWith("/visual-packs/pack-1")) data = pack
+        else if (path.includes("/live/sessions"))
+          data = { sessions: [], focused_session_id: null }
+        else if (path.includes("/catalog"))
+          data = [
+            { id: personaId, name: "Research Assistant", buddy_summary: buddy }
+          ]
+        else if (path.includes("/profiles/"))
+          data = {
+            id: personaId,
+            version: 1,
+            buddy_summary: buddy,
+            voice_defaults: {},
+            setup: {
+              status: "completed",
+              version: 1,
+              current_step: "test",
+              completed_steps: [
+                "persona",
+                "voice",
+                "commands",
+                "safety",
+                "test"
+              ]
+            }
+          }
+        else if (path.endsWith("/session") && options?.method === "POST")
+          data = { session_id: "session-research", persona_id: personaId }
+        else if (path.includes("/sessions/session-research"))
+          data = {
+            session_id: "session-research",
+            persona_id: personaId,
+            turns: []
+          }
+        return { ok: true, status: 200, json: async () => data }
+      }
+    )
+    const view = render(<SidepanelPersona shell="options" />)
+    await screen.findByTestId("persona-memory-toggle")
+    await screen.findByTestId("persona-resume-session-select")
+    await screen.findByTestId("persona-buddy-drag-handle")
+    await waitFor(() =>
+      expect(
+        usePersonaVisualRuntimeStore.getState().runtimeDiagnostics
+          ?.packLoadStatus
+      ).toBe("loaded")
+    )
+    const count = () => ({
+      list: calls.filter((p) => p.endsWith("/visual-packs")).length,
+      detail: calls.filter((p) => p.endsWith("/visual-packs/pack-1")).length,
+      sessions: calls.filter((p) => p.includes("/live/sessions")).length
+    })
+    const initial = count()
+    expect(initial.list).toBe(1)
+    expect(initial.detail).toBe(1)
+    expect(initial.sessions).toBe(1)
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const ws = MockWebSocket.instances[0]
+    expect(ws.url).toBe("ws://persona.test/api/v1/persona/stream")
+    expect(ws.protocols).toEqual(["bearer", "test"])
+    expect(ws.readyState).toBe(MockWebSocket.CONNECTING)
+    act(() => ws.emitOpen())
+    expect(ws.readyState).toBe(MockWebSocket.OPEN)
+    await screen.findByRole("button", { name: /Disconnect/ })
+    const voiceStates = [
+      "idle",
+      "listening",
+      "thinking",
+      "speaking",
+      "error",
+      "idle"
+    ]
+    for (let i = 0; i < 24; i++) {
+      mocks.voiceState = voiceStates[i % voiceStates.length]
+      mocks.toolName = i % 2 ? "knowledge.search" : ""
+      act(() =>
+        ws.emitMessage(
+          JSON.stringify({
+            event: "assistant_delta",
+            text_delta: `Answer ${i}. `
+          })
+        )
+      )
+      act(() =>
+        usePersonaVisualRuntimeStore.getState().setOverride({
+          personaId,
+          sessionId: "session-research",
+          state: i % 2 ? "thinking" : "error",
+          reason: "lifecycle-diagnostic",
+          expiresAt: Date.now() + 5000
+        })
+      )
+      view.rerender(<SidepanelPersona shell="options" />)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+    }
+    const publishedVoiceStates = new Set(
+      mocks.buddyShellContextSnapshots
+        .filter(Boolean)
+        .map((c) => c?.live_voice_state)
+    )
+    expect([...publishedVoiceStates].sort()).toEqual(
+      [...new Set(voiceStates)].sort()
+    )
+    expect(
+      mocks.buddyShellContextSnapshots.some(
+        (c) => c?.active_tool_name === "knowledge.search"
+      )
+    ).toBe(true)
+    expect(count()).toEqual(initial)
+    expect(screen.getByTestId("persona-buddy-drag-handle")).toBeInTheDocument()
+    expect(
+      usePersonaVisualRuntimeStore.getState().runtimeDiagnostics?.packLoadStatus
+    ).toBe("loaded")
+    // A real route availability change is the positive control: it must unmount
+    // the host and then load exactly one replacement when connectivity returns.
+    mocks.isOnline = false
+    view.rerender(<SidepanelPersona shell="options" />)
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("persona-buddy-drag-handle")
+      ).not.toBeInTheDocument()
+    )
+    expect(count()).toEqual(initial)
+    mocks.isOnline = true
+    view.rerender(<SidepanelPersona shell="options" />)
+    await screen.findByTestId("persona-buddy-drag-handle")
+    await waitFor(() =>
+      expect(
+        usePersonaVisualRuntimeStore.getState().runtimeDiagnostics
+          ?.packLoadStatus
+      ).toBe("loaded")
+    )
+    expect(count()).toEqual({ list: 2, detail: 2, sessions: 2 })
+    view.unmount()
+    portal.remove()
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.buddy-lifecycle.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.buddy-lifecycle.test.tsx
@@ -359,9 +359,13 @@ describe("SidepanelPersona", () => {
   })
 
   afterEach(() => {
-    cleanup()
-    for (const client of queryClients.splice(0)) client.clear()
-    for (const portal of portalRoots.splice(0)) portal.remove()
+    try {
+      cleanup()
+      for (const client of queryClients.splice(0)) client.clear()
+      for (const portal of portalRoots.splice(0)) portal.remove()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   afterAll(() => {
@@ -561,6 +565,11 @@ describe("SidepanelPersona", () => {
       "error",
       "idle"
     ]
+    // Control the repeated-update interval without coupling route bootstrap's
+    // Testing Library waits to a fake clock.
+    vi.useFakeTimers()
+    const startedAt = new Date("2026-09-10T00:00:00Z").getTime()
+    vi.setSystemTime(startedAt)
     for (let i = 0; i < 24; i++) {
       mocks.voiceState = voiceStates[i % voiceStates.length]
       mocks.toolName = i % 2 ? "knowledge.search" : ""
@@ -583,9 +592,10 @@ describe("SidepanelPersona", () => {
       )
       view.rerender(<SidepanelPersona shell="options" />)
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 250))
+        await vi.advanceTimersByTimeAsync(250)
       })
     }
+    expect(Date.now() - startedAt).toBe(6000)
     const publishedVoiceStates = new Set(
       mocks.buddyShellContextSnapshots
         .filter(Boolean)
@@ -604,6 +614,7 @@ describe("SidepanelPersona", () => {
     expect(
       usePersonaVisualRuntimeStore.getState().runtimeDiagnostics?.packLoadStatus
     ).toBe("loaded")
+    vi.useRealTimers()
     // A real route availability change is the positive control: it must unmount
     // the host and then load exactly one replacement when connectivity returns.
     mocks.isOnline = false

--- a/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
+++ b/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
@@ -4,7 +4,7 @@ title: Investigate repeated Buddy visual pack loads during live UAT
 status: In Progress
 assignee: []
 created_date: 2026-09-06 16:57
-updated_date: 2026-09-10 15:27
+updated_date: 2026-09-10 16:24
 labels: []
 dependencies: []
 references:
@@ -44,6 +44,7 @@ Voice follow-up PR created against dev: https://github.com/rmusser01/tldw_server
 
 2026-09-10 controlled browser diagnostics: 1280px mount, 1023px cleanup, 1024px remount with two development pack-list calls and one session-list call. Confirms breakpoint source of paired reloads, not original rapid loop. No initiating trigger or 429 reproduced; all original AC remain open. Source-bound details/timestamps in Docs/Reviews/2026-09-10-buddy-followup.md. Temporary probes not shipped; viewport restored.
 Recovered incident frontend73640bbb89aed7d878d254bd622ca68f79923ad8 from the separate local tldw_server checkout. The real route/context/host/live-control integration kept exactly one pack-list, detail and session-list across24 simulated voice/tool transitions at250ms; deliberately taking the route offline and back creates exactly one additional request set. Replaying the four historical source files also stayed stable. This is a bounded lifecycle regression, not an established initiating cause or physical voice acceptance. No production behavior was changed; AC1/AC3 remain open. Details and executable check in Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md.
+PR #2941 Qodo review: replace the 24 real-time waits with a fixed Vitest clock and explicit 250 ms advancement, assert exactly 6000 ms elapsed, and restore real timers before reconnect checks plus failure cleanup. The focused test passes in 0.97 seconds; this is deterministic bounded-load coverage, with no new claim about the historical trigger.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
+++ b/backlog/tasks/task-13211 - Investigate-repeated-Buddy-visual-pack-loads-during-live-UAT.md
@@ -4,7 +4,7 @@ title: Investigate repeated Buddy visual pack loads during live UAT
 status: In Progress
 assignee: []
 created_date: 2026-09-06 16:57
-updated_date: 2026-09-10 14:58
+updated_date: 2026-09-10 15:27
 labels: []
 dependencies: []
 references:
@@ -20,7 +20,7 @@ During physical Migu voice UAT, the floating Buddy lost its image after repeated
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The initiating trigger is identified with reproducible evidence.
-- [ ] #2 A regression check verifies bounded visual-pack loading through live state updates.
+- [x] #2 A regression check verifies bounded visual-pack loading through live state updates.
 - [ ] #3 Real browser validation confirms the Buddy image remains available without repeated pack-load failures.
 <!-- AC:END -->
 
@@ -43,7 +43,7 @@ Voice follow-up PR created against dev: https://github.com/rmusser01/tldw_server
 2026-09-10 follow-up: investigate current dev 50c1f68957 in isolated branch codex/buddy-v1-followup. Review real route/host/service boundaries and instrument disposable live UI before choosing a fix. Existing ADR005 applies; no new architecture or speculative repair. Official MCP task_view was unresponsive; using CLI fallback.
 
 2026-09-10 controlled browser diagnostics: 1280px mount, 1023px cleanup, 1024px remount with two development pack-list calls and one session-list call. Confirms breakpoint source of paired reloads, not original rapid loop. No initiating trigger or 429 reproduced; all original AC remain open. Source-bound details/timestamps in Docs/Reviews/2026-09-10-buddy-followup.md. Temporary probes not shipped; viewport restored.
-
+Recovered incident frontend73640bbb89aed7d878d254bd622ca68f79923ad8 from the separate local tldw_server checkout. The real route/context/host/live-control integration kept exactly one pack-list, detail and session-list across24 simulated voice/tool transitions at250ms; deliberately taking the route offline and back creates exactly one additional request set. Replaying the four historical source files also stayed stable. This is a bounded lifecycle regression, not an established initiating cause or physical voice acceptance. No production behavior was changed; AC1/AC3 remain open. Details and executable check in Docs/Reviews/2026-09-10-buddy-lifecycle-regression.md.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
+++ b/backlog/tasks/task-13242 - Preserve-imported-Buddy-artwork-credits-through-server-copies-and-exports.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-13242
 title: Preserve imported Buddy artwork credits through server copies and exports
-status: In Progress
+status: Done
 assignee:
 - '@codex'
 created_date: 2026-09-10 14:16
-updated_date: 2026-09-10 15:01
+updated_date: 2026-09-10 15:27
 labels:
 - buddy
 - persona
@@ -56,13 +56,21 @@ Implemented ADR-006: native credit validation/storage, independent attribution s
 
 Published PR https://github.com/rmusser01/tldw_server/pull/2940 against freshly fetched dev50c1f68957. Implementation commit0e72f25515, no behind-dev commits at publication. Collection installation guidance in tldw-stuff PR18 links the source-bound verification and recovery instructions. Task remains In Progress pending PR review/merge.
 PR2940 Qodo follow-up: documented helper contracts, typed/documented tests, central ValueError-compatible artwork exception, repaired mixed-CLI nested task markers without losing notes. Nine invalid-record tests RED on generic exceptions;44 SQLite portability cases pass after domain type. Ruff/Black/Bandit pass. Fixed curated-site API link from actual docs CI failure; local exact docs gate blocked before build by macOS SemLock ENOSPC, Linux CI pending. Collection PR18 merged75a800815f51aa220c82da7778d17f8a1e292a42.
+PR2940 merged f45bdca7b0ad06b29cad8f98d87e5025158cbde4 on2026-09-10 after all current-head CI checks passed and all six Qodo findings were resolved. Implementation and merge complete; collection guide PR18 is merged. Separate physical/native qualification and the historical lifecycle investigation remain tracked in their own tasks.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Preserved bounded native artwork credits across server import, independent copies and compatible export; fixed PostgreSQL timestamp serialization. Targeted storage/HTTP/native roundtrip verification and required CI passed. Merged PR2940. ADR006 extends the existing independent ownership contract without a migration.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Bugfixes+ux fixes for buddy mgmt and usage

## Regression coverage

Add an integrated Persona route/Buddy host test that verifies 24 voice, transcript, and tool updates keep pack-list, pack-detail, and session-list requests at one each. An offline/reconnect positive control verifies one new request set after a real remount. HTTP and availability outputs are controlled; this is not a physical voice or browser acceptance test.

Record the historical four-file replay, which also remained bounded, without claiming to have identified the old rapid-load trigger. Close the artwork-credit task following merged PR #2940; keep the original lifecycle investigation open.

## Validation

- Focused Vitest check: 1 passed; historical replay: 1 passed, current source restored byte-for-byte.
- ESLint: no code findings (shared-package Next pages-directory diagnostic only).
- Git whitespace check passed. No Python production changes; Bandit not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integrated regression test proving Buddy visual pack requests stay at one each across 24 live voice, transcript, and tool updates. No production code changes; the original rapid-load trigger remains unidentified.

**Test coverage**
- Uses the real Persona route, Buddy context, host, and live-control hook with controlled HTTP, WebSocket, and connection outputs; updates run on a fixed clock, then real timers are restored before reconnect checks.
- An offline/reconnect positive control confirms exactly one new request set after a real remount.
- A controlled replay of the historical four-file source also stayed bounded; this is not physical voice or browser acceptance.

**Task updates**
- TASK-13211 checks off the bounded-loading criterion; the initiating trigger and real-browser validation remain open.
- TASK-13242 is marked Done since the artwork-credit repair merged.

<sup>Written for commit c7cf94d24a473534b831c720b8d2348b9d38a0d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

