### PR TITLE
feat(scheduled-tasks): bound model overrides to usable providers at authoring time (TASK-13234)

### DIFF
--- a/backlog/tasks/task-13234 - Bound-scheduled-automation-model-overrides-to-usable-providers.md
+++ b/backlog/tasks/task-13234 - Bound-scheduled-automation-model-overrides-to-usable-providers.md
@@ -1,0 +1,80 @@
+---
+id: TASK-13234
+title: 'Bound scheduled-automation model overrides to usable providers at authoring time'
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-30 00:00'
+updated_date: '2026-08-30 00:00'
+labels:
+  - scheduled-tasks
+  - automation
+  - llm-providers
+  - authnz
+dependencies: []
+---
+
+## Description (the why)
+
+ADR-077 (chatbook task-18940) gives scheduled automations per-task model
+selection that rides the definition payload: `input.provider` /
+`input.model` / `input.max_tokens` override the automation config defaults
+(`automation_executors.resolve_execution_target` precedence: definition
+input → config defaults → server-default resolution). The execution half
+honors the override, but **nothing bounds it at authoring time**: a
+definition can name a provider the server does not configure (and the user
+has no BYOK secret for), or a provider an admin override has disabled, and
+the failure only surfaces as a failed run after the schedule fires — the
+worst possible place to discover a typo.
+
+This is AC#7 of chatbook TASK-18940: "per-task model selection rides the
+definition payload (hermes parity), **bounded to the providers the server
+account can use**."
+
+## Acceptance Criteria (the what)
+
+- [ ] Preview and definition create/update validate `input.provider` when
+      present: a provider that is neither in the configured listing (after
+      admin overrides: enabled) nor covered by the owner's BYOK secret is
+      a validation **error** (`input.provider` unusable), so authoring
+      refuses with the reason instead of a future failed run
+- [ ] An admin-override-disabled provider, or a model outside the
+      override's `allowed_models`, is a validation **error** (admin policy
+      is a hard bound, not a warning)
+- [ ] A set `input.model` that is not in the resolved provider's known
+      model list is a validation **warning** only (model lists drift and
+      passthrough providers accept new names; the preview surfaces it, the
+      definition still saves)
+- [ ] Blank/whitespace keys keep today's behavior (fall through to config
+      defaults; no new errors)
+- [ ] The bound check runs at preview, create, and update — the three
+      authoring surfaces — and the validation result is recorded in the
+      preview's `validation_errors`/`warnings` like existing findings
+- [ ] Tests cover: usable provider passes; unconfigured provider errors;
+      BYOK-covered provider passes without server config; disabled
+      provider errors; model-not-allowed errors; unknown model warns;
+      blank keys unaffected
+
+## Implementation Plan (the how)
+
+1. Add an async bound check to `ScheduledTaskAutomationService` that takes
+   the owner id and the normalized payload, extracting
+   `input.provider`/`input.model` with the executor's coercion semantics
+2. Provider usability: configured listing via `get_configured_providers()`
+   + `apply_llm_provider_overrides_to_listing` (admin enablement) +
+   `validate_provider_override(provider, model)` for hard policy, and the
+   owner's BYOK secrets (`AuthnzUserProviderSecretsRepo`) as the
+   server-config-independent path
+3. Model-not-in-listing → warning only; unknown provider → error; wire
+   both into the existing `_field_error` shapes
+4. Call it from `create_preview`, `create_definition`, `update_definition`
+   (owner id is already in scope at all three)
+5. Tests mirroring the existing preview-validation suite's style, with the
+   provider/BYOK/override layers monkeypatched
+
+## Implementation Notes
+
+(added after implementation)
+
+ADR required: no — implements chatbook ADR-077's AC#7 clause within the
+existing scheduled-tasks control-plane design; no new boundary.

--- a/backlog/tasks/task-13234 - Bound-scheduled-automation-model-overrides-to-usable-providers.md
+++ b/backlog/tasks/task-13234 - Bound-scheduled-automation-model-overrides-to-usable-providers.md
@@ -33,27 +33,32 @@ account can use**."
 
 ## Acceptance Criteria (the what)
 
-- [ ] Preview and definition create/update validate `input.provider` when
-      present: a provider that is neither in the configured listing (after
-      admin overrides: enabled) nor covered by the owner's BYOK secret is
-      a validation **error** (`input.provider` unusable), so authoring
-      refuses with the reason instead of a future failed run
-- [ ] An admin-override-disabled provider, or a model outside the
+- [x] Preview and definition create/update validate `input.provider` when
+      present: a provider not in the configured listing (after admin
+      overrides: enabled) is a validation **error** (`input.provider`
+      unusable), so authoring refuses with the reason instead of a future
+      failed run. (Scope amendment: no BYOK exemption in this task — the
+      scheduled executor threads no owner credentials, so BYOK-covered
+      providers cannot run scheduled work today; accepting them at
+      authoring would lie. BYOK-for-scheduled-execution is a phase-2
+      design alongside server issue #2805.)
+- [x] An admin-override-disabled provider, or a model outside the
       override's `allowed_models`, is a validation **error** (admin policy
       is a hard bound, not a warning)
-- [ ] A set `input.model` that is not in the resolved provider's known
+- [x] A set `input.model` that is not in the resolved provider's known
       model list is a validation **warning** only (model lists drift and
       passthrough providers accept new names; the preview surfaces it, the
       definition still saves)
-- [ ] Blank/whitespace keys keep today's behavior (fall through to config
+- [x] Blank/whitespace keys keep today's behavior (fall through to config
       defaults; no new errors)
-- [ ] The bound check runs at preview, create, and update — the three
+- [x] The bound check runs at preview, create, and update — the three
       authoring surfaces — and the validation result is recorded in the
       preview's `validation_errors`/`warnings` like existing findings
-- [ ] Tests cover: usable provider passes; unconfigured provider errors;
-      BYOK-covered provider passes without server config; disabled
-      provider errors; model-not-allowed errors; unknown model warns;
-      blank keys unaffected
+- [x] Tests cover: usable provider passes; unconfigured provider errors;
+      disabled provider errors; model-not-allowed errors (attributed to
+      `input.model`); unknown model warns; blank keys unaffected;
+      listing-read failure does not brick authoring; legacy previews
+      hard-fail at create/update when the target becomes unusable
 
 ## Implementation Plan (the how)
 
@@ -74,7 +79,28 @@ account can use**."
 
 ## Implementation Notes
 
-(added after implementation)
+- `_bound_execution_target_findings` (module-level in the automation
+  service) coerces `input.provider`/`input.model` with the executor's
+  blank-fallthrough semantics and produces `(errors, warnings)` in the
+  shared `_field_error` / preview-warning-string shapes. Hard codes:
+  `unusable`, `provider_disabled`, `model_not_allowed`; soft:
+  `unknown_model` (warning only — model lists drift).
+- Usability source: `get_configured_providers(include_deprecated=True)`
+  (deferred import — the listing lives in the API layer) passed through
+  `apply_llm_provider_overrides_to_listing`, plus
+  `validate_provider_override(resolved, model)` for admin hard policy.
+  A listing read failure returns no findings rather than bricking
+  authoring; run-time failure semantics are unchanged.
+- Wiring: `_normalize_preview` appends the findings (preview turns
+  invalid on hard codes); `_create_definition`/`_update_definition` call
+  `_require_execution_target_bound` so previews authored before the bound
+  existed (or when the target became unusable between preview and
+  consume) hard-fail with new error code `execution_target_unusable`,
+  mapped to 422 `scheduled_task_execution_target_unusable` in the
+  control plane's error table.
+- Field attribution follows the error code: `model_not_allowed` lands on
+  `input.model`, `provider_disabled`/`unusable` on `input.provider`
+  (pinned-key discipline caught by the test matrix).
 
 ADR required: no — implements chatbook ADR-077's AC#7 clause within the
 existing scheduled-tasks control-plane design; no new boundary.

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -207,6 +207,11 @@ _AUTOMATION_ERROR_MAP: dict[str, tuple[int, str, str]] = {
         "scheduled_task_idempotency_conflict",
         "Idempotency key was already used with a different payload.",
     ),
+    "execution_target_unusable": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_execution_target_unusable",
+        "The definition's pinned provider/model cannot run on this server.",
+    ),
     "scheduled_task_idempotency_response_unavailable": (
         status.HTTP_409_CONFLICT,
         "scheduled_task_execution_unavailable",

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -41,6 +41,9 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     ScheduledTasksDatabase,
     ScheduledTasksTransaction,
 )
+from tldw_Server_API.app.core.Scheduled_Tasks.automation_executors import (
+    _config_section as _automation_config_section,
+)
 from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
     AgentAutomationAdmission,
     AgentExecutionDispatchReadiness,
@@ -128,11 +131,28 @@ def _usable_provider_listing() -> dict[str, Any] | None:
             get_configured_providers,
         )
 
-        return apply_llm_provider_overrides_to_listing(
+        listing = apply_llm_provider_overrides_to_listing(
             get_configured_providers(include_deprecated=True)
         )
     except Exception:  # noqa: BLE001
+        from loguru import logger as _logger
+
+        _logger.exception("Automation target-bound provider listing read failed")
         return None
+    if listing.get("error"):
+        # get_configured_providers converts its own read failures into an
+        # error payload (empty providers, 'error' key) instead of raising;
+        # treating that as a real listing would classify every pinned
+        # provider as unusable and fail authoring CLOSED on a config
+        # problem. Unavailable, not empty.
+        from loguru import logger as _logger
+
+        _logger.warning(
+            "Automation target-bound provider listing unavailable: {}",
+            listing.get("error"),
+        )
+        return None
+    return listing
 
 
 def _bound_execution_target_findings(
@@ -179,13 +199,17 @@ def _bound_execution_target_findings(
     listing = _usable_provider_listing()
     if listing is None:
         return errors, warnings
+    # Runtime routing normalizes provider names (normalize_provider =
+    # strip + lower), so the bound must compare on the normalized form --
+    # a cased alias the executor would happily run must not be rejected.
     providers = {
-        str(entry.get("name")): entry
+        str(entry.get("name")).strip().lower(): entry
         for entry in listing.get("providers", [])
         if isinstance(entry, dict) and entry.get("name")
     }
+    provider_key = provider.strip().lower() if provider is not None else None
 
-    if provider is not None and provider not in providers:
+    if provider_key is not None and provider_key not in providers:
         errors.append(
             _field_error(
                 "input.provider",
@@ -199,9 +223,15 @@ def _bound_execution_target_findings(
         return errors, warnings
 
     # Admin hard policy (disabled provider / model outside allowed_models)
-    # applies whether or not the provider was pinned; resolve it from the
-    # listing default otherwise so a pinned model still gets checked.
-    resolved = provider or _nonempty(listing.get("default_provider"))
+    # applies whether or not the provider was pinned; for a model-only pin,
+    # resolve the provider with the EXECUTOR's precedence (automation-config
+    # executor_provider first, then the listing default) so the check and
+    # the run agree on whose model list governs.
+    resolved = provider_key or _nonempty(
+        _automation_config_section().get("executor_provider")
+    ) or _nonempty(listing.get("default_provider"))
+    if resolved is not None:
+        resolved = resolved.strip().lower()
     if resolved is not None:
         override_error = validate_provider_override(resolved, model)
         if override_error is not None:
@@ -1500,6 +1530,11 @@ class ScheduledTaskAutomationService:
             raise ScheduledTaskAutomationError("definition_archived")
         if source.lifecycle == "disabled" and source.disabled_lock_kind in {"admin", "security"}:
             raise ScheduledTaskAutomationError("definition_disabled_locked")
+        # Duplicate bypasses preview authoring (an auto-valid preview is
+        # synthesized below), so the bound must be applied here explicitly
+        # -- otherwise copying a legacy definition whose target became
+        # unusable would mint another unrunnable one (review F6).
+        self._require_execution_target_bound(source.input)
         copy_name = request.name or f"{source.name} copy"
         copy_description = request.description if request.description is not None else source.description
         normalized = {

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -29,6 +29,10 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas impor
     ScheduledTaskRunNowResponse,
     ScheduledTaskRunResponse,
 )
+from tldw_Server_API.app.core.AuthNZ.llm_provider_overrides import (
+    apply_llm_provider_overrides_to_listing,
+    validate_provider_override,
+)
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     AuditEventRow,
@@ -106,6 +110,135 @@ def _canonical_hash(payload: dict[str, Any]) -> str:
 
 def _field_error(field: str, code: str, message: str) -> dict[str, Any]:
     return {"field": field, "code": code, "message": message}
+
+
+def _usable_provider_listing() -> dict[str, Any] | None:
+    """Return the provider listing scheduled runs can actually use, or None.
+
+    Scheduled execution resolves credentials from server config only (the
+    executor threads no owner/BYOK context), so the authoring bound is the
+    server's configured listing under admin-override policy -- the same
+    surface ``GET /llm/providers`` reports. Deferred import: the listing
+    lives in the API layer and importing it at module scope would cycle
+    through the router. A failure to READ the listing must not brick
+    authoring (the run-time failure semantics are unchanged), hence None.
+    """
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.llm_providers import (
+            get_configured_providers,
+        )
+
+        return apply_llm_provider_overrides_to_listing(
+            get_configured_providers(include_deprecated=True)
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _bound_execution_target_findings(
+    input_map: Any,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Bound a definition's pinned execution target (TASK-13234, ADR-077 AC#7).
+
+    ``input.provider``/``input.model`` ride the definition payload and the
+    executor honors them per run. This check bounds them at AUTHORING time
+    so a typo or an admin-policy violation surfaces in the preview instead
+    of as a failed run after the schedule fires.
+
+    Severity: an unusable pinned provider (not configured on this server),
+    an admin-disabled provider, or a model outside the admin override's
+    ``allowed_models`` are ERRORS; a model merely absent from the resolved
+    provider's known list is a WARNING (model lists drift and passthrough
+    providers accept new names -- the run may still succeed).
+
+    Args:
+        input_map: The normalized definition ``input`` mapping (or anything
+            else, coerced safely).
+
+    Returns:
+        ``(errors, warnings)`` in the shared ``_field_error`` / preview
+        warning-string shapes.
+    """
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    def _nonempty(value: Any) -> str | None:
+        if value is None or isinstance(value, bool):
+            return None
+        text = str(value).strip()
+        return text or None
+
+    source = input_map if isinstance(input_map, dict) else {}
+    provider = _nonempty(source.get("provider"))
+    model = _nonempty(source.get("model"))
+    if provider is None and model is None:
+        # Blank keys keep today's behavior: the server's fallback chain
+        # (automation-config executor defaults, then server default).
+        return errors, warnings
+
+    listing = _usable_provider_listing()
+    if listing is None:
+        return errors, warnings
+    providers = {
+        str(entry.get("name")): entry
+        for entry in listing.get("providers", [])
+        if isinstance(entry, dict) and entry.get("name")
+    }
+
+    if provider is not None and provider not in providers:
+        errors.append(
+            _field_error(
+                "input.provider",
+                "unusable",
+                (
+                    f"Provider '{provider}' is not configured on this server; "
+                    "scheduled runs use server credentials only."
+                ),
+            )
+        )
+        return errors, warnings
+
+    # Admin hard policy (disabled provider / model outside allowed_models)
+    # applies whether or not the provider was pinned; resolve it from the
+    # listing default otherwise so a pinned model still gets checked.
+    resolved = provider or _nonempty(listing.get("default_provider"))
+    if resolved is not None:
+        override_error = validate_provider_override(resolved, model)
+        if override_error is not None:
+            error_code = str(override_error.get("error_code") or "provider_disabled")
+            # Attribute the finding to the key the policy actually rejects:
+            # a disabled provider to input.provider, a blocked model to
+            # input.model (falling back to the provider when the model rode
+            # the resolved default, since nothing was pinned there).
+            if error_code == "model_not_allowed" and model is not None:
+                field = "input.model"
+            else:
+                field = "input.provider"
+            errors.append(
+                _field_error(
+                    field,
+                    error_code,
+                    (
+                        f"Provider '{resolved}' is blocked by server policy "
+                        f"({error_code})."
+                    ),
+                )
+            )
+            return errors, warnings
+
+    if model is not None and resolved is not None:
+        entry = providers.get(resolved) or {}
+        known = {
+            str(name)
+            for name in (entry.get("models") or [])
+            if isinstance(name, str) and name.strip()
+        }
+        if known and model not in known:
+            warnings.append(
+                f"input.model: unknown_model — '{model}' is not in the known "
+                f"model list for provider '{resolved}'; it may still work."
+            )
+    return errors, warnings
 
 
 def _redact_agent_message(message: str) -> dict[str, Any]:
@@ -345,6 +478,31 @@ class ScheduledTaskAutomationService:
             reason=admission.reason,
             recovery_action=admission.recovery_action,
         )
+
+    def _require_execution_target_bound(self, input_map: Any) -> None:
+        """Refuse an authoring surface whose pinned target cannot run.
+
+        Definition create/update consume previews that were already bound
+        at preview time; this re-check closes the window for previews
+        authored before the bound existed (TASK-13234) -- the same hard
+        codes the preview reports, surfaced as one service error.
+        """
+
+        errors, _warnings = _bound_execution_target_findings(input_map)
+        hard_codes = {"unusable", "provider_disabled", "model_not_allowed"}
+        hard = [error for error in errors if error.get("code") in hard_codes]
+        if hard:
+            detail = "; ".join(
+                f"{error.get('field')}: {error.get('message')}" for error in hard
+            )
+            raise ScheduledTaskAutomationError(
+                "execution_target_unusable",
+                reason=detail,
+                recovery_action=(
+                    "Pin a provider/model this server can run, or clear both "
+                    "keys to use the server default."
+                ),
+            )
 
     def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
         """Return additive per-family capability and feasibility truth."""
@@ -1052,6 +1210,7 @@ class ScheduledTaskAutomationService:
         if preview.mode != "create" or preview.definition_id is not None:
             raise ScheduledTaskAutomationError("preview_mode_mismatch")
         normalized = preview.normalized_config
+        self._require_execution_target_bound(normalized.get("input"))
         normalized_config = normalized.get("config", {})
         definition = tx.create_definition(
             owner_id=owner_id,
@@ -1110,6 +1269,7 @@ class ScheduledTaskAutomationService:
         if preview.definition_version != current.version:
             raise ScheduledTaskAutomationError("definition_version_mismatch")
         normalized = preview.normalized_config
+        self._require_execution_target_bound(normalized.get("input"))
         normalized_config = normalized.get("config", {})
         updated = tx.update_definition(
             owner_id=owner_id,
@@ -1504,7 +1664,14 @@ class ScheduledTaskAutomationService:
         normalized["family"] = request.family
         normalized["schedule"] = schedule
         normalized["visibility_policy"] = base["visibility_policy"]
-        return normalized, [*mode_errors, *errors, *schedule_errors], [*warnings, *schedule_warnings]
+        bound_errors, bound_warnings = _bound_execution_target_findings(
+            normalized.get("input")
+        )
+        return (
+            normalized,
+            [*mode_errors, *errors, *schedule_errors, *bound_errors],
+            [*warnings, *schedule_warnings, *bound_warnings],
+        )
 
     def _preview_hash_payload(self, request: ScheduledTaskPreviewCreateRequest) -> dict[str, Any]:
         payload = request.model_dump(mode="json")

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_target_bound.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_target_bound.py
@@ -1,0 +1,273 @@
+"""Authoring-time bound on automation execution targets (TASK-13234).
+
+ADR-077 (chatbook task-18940) AC#7: per-task model selection rides the
+definition payload, bounded to the providers the server can actually run.
+The executor honors ``input.provider``/``input.model`` per run; these
+tests pin the authoring-time bound in ``_bound_execution_target_findings``
+and its wiring into preview / create / update.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
+    ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionUpdateRequest,
+)
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.services import scheduled_task_automation_service as service_module
+from tldw_Server_API.app.services.scheduled_task_automation_service import (
+    ScheduledTaskAutomationError,
+    ScheduledTaskAutomationService,
+)
+
+OWNER_ID = 4210
+ACTOR = "target-bound-test"
+
+_LISTING: dict[str, Any] = {
+    "providers": [
+        {"name": "openai", "models": ["gpt-4o", "gpt-4o-mini"], "is_enabled": True},
+        {"name": "anthropic", "models": ["claude-3-5"], "is_enabled": True},
+    ],
+    "default_provider": "openai",
+    "total_configured": 2,
+}
+
+
+def _service(tmp_path) -> tuple[ScheduledTaskAutomationService, ScheduledTasksDatabase]:
+    repo = ScheduledTasksDatabase(tmp_path / "scheduled_tasks_bound.db")
+    repo.ensure_schema()
+    return ScheduledTaskAutomationService(repository=repo), repo
+
+
+def _bound(monkeypatch: pytest.MonkeyPatch, listing: dict[str, Any] | None) -> None:
+    monkeypatch.setattr(service_module, "_usable_provider_listing", lambda: listing)
+
+
+def _no_admin_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service_module, "validate_provider_override", lambda p, m: None)
+
+
+def _preview_payload(provider: str | None, model: str | None):
+    input_payload: dict[str, Any] = {
+        "question": "What changed in the selected sources?"
+    }
+    if provider is not None:
+        input_payload["provider"] = provider
+    if model is not None:
+        input_payload["model"] = model
+    return service_module.ScheduledTaskPreviewCreateRequest(
+        mode="create",
+        family="recurring_question",
+        name="Daily research check",
+        config={},
+        input=input_payload,
+        schedule={"kind": "daily", "time": "09:00", "timezone": "UTC"},
+        visibility_policy={"mode": "findings_only"},
+    )
+
+
+def test_usable_provider_passes_clean(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", "gpt-4o"),
+    )
+
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+    assert preview.warnings == []  # nosec B101
+
+
+def test_unconfigured_provider_is_a_validation_error(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("not-a-provider", None),
+    )
+
+    assert preview.status == "invalid"  # nosec B101
+    assert [(e["field"], e["code"]) for e in preview.validation_errors] == [
+        ("input.provider", "unusable")
+    ]  # nosec B101
+
+
+def test_admin_disabled_provider_is_a_validation_error(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    monkeypatch.setattr(
+        service_module,
+        "validate_provider_override",
+        lambda p, m: {"error_code": "provider_disabled"}
+        if p == "openai"
+        else None,
+    )
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", None),
+    )
+
+    assert preview.status == "invalid"  # nosec B101
+    assert [(e["field"], e["code"]) for e in preview.validation_errors] == [
+        ("input.provider", "provider_disabled")
+    ]  # nosec B101
+
+
+def test_admin_model_not_allowed_is_a_validation_error(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    monkeypatch.setattr(
+        service_module,
+        "validate_provider_override",
+        lambda p, m: {"error_code": "model_not_allowed"}
+        if (p == "openai" and m == "gpt-4o")
+        else None,
+    )
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", "gpt-4o"),
+    )
+
+    assert preview.status == "invalid"  # nosec B101
+    assert [(e["field"], e["code"]) for e in preview.validation_errors] == [
+        ("input.model", "model_not_allowed")
+    ]  # nosec B101
+
+
+def test_unknown_model_is_a_warning_only(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", "brand-new-model"),
+    )
+
+    # The preview stays valid; the drift is surfaced, not fatal.
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+    assert len(preview.warnings) == 1  # nosec B101
+    assert "unknown_model" in str(preview.warnings[0])  # nosec B101
+    assert "brand-new-model" in str(preview.warnings[0])  # nosec B101
+
+
+def test_blank_keys_keep_fallback_semantics(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("   ", ""),
+    )
+
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+    assert preview.warnings == []  # nosec B101
+
+
+def test_listing_read_failure_does_not_brick_authoring(tmp_path, monkeypatch):
+    _bound(monkeypatch, None)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", "gpt-4o"),
+    )
+
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+
+
+def test_legacy_preview_with_unusable_provider_hard_fails_on_create(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    # Preview authored while the provider looked usable...
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", None),
+    )
+    # ...then the server config loses the provider before create consumes it.
+    _bound(monkeypatch, {"providers": [], "default_provider": None, "total_configured": 0})
+
+    with pytest.raises(ScheduledTaskAutomationError) as excinfo:
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+        )
+    assert excinfo.value.code == "execution_target_unusable"  # nosec B101
+
+
+def test_update_hard_fails_for_newly_unusable_target(tmp_path, monkeypatch):
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    create_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", None),
+    )
+    definition = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=create_preview.id),
+    )
+
+    update_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=service_module.ScheduledTaskPreviewCreateRequest(
+            mode="update",
+            family="recurring_question",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Daily research check",
+            config={},
+            input={"question": "What changed?", "provider": "anthropic"},
+            schedule={"kind": "daily", "time": "09:00", "timezone": "UTC"},
+            visibility_policy={"mode": "findings_only"},
+        ),
+    )
+    # Admin disables the provider between preview and update.
+    monkeypatch.setattr(
+        service_module,
+        "validate_provider_override",
+        lambda p, m: {"error_code": "provider_disabled"}
+        if p == "anthropic"
+        else None,
+    )
+
+    with pytest.raises(ScheduledTaskAutomationError) as excinfo:
+        service.update_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDefinitionUpdateRequest(preview_id=update_preview.id),
+        )
+    assert excinfo.value.code == "execution_target_unusable"  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_target_bound.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_target_bound.py
@@ -16,6 +16,7 @@ import pytest
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
     ScheduledTaskDefinitionCreateRequest,
     ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskDuplicateRequest,
 )
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     ScheduledTasksDatabase,
@@ -39,13 +40,17 @@ _LISTING: dict[str, Any] = {
 }
 
 
-def _service(tmp_path) -> tuple[ScheduledTaskAutomationService, ScheduledTasksDatabase]:
+def _service(
+    tmp_path: Any,
+) -> tuple[ScheduledTaskAutomationService, ScheduledTasksDatabase]:
     repo = ScheduledTasksDatabase(tmp_path / "scheduled_tasks_bound.db")
     repo.ensure_schema()
     return ScheduledTaskAutomationService(repository=repo), repo
 
 
-def _bound(monkeypatch: pytest.MonkeyPatch, listing: dict[str, Any] | None) -> None:
+def _bound(
+    monkeypatch: pytest.MonkeyPatch, listing: dict[str, Any] | None
+) -> None:
     monkeypatch.setattr(service_module, "_usable_provider_listing", lambda: listing)
 
 
@@ -269,5 +274,102 @@ def test_update_hard_fails_for_newly_unusable_target(tmp_path, monkeypatch):
             actor=ACTOR,
             definition_id=definition.id,
             payload=ScheduledTaskDefinitionUpdateRequest(preview_id=update_preview.id),
+        )
+    assert excinfo.value.code == "execution_target_unusable"  # nosec B101
+
+
+def test_listing_error_payload_fails_open(tmp_path, monkeypatch):
+    """A config-read failure (error payload, not an exception) must not brick authoring."""
+    from tldw_Server_API.app.api.v1.endpoints import llm_providers as listing_module
+
+    _no_admin_policy(monkeypatch)
+    monkeypatch.setattr(
+        listing_module,
+        "get_configured_providers",
+        lambda **kwargs: {
+            "providers": [],
+            "default_provider": "openai",
+            "total_configured": 0,
+            "error": "internal error reading config",
+        },
+    )
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", "gpt-4o"),
+    )
+
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+
+
+def test_cased_provider_alias_is_accepted(tmp_path, monkeypatch):
+    """Runtime routing normalizes provider casing; the bound must too."""
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("OpenAI", None),
+    )
+
+    assert preview.status == "valid"  # nosec B101
+    assert preview.validation_errors == []  # nosec B101
+
+
+def test_model_only_pin_checks_automation_config_executor_provider(tmp_path, monkeypatch):
+    """A model-only pin resolves the provider with the executor's precedence."""
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    monkeypatch.setattr(
+        service_module,
+        "_automation_config_section",
+        lambda: {"executor_provider": "anthropic"},
+    )
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload(None, "gpt-4o"),
+    )
+
+    # gpt-4o is unknown for anthropic (the automation-config provider),
+    # not for the listing default (openai) -- the warning names anthropic.
+    assert preview.status == "valid"  # nosec B101
+    assert len(preview.warnings) == 1  # nosec B101
+    assert "anthropic" in str(preview.warnings[0])  # nosec B101
+
+
+def test_duplicate_hard_fails_when_target_became_unusable(tmp_path, monkeypatch):
+    """Duplicate synthesizes an auto-valid preview; the bound must apply there too."""
+    _bound(monkeypatch, _LISTING)
+    _no_admin_policy(monkeypatch)
+    service, _repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_preview_payload("openai", None),
+    )
+    definition = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+    )
+
+    # The provider disappears from the server before the duplicate.
+    _bound(monkeypatch, {"providers": [], "default_provider": None, "total_configured": 0})
+
+    with pytest.raises(ScheduledTaskAutomationError) as excinfo:
+        service.duplicate_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDuplicateRequest(),
         )
     assert excinfo.value.code == "execution_target_unusable"  # nosec B101


### PR DESCRIPTION
## What

Implements TASK-13234 — the server half of chatbook ADR-077 AC#7 (task-18940): per-task model selection rides the definition payload, **bounded to the providers the server account can use.**

The executor already honors `input.provider`/`input.model`/`input.max_tokens` per run (`resolve_execution_target`: definition input → automation-config defaults → server default). Nothing bounded them — a typo'd provider or an admin-policy violation only surfaced as a failed run after the schedule fired.

### The bound (authoring time)

New `_bound_execution_target_findings` in the automation service, wired into all three authoring surfaces:

| Condition | Severity |
|---|---|
| Pinned provider not in the configured listing (after admin overrides) | **error** `input.provider`/`unusable` |
| Admin override disables the provider | **error** `provider_disabled` |
| Model outside the admin override's `allowed_models` | **error** `model_not_allowed` (attributed to `input.model`) |
| Model not in the resolved provider's known list | **warning** only (lists drift; passthrough accepts new names) |
| Blank/whitespace keys | unchanged (fallback chain) |
| Listing read fails | no findings — authoring is not bricked; run-time semantics unchanged |

- **Preview**: findings append to the existing `validation_errors`/`warnings` (hard codes turn the preview invalid).
- **Create/update**: `_require_execution_target_bound` re-checks the preview payload, closing the window for previews authored before the bound existed (or when the target became unusable between preview and consume) — new error code `execution_target_unusable`, mapped to 422 `scheduled_task_execution_target_unusable` with a recovery action.

### Scope note (recorded in the task)

No BYOK exemption: the scheduled executor threads no owner credentials, so BYOK-covered providers cannot run scheduled work today — accepting them at authoring would lie. BYOK-for-scheduled-execution is phase-2 alongside #2805.

## Verification

- 9 new focused tests (full severity matrix + legacy-preview hard-fail at create and update)
- Full Notifications suite: 371 passed (no regressions)
- ruff clean

Task file: ACs ticked, scope amendment and implementation notes recorded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds scheduled automation `input.provider`/`input.model` overrides to the providers this server can actually run (TASK-13234), so a typo or admin-policy violation surfaces in the preview instead of as a failed run after the schedule fires.

**Validation behavior**
- A provider not in the configured listing, an admin-disabled provider, or a model outside the admin override's allowed list is a validation error; a model missing from the resolved provider's known list is a warning only.
- Provider names compare case-insensitively to match runtime routing, and a model-only pin resolves its provider with the executor's precedence (automation-config `executor_provider`, then listing default).
- Blank or whitespace keys keep the fallback chain; a failed listing read (exception or error payload) adds no findings so authoring stays open, with logging on both paths.

**Create, update, and duplicate checks**
- Create and update re-validate the preview payload, and duplicate applies the same bound to the source definition, so targets that became unusable since authoring hard-fail with error code `execution_target_unusable` (422 `scheduled_task_execution_target_unusable`).
- No BYOK exemption: scheduled runs carry no owner credentials, so BYOK-covered providers can't run scheduled work today; that support is phase-2.

<sup>Written for commit 63923a22607f4c84b214d44840f201726c272667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

