### PR TITLE
test(quizzes): add advanced profile contract fixtures

### DIFF
--- a/Docs/API/Quizzes.md
+++ b/Docs/API/Quizzes.md
@@ -118,7 +118,8 @@ questions.
 Each output is a `multiple_choice` question with exactly five distinct options, a
 zero-based `correct_answer`, a source-backed explanation, and one canonical
 `best_of_five` tag in addition to optional topic tags. Generation rejects an
-invalid option count or answer instead of guessing. Take Quiz renders the five
+invalid option count or answer, or a missing, blank, or non-string explanation,
+instead of guessing. Take Quiz renders the five
 options as an ordinary single-answer question. The profile constrains shape but
 cannot guarantee that model-generated distractors are equally plausible.
 

--- a/Docs/API/Quizzes.md
+++ b/Docs/API/Quizzes.md
@@ -6,11 +6,181 @@ score, percentage, passing threshold, or pass/fail result.
 
 ## Generation Profiles
 
-`GET /api/v1/quizzes/generation-profiles` returns the available and planned
-generation profiles. Clients must inspect `status` before offering a profile.
-The `osce_scenario` profile is available. Use `default_num_stations` for its
-station count; `default_num_questions` remains `1` only for compatibility with
-older catalog parsers.
+`GET /api/v1/quizzes/generation-profiles` is the source of truth for profile
+availability and defaults. Clients must inspect `status` and `output_kind`
+before offering a profile. All profiles below are currently available.
+
+| Profile | Output | Default size | Main constraint |
+| --- | --- | --- | --- |
+| `standard_recall` | Questions | 10 questions | General recall and application |
+| `mixed_assessment` | Questions | 10 questions | Mixed recall, interpretation, and application |
+| `best_of_five` | Questions | 5 questions | Exactly five options and one best answer |
+| `emq` | Questions | 5 stems | At least two stems per shared option bank |
+| `assertion_reasoning` | Questions | 5 questions | Canonical A-E assertion/reason scale |
+| `osce_scenario` | OSCE stations | 1 station | Self-assessed practice with no numeric score |
+
+Question-profile requests accept `sources`, `generation_profile`,
+`num_questions`, `difficulty`, optional `focus_topics`, and either
+`question_types` or a `question_plan`. `question_plan` is supported only by
+`standard_recall` and `mixed_assessment`. OSCE requests use `num_stations` and
+reject question-count and question-shape controls.
+
+Every generated question is normalized to the same base shape. Optional fields
+are `null` or omitted when they do not apply:
+
+```json
+{
+  "output_kind": "questions",
+  "questions": [{
+    "question_type": "multiple_choice",
+    "question_text": "Question text",
+    "group_id": null,
+    "group_prompt": null,
+    "options": ["A", "B", "C", "D"],
+    "correct_answer": 1,
+    "explanation": "Concise source-backed rationale.",
+    "hint": null,
+    "hint_penalty_points": 0,
+    "source_citations": [{
+      "source_type": "note",
+      "source_id": "note-advanced-quiz",
+      "quote": "Bounded supporting excerpt."
+    }],
+    "tags": ["topic"],
+    "points": 1
+  }]
+}
+```
+
+Citations must reference a selected source. Generation fails when a question
+has no citation or names an unselected source. Explanations are concise
+rationales, not hidden chain-of-thought. The complete machine-validated example
+and malformed-output matrix is in
+`tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json`.
+
+<a id="profile-standard_recall"></a>
+### `standard_recall`
+
+Use this profile for a conventional quiz or a precise per-type plan:
+
+```json
+{
+  "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+  "generation_profile": "standard_recall",
+  "num_questions": 3,
+  "question_plan": [
+    {"question_type": "multiple_choice", "count": 2, "option_count": 4},
+    {"question_type": "true_false", "count": 1}
+  ],
+  "difficulty": "mixed"
+}
+```
+
+The response uses ordinary question records with no reserved subtype or group
+metadata. The Generate tab exposes the complete question-plan editor; Take Quiz
+uses the normal controls for each base question type. A plan is exact: missing,
+extra, or malformed generated questions reject the generation rather than
+silently changing the requested mix.
+
+<a id="profile-mixed_assessment"></a>
+### `mixed_assessment`
+
+```json
+{
+  "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+  "generation_profile": "mixed_assessment",
+  "num_questions": 2,
+  "question_types": ["true_false", "fill_blank"],
+  "difficulty": "mixed",
+  "focus_topics": ["mechanisms", "application"]
+}
+```
+
+The output uses the same ordinary question schema as `standard_recall`, while
+the prompt asks for a broader cognitive mix. The WebUI and extension expose the
+same per-type controls. Difficulty is a generation instruction, not a calibrated
+psychometric guarantee, and source quality limits the quality of application
+questions.
+
+<a id="profile-best_of_five"></a>
+### `best_of_five`
+
+```json
+{
+  "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+  "generation_profile": "best_of_five",
+  "num_questions": 5,
+  "question_types": ["multiple_choice"],
+  "difficulty": "mixed"
+}
+```
+
+Each output is a `multiple_choice` question with exactly five distinct options, a
+zero-based `correct_answer`, a source-backed explanation, and one canonical
+`best_of_five` tag in addition to optional topic tags. Generation rejects an
+invalid option count or answer instead of guessing. Take Quiz renders the five
+options as an ordinary single-answer question. The profile constrains shape but
+cannot guarantee that model-generated distractors are equally plausible.
+
+<a id="profile-emq"></a>
+### `emq`
+
+```json
+{
+  "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+  "generation_profile": "emq",
+  "num_questions": 4,
+  "question_types": ["multiple_choice"],
+  "difficulty": "mixed"
+}
+```
+
+Every stem repeats the same nonempty `group_id`, `group_prompt`, and option bank
+for its group. A group contains at least two stems, each with its own
+zero-based answer, explanation, and citations. The UI presents the shared bank
+once with its related stems. Because groups are atomic, asking for one stem can
+produce two and result limiting never splits a group.
+
+```json
+{
+  "question_type": "multiple_choice",
+  "question_text": "A patient has episodic reversible wheeze.",
+  "group_id": "respiratory-diagnosis",
+  "group_prompt": "Choose the single most likely diagnosis for each stem.",
+  "options": ["Asthma", "Pneumonia", "Pulmonary embolism"],
+  "correct_answer": 0,
+  "explanation": "Variable reversible airflow obstruction supports asthma.",
+  "source_citations": [{
+    "source_type": "note",
+    "source_id": "note-advanced-quiz",
+    "quote": "Asthma causes episodic reversible airflow obstruction."
+  }]
+}
+```
+
+<a id="profile-assertion_reasoning"></a>
+### `assertion_reasoning`
+
+```json
+{
+  "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+  "generation_profile": "assertion_reasoning",
+  "num_questions": 5,
+  "question_types": ["multiple_choice"],
+  "difficulty": "mixed"
+}
+```
+
+Generated input contains separate `assertion` and `reason` fields. Persisted
+questions combine them into explicitly labeled `question_text`, own the
+canonical five-option A-E scale, and carry exactly one
+`assertion_reasoning` tag. Answers may arrive as a zero-based index, A-E letter,
+or exact canonical label and are stored as a zero-based index. The UI shows the
+scale once and keeps option order fixed. Explanations must state the concise
+evidential relationship; hidden reasoning fields are discarded.
+
+<a id="profile-osce_scenario"></a>
+### `osce_scenario`
 
 Generate OSCE content with `POST /api/v1/quizzes/generate`:
 
@@ -25,7 +195,14 @@ Generate OSCE content with `POST /api/v1/quizzes/generate`:
 
 The response has `output_kind: "osce_stations"`, an OSCE quiz shell, an empty
 `questions` array, and authoring-detail entries in `osce_stations`. Generation
-validates and persists the quiz and every station atomically.
+validates and persists the quiz and every station atomically. The Generate tab
+switches to station-count controls, and practice uses the dedicated scenario,
+notes, reveal, and self-assessment interface. Marking guides remain hidden until
+self-assessment; results contain no score, percentage, or pass/fail outcome.
+`default_num_questions` remains `1` only for compatibility with older catalog
+parsers; use `default_num_stations` for the station count. Likewise,
+`default_question_types` remains `["fill_blank"]` for catalog compatibility and
+is ignored for OSCE station generation.
 
 ## Station Authoring
 

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/GenerateTab.media-selection.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/GenerateTab.media-selection.test.tsx
@@ -27,6 +27,7 @@ import {
   type QuestionUpdate,
   type QuizImportQuestion,
 } from "@/services/quizzes";
+import { advancedQuizFixtureMatrix } from "./advancedQuizFixtureMatrix";
 
 const navigationMocks = {
   navigate: vi.fn(),
@@ -169,6 +170,82 @@ describe("GenerateTab scalable media selection and generation flow", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("keeps available fallback profiles aligned with shared contract fixtures", () => {
+    const availableProfiles = QUIZ_GENERATION_PROFILES.filter(
+      (profile) => profile.status === "available",
+    );
+    const fallbackProfileIds = availableProfiles
+      .map((profile) => profile.id)
+      .sort();
+    const fixtureProfileIds = Object.keys(
+      advancedQuizFixtureMatrix.profiles,
+    ).sort();
+
+    expect(advancedQuizFixtureMatrix.schema_version).toBe(1);
+    expect(fixtureProfileIds).toEqual(fallbackProfileIds);
+    for (const profile of availableProfiles) {
+      const fixture = advancedQuizFixtureMatrix.profiles[profile.id];
+      expect(fixture.catalog).toEqual(profile);
+      expect(
+        fixture.request.generation_profile,
+      ).toBe(profile.id);
+      expect(fixture.output.output_kind).toBe(profile.output_kind);
+    }
+
+    const malformedCases = advancedQuizFixtureMatrix.malformed_output_cases;
+    expect(new Set(malformedCases.map((fixture) => fixture.profile))).toEqual(
+      new Set(fallbackProfileIds),
+    );
+    expect(malformedCases.map((fixture) => fixture.id)).toEqual(
+      expect.arrayContaining([
+        "question_count_mismatch",
+        "invalid_citation",
+        "best_of_five_wrong_option_count",
+        "best_of_five_too_many_options",
+        "best_of_five_invalid_answer",
+        "best_of_five_ambiguous_answer",
+        "best_of_five_duplicate_answer_label",
+        "best_of_five_non_multiple_choice",
+        "emq_incomplete_group",
+        "emq_inconsistent_option_bank",
+        "assertion_reasoning_missing_reason",
+        "assertion_reasoning_invalid_answer",
+        "assertion_reasoning_noncanonical_options",
+        "assertion_reasoning_unlabeled_question_text",
+        "reserved_tag_leakage",
+        "osce_missing_rubric",
+      ]),
+    );
+    for (const fixture of malformedCases) {
+      expect(fallbackProfileIds).toContain(fixture.profile);
+      expect([
+        "normalize_reject",
+        "normalize_expect",
+        "assertion_schema_reject",
+        "planned_reject",
+        "provenance_reject",
+        "osce_schema_reject",
+      ]).toContain(fixture.mode);
+      expect(
+        Object.values(fixture.output).some(
+          (value) => Array.isArray(value) && value.length > 0,
+        ),
+      ).toBe(true);
+      if (fixture.mode.endsWith("_reject")) {
+        expect(fixture.error).toEqual(expect.any(String));
+      }
+      if (fixture.mode === "normalize_expect") {
+        expect(Object.keys(fixture.expected ?? {})).not.toHaveLength(0);
+      }
+      if (fixture.mode === "planned_reject") {
+        expect(fixture.question_plan).not.toHaveLength(0);
+      }
+      if (fixture.mode === "provenance_reject") {
+        expect(fixture.selected_sources).not.toHaveLength(0);
+      }
+    }
   });
 
   it("loads media in pages and keeps selection stable while loading more", async () => {

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/TakeQuizTab.study-modes.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/TakeQuizTab.study-modes.test.tsx
@@ -14,6 +14,7 @@ import { useQuizTimer } from "../../hooks/useQuizTimer"
 import { listQuestions } from "@/services/quizzes"
 import { TAKE_QUIZ_LIST_PREFS_KEY } from "../../stateKeys"
 import { drawDeterministicQuestionPool } from "../../utils/optionShuffle"
+import { advancedQuizFixtureMatrix } from "./advancedQuizFixtureMatrix"
 
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>()
@@ -280,18 +281,16 @@ describe("TakeQuizTab study modes", () => {
       JSON.stringify({ modePreference: "practice" })
     )
 
+    const assertionReasoningQuestion = advancedQuizFixtureMatrix.profiles
+      .assertion_reasoning.output.questions?.[0]
+    expect(assertionReasoningQuestion).toBeDefined()
+
     vi.mocked(listQuestions).mockResolvedValue({
       items: [
         {
+          ...assertionReasoningQuestion,
           id: 21,
-          quiz_id: 7,
-          question_type: "multiple_choice",
-          question_text: "**Assertion:** Insulin lowers blood glucose.\n\n**Reason:** Insulin promotes cellular glucose uptake.",
-          options: ASSERTION_REASONING_OPTIONS,
-          correct_answer: 0,
-          explanation: "Both statements are true, and increased glucose uptake explains the effect.",
-          source_citations: [{ label: "Endocrinology source" }],
-          tags: ["assertion_reasoning"]
+          quiz_id: 7
         }
       ],
       count: 1
@@ -307,14 +306,40 @@ describe("TakeQuizTab study modes", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: ASSERTION_REASONING_OPTIONS[2] }))
     expect(await screen.findByText("Incorrect")).toBeInTheDocument()
-    expect(screen.getByText("Both statements are true, and increased glucose uptake explains the effect.")).toBeInTheDocument()
+    expect(screen.getByText("Increased cellular uptake is one mechanism by which insulin lowers blood glucose.")).toBeInTheDocument()
     expect(screen.getByText("Endocrinology source")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("radio", { name: ASSERTION_REASONING_OPTIONS[0] }))
     expect(await screen.findByText("Correct")).toBeInTheDocument()
-    expect(screen.getByText("Both statements are true, and increased glucose uptake explains the effect.")).toBeInTheDocument()
+    expect(screen.getByText("Increased cellular uptake is one mechanism by which insulin lowers blood glucose.")).toBeInTheDocument()
     expect(screen.getByText("Endocrinology source")).toBeInTheDocument()
     expect(screen.getAllByTestId("assertion-reasoning-scale")).toHaveLength(1)
+  }, 15000)
+
+  it("grades the shared Best-of-Five fixture as a five-option practice question", async () => {
+    window.sessionStorage.setItem(
+      TAKE_QUIZ_LIST_PREFS_KEY,
+      JSON.stringify({ modePreference: "practice" })
+    )
+    const bestOfFiveQuestion = advancedQuizFixtureMatrix.profiles
+      .best_of_five.output.questions?.[0]
+    if (!bestOfFiveQuestion) throw new Error("Best-of-Five fixture is missing")
+
+    vi.mocked(listQuestions).mockResolvedValue({
+      items: [{ ...bestOfFiveQuestion, id: 22, quiz_id: 7 }],
+      count: 1
+    } as any)
+
+    render(<MemoryRouter><TakeQuizTab onNavigateToGenerate={() => {}} onNavigateToCreate={() => {}} /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole("button", { name: /Start Practice/i }))
+
+    expect(await screen.findAllByRole("radio")).toHaveLength(5)
+    fireEvent.click(screen.getByRole("radio", { name: "High ferritin" }))
+    expect(await screen.findByText("Incorrect")).toBeInTheDocument()
+    expect(screen.getByText("Low ferritin reflects depleted iron stores and is the best answer.")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("radio", { name: "Low ferritin" }))
+    expect(await screen.findByText("Correct")).toBeInTheDocument()
   }, 15000)
 
   it("opens review mode as read-only with answers and explanations", async () => {
@@ -639,30 +664,24 @@ describe("TakeQuizTab study modes", () => {
   }, 15000)
 
   it("keeps an EMQ group atomic in a practice pool and grades each stem immediately", async () => {
-    const groupPrompt = "For each presentation, choose one condition from the shared bank."
-    const optionBank = ["Asthma", "Pneumonia", "Pulmonary embolism"]
-    const stems = [
-      "Episodic wheeze improves after a bronchodilator.",
-      "Fever, productive cough, and focal crackles are present.",
-      "Sudden pleuritic pain follows a long-haul flight."
-    ]
+    const emqQuestions = advancedQuizFixtureMatrix.profiles.emq.output.questions ?? []
+    expect(emqQuestions).toHaveLength(2)
+    const firstStem = emqQuestions[0]
+    if (!firstStem) throw new Error("EMQ fixture is missing")
+    const groupPrompt = firstStem.group_prompt as string
+    const optionBank = firstStem.options ?? []
+    const stems = emqQuestions.map((question) => question.question_text as string)
     window.sessionStorage.setItem(
       TAKE_QUIZ_LIST_PREFS_KEY,
       JSON.stringify({ modePreference: "practice", studyPoolSize: 1, studyPoolSeedOverride: 77 })
     )
     vi.mocked(listQuestions).mockResolvedValue({
-      items: stems.map((questionText, index) => ({
+      items: emqQuestions.map((question, index) => ({
+        ...question,
         id: 601 + index,
-        quiz_id: 7,
-        question_type: "multiple_choice",
-        question_text: questionText,
-        options: optionBank,
-        correct_answer: index,
-        explanation: `Explanation ${index + 1}`,
-        group_id: "respiratory-emq",
-        group_prompt: groupPrompt
+        quiz_id: 7
       })),
-      count: stems.length
+      count: emqQuestions.length
     } as any)
 
     render(<MemoryRouter><TakeQuizTab onNavigateToGenerate={() => {}} onNavigateToCreate={() => {}} /></MemoryRouter>)
@@ -670,7 +689,7 @@ describe("TakeQuizTab study modes", () => {
     fireEvent.click(screen.getByRole("button", { name: /Start Practice/i }))
 
     await waitFor(() => {
-      expect(screen.getAllByTestId(/quiz-question-/)).toHaveLength(3)
+      expect(screen.getAllByTestId(/quiz-question-/)).toHaveLength(2)
     })
     expect(screen.getAllByTestId("emq-group-bank")).toHaveLength(1)
     expect(screen.getAllByText(groupPrompt)).toHaveLength(1)

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/advancedQuizFixtureMatrix.ts
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/advancedQuizFixtureMatrix.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+type FixtureQuestion = Record<string, unknown> & {
+  question_type: string
+  question_text?: string
+  options?: string[]
+  correct_answer?: number | string
+}
+
+type FixtureCatalogProfile = {
+  id: string
+  label: string
+  description: string
+  status: "available"
+  output_kind: "questions" | "osce_stations"
+  default_num_stations: number | null
+  default_num_questions: number
+  default_difficulty: "easy" | "medium" | "hard" | "mixed"
+  default_question_types: string[]
+}
+
+type FixtureProfile = {
+  catalog: FixtureCatalogProfile
+  request: Record<string, unknown> & { generation_profile: string }
+  output: {
+    output_kind: "questions" | "osce_stations"
+    questions?: FixtureQuestion[]
+    osce_stations?: Array<Record<string, unknown>>
+  }
+}
+
+type MalformedOutputCase = {
+  id: string
+  profile: string
+  mode: string
+  output: Record<string, unknown>
+  error?: string
+  expected?: Record<string, unknown>
+  question_plan?: Array<Record<string, unknown>>
+  selected_sources?: Array<Record<string, unknown>>
+}
+
+type AdvancedQuizFixtureMatrix = {
+  schema_version: number
+  profiles: Record<string, FixtureProfile>
+  malformed_output_cases: MalformedOutputCase[]
+}
+
+const fixturePath = resolve(
+  __dirname,
+  "../../../../../../../../tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json",
+)
+
+export const advancedQuizFixtureMatrix = JSON.parse(
+  readFileSync(fixturePath, "utf8"),
+) as AdvancedQuizFixtureMatrix

--- a/apps/packages/ui/src/services/quizzes.ts
+++ b/apps/packages/ui/src/services/quizzes.ts
@@ -118,13 +118,13 @@ export const QUIZ_GENERATION_PROFILES: QuizGenerationProfileDefinition[] = [
   {
     id: "osce_scenario",
     label: "OSCE Scenario",
-    description: "Source-grounded clinical practice stations.",
+    description: "Scenario practice with checklist and rubric feedback.",
     status: "available",
     output_kind: "osce_stations",
     default_num_stations: 1,
     default_num_questions: 1,
     default_difficulty: "mixed",
-    default_question_types: []
+    default_question_types: ["fill_blank"]
   }
 ]
 export type AnswerValue = number | string | number[] | Record<string, string>

--- a/backlog/tasks/task-12102.3.6 - Add-advanced-quiz-docs-examples-and-generated-output-validation-fixtures.md
+++ b/backlog/tasks/task-12102.3.6 - Add-advanced-quiz-docs-examples-and-generated-output-validation-fixtures.md
@@ -1,16 +1,21 @@
 ---
 id: TASK-12102.3.6
 title: Add advanced quiz docs examples and generated-output validation fixtures
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-09-12 03:17
 labels:
 - quiz
 - phase-6
 - docs
 - tests
-priority: medium
-parent_task_id: TASK-12102.3
+dependencies: []
 references:
 - Docs/Product/Advanced_Quiz_Customization_PRD.md
+- https://github.com/rmusser01/tldw_server/pull/2946
+parent_task_id: TASK-12102.3
+priority: medium
 ---
 
 ## Description
@@ -21,31 +26,33 @@ Phase 6 for Advanced Quiz Customization: document generation profiles and limita
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User/developer examples document standard_recall, mixed_assessment, best_of_five, emq, and assertion_reasoning; OSCE is labeled planned until available.
-- [ ] #2 Examples include request parameters, canonical output shape, subtype/group metadata, citation/rationale expectations, UI behavior, and limitations.
-- [ ] #3 Malformed-output fixtures cover wrong BOF option counts/answers, incomplete or inconsistent EMQ groups, malformed assertion/reasoning labels/options/answers, reserved-tag leakage, invalid citations, and question-count mismatches.
-- [ ] #4 Fixture validation runs through the focused pytest quiz-generator/schema suites and the focused Vitest GenerateTab/TakeQuizTab suites, with commands recorded in the task.
-- [ ] #5 Docs and fixtures remain aligned with the server generation-profile catalog and fail when an available profile lacks an example or validation case.
+- [x] #1 User/developer examples document standard_recall, mixed_assessment, best_of_five, emq, assertion_reasoning, and the available osce_scenario profile.
+- [x] #2 Examples include request parameters, canonical output shape, subtype/group metadata, citation/rationale expectations, UI behavior, and limitations.
+- [x] #3 Malformed-output fixtures cover too few or too many BOF options, invalid BOF answers, incomplete or inconsistent EMQ groups, malformed assertion/reasoning fields and answers, reserved-tag leakage, invalid citations, question-count mismatches, and malformed OSCE stations.
+- [x] #4 Fixture validation runs through focused pytest quiz-generator/schema suites and focused Vitest GenerateTab/TakeQuizTab suites, with commands recorded in the task.
+- [x] #5 Docs and fixtures remain aligned with the server generation-profile catalog and fail when an available profile lacks an example or validation case.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Approved bounded design implemented with one shared JSON fixture matrix consumed by pytest and focused Vitest suites. Review found and fixed fail-open Best-of-Five behaviors: invalid answers defaulted to option zero, extra options were truncated to five, non-MCQ output was accepted, ambiguous answer strings could select the wrong option, and duplicate option labels were accepted with numeric answers. All now reject malformed generated output.
 
+The shared catalog contract now covers labels, descriptions, output kinds, default counts, difficulty, and question types across server and frontend fallback definitions. Valid OSCE fixtures run through the production normalizer with source-resolvable citations. Frontend fixture tests consume valid BOF, EMQ, and Assertion/Reasoning records plus malformed case modes, payloads, errors, and mode-specific metadata.
+
+Final verification: ../../.venv/bin/python -m pytest tldw_Server_API/tests/Quizzes -q -> 517 passed, 4 skipped; focused backend contract/generator/OSCE suites -> 249 passed; focused Vitest quiz service, GenerateTab, and TakeQuizTab suites -> 45 passed. Ruff, compileall, JSON parsing, git diff --check, and production-scope Bandit passed. Repository-wide TypeScript reports 349 pre-existing errors outside touched files and none in touched files. The 4 pytest skips are existing environment-dependent OSCE privacy cases.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Documented all six available quiz generation profiles, including request and output contracts, metadata, citations, UI behavior, compatibility fields, and limitations. Added a shared generated-output fixture matrix consumed by backend and frontend tests, with exact catalog completeness guards and malformed BOF, EMQ, assertion/reasoning, provenance, count, tag, and OSCE cases. Tightened Best-of-Five normalization so wrong option counts, non-MCQ output, duplicate option labels, and invalid or ambiguous answers fail closed.
 <!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12102.3.6 - Add-advanced-quiz-docs-examples-and-generated-output-validation-fixtures.md
+++ b/backlog/tasks/task-12102.3.6 - Add-advanced-quiz-docs-examples-and-generated-output-validation-fixtures.md
@@ -4,7 +4,7 @@ title: Add advanced quiz docs examples and generated-output validation fixtures
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-09-12 03:17
+updated_date: 2026-09-12 03:58
 labels:
 - quiz
 - phase-6
@@ -38,14 +38,16 @@ Phase 6 for Advanced Quiz Customization: document generation profiles and limita
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Approved bounded design implemented with one shared JSON fixture matrix consumed by pytest and focused Vitest suites. Review found and fixed fail-open Best-of-Five behaviors: invalid answers defaulted to option zero, extra options were truncated to five, non-MCQ output was accepted, ambiguous answer strings could select the wrong option, and duplicate option labels were accepted with numeric answers. All now reject malformed generated output.
 
-The shared catalog contract now covers labels, descriptions, output kinds, default counts, difficulty, and question types across server and frontend fallback definitions. Valid OSCE fixtures run through the production normalizer with source-resolvable citations. Frontend fixture tests consume valid BOF, EMQ, and Assertion/Reasoning records plus malformed case modes, payloads, errors, and mode-specific metadata.
+The shared catalog contract covers labels, descriptions, output kinds, default counts, difficulty, and question types across server and frontend fallback definitions. Valid OSCE fixtures run through the production normalizer with source-resolvable citations. Frontend fixture tests consume valid BOF, EMQ, and Assertion/Reasoning records plus malformed case modes, payloads, errors, and mode-specific metadata.
 
-Final verification: ../../.venv/bin/python -m pytest tldw_Server_API/tests/Quizzes -q -> 517 passed, 4 skipped; focused backend contract/generator/OSCE suites -> 249 passed; focused Vitest quiz service, GenerateTab, and TakeQuizTab suites -> 45 passed. Ruff, compileall, JSON parsing, git diff --check, and production-scope Bandit passed. Repository-wide TypeScript reports 349 pre-existing errors outside touched files and none in touched files. The 4 pytest skips are existing environment-dependent OSCE privacy cases.
+Qodo review remediation for PR #2946: added module/function docstrings; introduced central QuizMalformedOutputError as a ValueError subclass to preserve endpoint error handling; rejected missing, blank, or non-string Best-of-Five explanations; moved shared question fixture tests through public generate_quiz_from_sources with external I/O stubbed and rejection-before-persistence assertions. Eight new explanation regressions failed before the fix and passed afterward. Independent review found no remaining actionable issues.
+
+Final verification after Qodo fixes: source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Quizzes -q --tb=short -> 525 passed, 4 skipped; focused Vitest quiz service, GenerateTab, and TakeQuizTab suites -> 45 passed. Ruff, compileall, git diff --check, and Bandit on quiz_generator.py and core/exceptions.py passed with no security findings. Earlier repository-wide TypeScript output contained 349 lines of pre-existing diagnostics outside touched files and none in touched files. Four pytest skips remain existing environment-dependent OSCE privacy cases. Unrelated pytest temporary-directory cleanup warnings do not affect test results. Latest fetched dev remains aeae95fe3b; branch is already rebased onto it.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Documented all six available quiz generation profiles, including request and output contracts, metadata, citations, UI behavior, compatibility fields, and limitations. Added a shared generated-output fixture matrix consumed by backend and frontend tests, with exact catalog completeness guards and malformed BOF, EMQ, assertion/reasoning, provenance, count, tag, and OSCE cases. Tightened Best-of-Five normalization so wrong option counts, non-MCQ output, duplicate option labels, and invalid or ambiguous answers fail closed.
+Documented all six available quiz generation profiles and added a shared backend/frontend contract matrix. Hardened Best-of-Five generation against malformed types, option counts, duplicates, invalid or ambiguous answers, and missing or non-text explanations using a centralized ValueError-compatible exception. Shared question fixtures exercise the public generation flow and verify malformed output is rejected before persistence; OSCE examples validate source-resolvable citations. Addressed all four initial Qodo review findings. Final verification: 525 backend tests passed, 4 existing skips; 45 frontend tests passed; Ruff, compileall, diff checks, and production-scope Bandit passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -194,6 +194,10 @@ class ClaimsAnalyticsExportError(RuntimeError):
         self.http_status = http_status
 
 
+class QuizMalformedOutputError(ValueError):
+    """Generated quiz content violates a required output contract."""
+
+
 class OsceGenerationError(ValueError):
     """Base class for bounded OSCE generation failures."""
 

--- a/tldw_Server_API/app/services/quiz_generator.py
+++ b/tldw_Server_API/app/services/quiz_generator.py
@@ -21,7 +21,7 @@ from tldw_Server_API.app.core.Claims_Extraction.artifact_verification import (
 )
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
-from tldw_Server_API.app.core.exceptions import BadRequestError, OsceVerificationError
+from tldw_Server_API.app.core.exceptions import BadRequestError, OsceVerificationError, QuizMalformedOutputError
 from tldw_Server_API.app.core.LLM_Calls.adapter_registry import get_registry
 from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
 from tldw_Server_API.app.core.RAG.rag_service.types import Document
@@ -458,15 +458,15 @@ def _normalize_emq_mc_answer(raw: Any, options: list[str]) -> int:
 def _normalize_best_of_five_answer(raw: Any, options: list[str]) -> int:
     """Return a strict zero-based answer index for a Best-of-Five question."""
     if isinstance(raw, bool):
-        raise ValueError(
+        raise QuizMalformedOutputError(
             "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
         )
     if isinstance(raw, int):
         if 0 <= raw < len(options):
             return raw
-        raise ValueError("Best-of-Five correct_answer index is out of range")
+        raise QuizMalformedOutputError("Best-of-Five correct_answer index is out of range")
     if not isinstance(raw, str):
-        raise ValueError(
+        raise QuizMalformedOutputError(
             "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
         )
 
@@ -485,8 +485,8 @@ def _normalize_best_of_five_answer(raw: Any, options: list[str]) -> int:
     if len(candidates) == 1:
         return candidates.pop()
     if candidates:
-        raise ValueError("Best-of-Five correct_answer is ambiguous")
-    raise ValueError(
+        raise QuizMalformedOutputError("Best-of-Five correct_answer is ambiguous")
+    raise QuizMalformedOutputError(
         "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
     )
 
@@ -1038,7 +1038,7 @@ def _normalize_questions(
         if is_assertion_reasoning and q_type != "multiple_choice":
             raise ValueError("Assertion / Reasoning questions must use the multiple_choice question type")
         if is_best_of_five and q_type != "multiple_choice":
-            raise ValueError("Best-of-Five questions must use the multiple_choice question type")
+            raise QuizMalformedOutputError("Best-of-Five questions must use the multiple_choice question type")
         if q_type not in DEFAULT_QUESTION_TYPES and not is_emq:
             continue
         if is_assertion_reasoning:
@@ -1086,17 +1086,19 @@ def _normalize_questions(
                     max_options=None if profile_id == "best_of_five" else mc_option_count,
                 )
                 if profile_id == "best_of_five" and len(options) != 5:
-                    raise ValueError("Best-of-Five questions must include exactly 5 options")
+                    raise QuizMalformedOutputError("Best-of-Five questions must include exactly 5 options")
                 if profile_id == "best_of_five" and len(
                     {option.casefold() for option in options}
                 ) != len(options):
-                    raise ValueError("Best-of-Five questions must not include duplicate option labels")
+                    raise QuizMalformedOutputError("Best-of-Five questions must not include duplicate option labels")
                 if is_emq:
                     correct_answer = raw.get("correct_answer")
                 elif profile_id == "best_of_five":
                     correct_answer = _normalize_best_of_five_answer(
                         raw.get("correct_answer"), options
                     )
+                    if not isinstance(raw.get("explanation"), str) or not explanation:
+                        raise QuizMalformedOutputError("Best-of-Five questions must include a nonempty explanation")
                 else:
                     correct_answer = _normalize_mc_answer(
                         raw.get("correct_answer"), options

--- a/tldw_Server_API/app/services/quiz_generator.py
+++ b/tldw_Server_API/app/services/quiz_generator.py
@@ -455,6 +455,42 @@ def _normalize_emq_mc_answer(raw: Any, options: list[str]) -> int:
     raise ValueError("EMQ correct_answer must be a valid option index, letter, or exact label")
 
 
+def _normalize_best_of_five_answer(raw: Any, options: list[str]) -> int:
+    """Return a strict zero-based answer index for a Best-of-Five question."""
+    if isinstance(raw, bool):
+        raise ValueError(
+            "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
+        )
+    if isinstance(raw, int):
+        if 0 <= raw < len(options):
+            return raw
+        raise ValueError("Best-of-Five correct_answer index is out of range")
+    if not isinstance(raw, str):
+        raise ValueError(
+            "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
+        )
+
+    text = raw.strip()
+    candidates: set[int] = set()
+    if text.isdigit():
+        index = int(text)
+        if 0 <= index < len(options):
+            candidates.add(index)
+    if len(text) == 1 and "A" <= text.upper() <= "E":
+        candidates.add(ord(text.upper()) - ord("A"))
+    candidates.update(
+        index for index, option in enumerate(options) if option.casefold() == text.casefold()
+    )
+
+    if len(candidates) == 1:
+        return candidates.pop()
+    if candidates:
+        raise ValueError("Best-of-Five correct_answer is ambiguous")
+    raise ValueError(
+        "Best-of-Five correct_answer must be an integer, A-E letter, or exact option label"
+    )
+
+
 def _normalize_assertion_reasoning_answer(raw: Any) -> int:
     if isinstance(raw, bool):
         raise ValueError("Assertion / Reasoning correct_answer must be an integer, A-E letter, or exact label")
@@ -990,6 +1026,7 @@ def _normalize_questions(
     profile_id = _normalize_generation_profile(generation_profile)
     is_emq = profile_id == "emq"
     is_assertion_reasoning = profile_id == ASSERTION_REASONING_TAG
+    is_best_of_five = profile_id == "best_of_five"
     mc_option_count = None if is_emq else 5 if profile_id == "best_of_five" else 4
     normalized: list[dict[str, Any]] = []
     for raw in raw_questions:
@@ -1000,6 +1037,8 @@ def _normalize_questions(
         q_type = _normalize_question_type(raw.get("question_type"))
         if is_assertion_reasoning and q_type != "multiple_choice":
             raise ValueError("Assertion / Reasoning questions must use the multiple_choice question type")
+        if is_best_of_five and q_type != "multiple_choice":
+            raise ValueError("Best-of-Five questions must use the multiple_choice question type")
         if q_type not in DEFAULT_QUESTION_TYPES and not is_emq:
             continue
         if is_assertion_reasoning:
@@ -1042,14 +1081,26 @@ def _normalize_questions(
                 options = list(ASSERTION_REASONING_OPTIONS)
                 correct_answer = _normalize_assertion_reasoning_answer(raw.get("correct_answer"))
             else:
-                options = _coerce_options(raw.get("options"), max_options=mc_option_count)
+                options = _coerce_options(
+                    raw.get("options"),
+                    max_options=None if profile_id == "best_of_five" else mc_option_count,
+                )
                 if profile_id == "best_of_five" and len(options) != 5:
                     raise ValueError("Best-of-Five questions must include exactly 5 options")
-                correct_answer = (
-                    raw.get("correct_answer")
-                    if is_emq
-                    else _normalize_mc_answer(raw.get("correct_answer"), options)
-                )
+                if profile_id == "best_of_five" and len(
+                    {option.casefold() for option in options}
+                ) != len(options):
+                    raise ValueError("Best-of-Five questions must not include duplicate option labels")
+                if is_emq:
+                    correct_answer = raw.get("correct_answer")
+                elif profile_id == "best_of_five":
+                    correct_answer = _normalize_best_of_five_answer(
+                        raw.get("correct_answer"), options
+                    )
+                else:
+                    correct_answer = _normalize_mc_answer(
+                        raw.get("correct_answer"), options
+                    )
         elif q_type == "true_false":
             correct_answer = _normalize_tf_answer(raw.get("correct_answer"))
         elif q_type == "fill_blank":

--- a/tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json
+++ b/tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json
@@ -234,6 +234,13 @@
   },
   "malformed_output_cases": [
     {
+      "id": "best_of_five_missing_explanation",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "nonempty explanation",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["A", "B", "C", "D", "E"], "correct_answer": 0, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
       "id": "question_count_mismatch",
       "profile": "standard_recall",
       "mode": "planned_reject",
@@ -336,8 +343,8 @@
     {
       "id": "assertion_reasoning_unlabeled_question_text",
       "profile": "assertion_reasoning",
-      "mode": "assertion_schema_reject",
-      "error": "labeled assertion and reason",
+      "mode": "normalize_reject",
+      "error": "assertion must contain",
       "output": {"questions": [{"question_type": "multiple_choice", "question_text": "The assertion and reason labels are missing.", "group_id": null, "group_prompt": null, "options": ["Both the assertion and reason are true, and the reason correctly explains the assertion.", "Both the assertion and reason are true, but the reason does not explain the assertion.", "The assertion is true, but the reason is false.", "The assertion is false, but the reason is true.", "Both the assertion and reason are false."], "correct_answer": 0, "explanation": "A concise rationale.", "tags": ["assertion_reasoning"]}]}
     },
     {

--- a/tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json
+++ b/tldw_Server_API/tests/Quizzes/fixtures/advanced_quiz_generation_profiles.json
@@ -1,0 +1,358 @@
+{
+  "schema_version": 1,
+  "profiles": {
+    "standard_recall": {
+      "catalog": {
+        "id": "standard_recall",
+        "label": "Standard Recall",
+        "description": "Balanced source-grounded recall and application questions.",
+        "status": "available",
+        "output_kind": "questions",
+        "default_num_stations": null,
+        "default_num_questions": 10,
+        "default_difficulty": "mixed",
+        "default_question_types": ["multiple_choice", "true_false", "fill_blank"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "standard_recall",
+        "num_questions": 1,
+        "question_types": ["multiple_choice"],
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "questions",
+        "questions": [
+          {
+            "question_type": "multiple_choice",
+            "question_text": "Which process converts light energy into stored chemical energy?",
+            "options": ["Respiration", "Photosynthesis", "Fermentation", "Transpiration"],
+            "correct_answer": 1,
+            "explanation": "Photosynthesis stores captured light energy in chemical bonds.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "quote": "Photosynthesis converts light energy into chemical energy."}],
+            "tags": ["biology"],
+            "points": 1
+          }
+        ]
+      }
+    },
+    "mixed_assessment": {
+      "catalog": {
+        "id": "mixed_assessment",
+        "label": "Mixed Assessment",
+        "description": "A broader mix of recall, interpretation, and applied understanding.",
+        "status": "available",
+        "output_kind": "questions",
+        "default_num_stations": null,
+        "default_num_questions": 10,
+        "default_difficulty": "mixed",
+        "default_question_types": ["multiple_choice", "true_false", "fill_blank"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "mixed_assessment",
+        "num_questions": 1,
+        "question_types": ["true_false"],
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "questions",
+        "questions": [
+          {
+            "question_type": "true_false",
+            "question_text": "A catalyst lowers activation energy without being consumed.",
+            "correct_answer": "true",
+            "explanation": "Catalysts provide a lower-energy reaction pathway and are regenerated.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "quote": "Catalysts lower activation energy and are not consumed."}],
+            "tags": ["chemistry"],
+            "points": 1
+          }
+        ]
+      }
+    },
+    "best_of_five": {
+      "catalog": {
+        "id": "best_of_five",
+        "label": "Best of Five",
+        "description": "Single-best-answer questions with five plausible options.",
+        "status": "available",
+        "output_kind": "questions",
+        "default_num_stations": null,
+        "default_num_questions": 5,
+        "default_difficulty": "mixed",
+        "default_question_types": ["multiple_choice"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "best_of_five",
+        "num_questions": 1,
+        "question_types": ["multiple_choice"],
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "questions",
+        "questions": [
+          {
+            "question_type": "multiple_choice",
+            "question_text": "Which finding is most consistent with iron deficiency anaemia?",
+            "options": ["High ferritin", "Low ferritin", "High vitamin B12", "Raised haptoglobin", "Low transferrin"],
+            "correct_answer": 1,
+            "explanation": "Low ferritin reflects depleted iron stores and is the best answer.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "quote": "Iron deficiency is associated with reduced serum ferritin."}],
+            "tags": ["haematology", "best_of_five"],
+            "points": 1
+          }
+        ]
+      }
+    },
+    "emq": {
+      "catalog": {
+        "id": "emq",
+        "label": "EMQ",
+        "description": "Extended matching questions with shared option banks.",
+        "status": "available",
+        "output_kind": "questions",
+        "default_num_stations": null,
+        "default_num_questions": 5,
+        "default_difficulty": "mixed",
+        "default_question_types": ["multiple_choice"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "emq",
+        "num_questions": 2,
+        "question_types": ["multiple_choice"],
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "questions",
+        "questions": [
+          {
+            "question_type": "multiple_choice",
+            "question_text": "A patient has episodic wheeze that improves with a bronchodilator.",
+            "group_id": "respiratory-diagnosis",
+            "group_prompt": "For each presentation, choose the single most likely diagnosis.",
+            "options": ["Asthma", "Pneumonia", "Pulmonary embolism"],
+            "correct_answer": 0,
+            "explanation": "Variable reversible airflow obstruction is characteristic of asthma.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "quote": "Asthma causes episodic reversible airflow obstruction."}],
+            "points": 1
+          },
+          {
+            "question_type": "multiple_choice",
+            "question_text": "A patient has fever, productive cough, and focal consolidation.",
+            "group_id": "respiratory-diagnosis",
+            "group_prompt": "For each presentation, choose the single most likely diagnosis.",
+            "options": ["Asthma", "Pneumonia", "Pulmonary embolism"],
+            "correct_answer": 1,
+            "explanation": "Fever and focal consolidation are most consistent with pneumonia.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "quote": "Pneumonia commonly presents with fever, cough, and focal consolidation."}],
+            "points": 1
+          }
+        ]
+      }
+    },
+    "assertion_reasoning": {
+      "catalog": {
+        "id": "assertion_reasoning",
+        "label": "Assertion / Reasoning",
+        "description": "Assertion and reason pairs with concise evidence-backed rationales.",
+        "status": "available",
+        "output_kind": "questions",
+        "default_num_stations": null,
+        "default_num_questions": 5,
+        "default_difficulty": "mixed",
+        "default_question_types": ["multiple_choice"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "assertion_reasoning",
+        "num_questions": 1,
+        "question_types": ["multiple_choice"],
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "questions",
+        "questions": [
+          {
+            "question_type": "multiple_choice",
+            "question_text": "**Assertion:** Insulin lowers blood glucose.\n\n**Reason:** Insulin promotes cellular glucose uptake.",
+            "assertion": "Insulin lowers blood glucose.",
+            "reason": "Insulin promotes cellular glucose uptake.",
+            "options": [
+              "Both the assertion and reason are true, and the reason correctly explains the assertion.",
+              "Both the assertion and reason are true, but the reason does not explain the assertion.",
+              "The assertion is true, but the reason is false.",
+              "The assertion is false, but the reason is true.",
+              "Both the assertion and reason are false."
+            ],
+            "correct_answer": 0,
+            "explanation": "Increased cellular uptake is one mechanism by which insulin lowers blood glucose.",
+            "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "label": "Endocrinology source", "quote": "Insulin promotes glucose uptake and lowers blood glucose."}],
+            "tags": ["endocrinology", "assertion_reasoning"],
+            "points": 1
+          }
+        ]
+      }
+    },
+    "osce_scenario": {
+      "catalog": {
+        "id": "osce_scenario",
+        "label": "OSCE Scenario",
+        "description": "Scenario practice with checklist and rubric feedback.",
+        "status": "available",
+        "output_kind": "osce_stations",
+        "default_num_stations": 1,
+        "default_num_questions": 1,
+        "default_difficulty": "mixed",
+        "default_question_types": ["fill_blank"]
+      },
+      "request": {
+        "sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+        "generation_profile": "osce_scenario",
+        "num_stations": 1,
+        "difficulty": "mixed"
+      },
+      "output": {
+        "output_kind": "osce_stations",
+        "questions": [],
+        "osce_stations": [
+          {
+            "schema_version": "osce.station.v1",
+            "title": "Explain safe anticoagulant use",
+            "candidate_instructions": "You are speaking with a fictional patient who recently started warfarin.",
+            "candidate_task": "Explain the key safety advice and respond to the patient's concerns.",
+            "patient_context": {"text": "A fictional adult has recently started warfarin.", "citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "chunk_id": "chunk-anticoagulation", "quote": "Warfarin is used for anticoagulation"}]},
+            "recommended_duration_seconds": 480,
+            "checklist_items": [{"label": "Explains the purpose of treatment", "rationale": "Understanding the indication supports safe use.", "citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "chunk_id": "chunk-anticoagulation", "quote": "Warfarin is used for anticoagulation"}]}],
+            "rubric_domains": [{"label": "Communication", "levels": [{"label": "Needs development", "description": "The explanation is incomplete or unclear."}, {"label": "Effective", "description": "The explanation is clear and checks understanding."}]}],
+            "expected_key_points": [{"text": "Discuss monitoring and important warning signs.", "citations": [{"source_type": "note", "source_id": "note-advanced-quiz", "chunk_id": "chunk-anticoagulation", "quote": "requires regular monitoring, and patients should seek help for important bleeding warning signs"}]}]
+          }
+        ]
+      }
+    }
+  },
+  "malformed_output_cases": [
+    {
+      "id": "question_count_mismatch",
+      "profile": "standard_recall",
+      "mode": "planned_reject",
+      "error": "count mismatch",
+      "question_plan": [{"question_type": "multiple_choice", "count": 2, "option_count": 4}],
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Only one question was returned.", "options": ["A", "B", "C", "D"], "correct_answer": 0, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "invalid_citation",
+      "profile": "mixed_assessment",
+      "mode": "provenance_reject",
+      "error": "do not map to selected sources",
+      "selected_sources": [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+      "output": {"questions": [{"question_type": "true_false", "question_text": "A source-backed statement.", "correct_answer": "true", "source_citations": [{"source_type": "note", "source_id": "different-note"}]}]}
+    },
+    {
+      "id": "best_of_five_wrong_option_count",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "exactly 5 options",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["A", "B", "C", "D"], "correct_answer": 0, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_too_many_options",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "exactly 5 options",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["A", "B", "C", "D", "E", "F"], "correct_answer": 0, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_invalid_answer",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "Best-of-Five correct_answer",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["A", "B", "C", "D", "E"], "correct_answer": 9, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_ambiguous_answer",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "ambiguous",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["B", "A", "C", "D", "E"], "correct_answer": "B", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_duplicate_answer_label",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "duplicate option labels",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["Same", "Same", "C", "D", "E"], "correct_answer": "Same", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_duplicate_options_numeric_answer",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "duplicate option labels",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "Choose the best answer.", "options": ["Same", "same", "C", "D", "E"], "correct_answer": 0, "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "best_of_five_non_multiple_choice",
+      "profile": "best_of_five",
+      "mode": "normalize_reject",
+      "error": "multiple_choice",
+      "output": {"questions": [{"question_type": "true_false", "question_text": "This profile must reject non-MCQ output.", "correct_answer": "true", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "emq_incomplete_group",
+      "profile": "emq",
+      "mode": "normalize_reject",
+      "error": "at least two stems",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "A single stem.", "group_id": "group-1", "group_prompt": "Choose one option.", "options": ["A", "B"], "correct_answer": 0, "explanation": "A is supported.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "emq_inconsistent_option_bank",
+      "profile": "emq",
+      "mode": "normalize_reject",
+      "error": "same option bank",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "First stem.", "group_id": "group-1", "group_prompt": "Choose one option.", "options": ["A", "B"], "correct_answer": 0, "explanation": "A is supported.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}, {"question_type": "multiple_choice", "question_text": "Second stem.", "group_id": "group-1", "group_prompt": "Choose one option.", "options": ["A", "C"], "correct_answer": 1, "explanation": "C is supported.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "assertion_reasoning_missing_reason",
+      "profile": "assertion_reasoning",
+      "mode": "normalize_reject",
+      "error": "reason must contain",
+      "output": {"questions": [{"question_type": "multiple_choice", "assertion": "The assertion is present.", "correct_answer": "A", "explanation": "A concise rationale.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "assertion_reasoning_invalid_answer",
+      "profile": "assertion_reasoning",
+      "mode": "normalize_reject",
+      "error": "correct_answer",
+      "output": {"questions": [{"question_type": "multiple_choice", "assertion": "The assertion is present.", "reason": "The reason is present.", "correct_answer": "F", "explanation": "A concise rationale.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "assertion_reasoning_noncanonical_options",
+      "profile": "assertion_reasoning",
+      "mode": "normalize_expect",
+      "expected": {"options": ["Both the assertion and reason are true, and the reason correctly explains the assertion.", "Both the assertion and reason are true, but the reason does not explain the assertion.", "The assertion is true, but the reason is false.", "The assertion is false, but the reason is true.", "Both the assertion and reason are false."]},
+      "output": {"questions": [{"question_type": "multiple_choice", "assertion": "The assertion is present.", "reason": "The reason is present.", "options": ["Yes", "No"], "correct_answer": "A", "explanation": "A concise rationale.", "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "assertion_reasoning_unlabeled_question_text",
+      "profile": "assertion_reasoning",
+      "mode": "assertion_schema_reject",
+      "error": "labeled assertion and reason",
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "The assertion and reason labels are missing.", "group_id": null, "group_prompt": null, "options": ["Both the assertion and reason are true, and the reason correctly explains the assertion.", "Both the assertion and reason are true, but the reason does not explain the assertion.", "The assertion is true, but the reason is false.", "The assertion is false, but the reason is true.", "Both the assertion and reason are false."], "correct_answer": 0, "explanation": "A concise rationale.", "tags": ["assertion_reasoning"]}]}
+    },
+    {
+      "id": "reserved_tag_leakage",
+      "profile": "standard_recall",
+      "mode": "normalize_expect",
+      "expected": {"tags": ["biology"]},
+      "output": {"questions": [{"question_type": "multiple_choice", "question_text": "A standard question.", "options": ["A", "B", "C", "D"], "correct_answer": 0, "tags": ["biology", "best of five", "assertion/reasoning"], "source_citations": [{"source_type": "note", "source_id": "note-advanced-quiz"}]}]}
+    },
+    {
+      "id": "osce_missing_rubric",
+      "profile": "osce_scenario",
+      "mode": "osce_schema_reject",
+      "error": "rubric",
+      "output": {"osce_stations": [{"schema_version": "osce.station.v1", "title": "Incomplete station", "candidate_instructions": "Read the task.", "candidate_task": "Explain the topic.", "patient_context": {"text": "A fictional context.", "citations": []}, "recommended_duration_seconds": 300, "checklist_items": [{"label": "Covers the topic", "citations": []}], "rubric_domains": [], "expected_key_points": [{"text": "Key point", "citations": []}]}]}
+    }
+  ]
+}

--- a/tldw_Server_API/tests/Quizzes/test_advanced_quiz_generation_fixtures.py
+++ b/tldw_Server_API/tests/Quizzes/test_advanced_quiz_generation_fixtures.py
@@ -1,19 +1,21 @@
+"""Check shared advanced quiz examples against public generation contracts."""
+
 import json
 from copy import deepcopy
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.osce import OsceStationCreateContent
 from tldw_Server_API.app.api.v1.schemas.quizzes import QuizGenerateRequest
+from tldw_Server_API.app.core.exceptions import QuizMalformedOutputError
+from tldw_Server_API.app.services import quiz_generator
 from tldw_Server_API.app.services.osce_generator import normalize_generated_station
 from tldw_Server_API.app.services.quiz_generator import (
     QuizProvenanceValidationError,
-    _normalize_planned_questions,
-    _normalize_questions,
-    _validate_assertion_reasoning_questions,
-    _validate_strict_provenance,
+    generate_quiz_from_sources,
     get_quiz_generation_profiles,
 )
 
@@ -24,14 +26,17 @@ DOC_PATH = Path(__file__).parents[3] / "Docs" / "API" / "Quizzes.md"
 
 
 def _load_fixture_matrix() -> dict:
+    """Return the JSON contract shared with frontend tests."""
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
 def _available_profile_ids() -> set[str]:
+    """Return the available server profile identifiers."""
     return {profile["id"] for profile in get_quiz_generation_profiles() if profile["status"] == "available"}
 
 
 def _available_question_profile_ids() -> list[str]:
+    """Return available question-producing profiles in stable test order."""
     return sorted(
         profile["id"]
         for profile in get_quiz_generation_profiles()
@@ -39,7 +44,36 @@ def _available_question_profile_ids() -> list[str]:
     )
 
 
+@pytest.fixture
+def generation_dependencies(monkeypatch: pytest.MonkeyPatch) -> tuple[Mock, AsyncMock]:
+    """Stub external I/O while retaining the public generation and persistence flow."""
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setattr(
+        quiz_generator,
+        "resolve_quiz_sources",
+        Mock(
+            return_value=[
+                {
+                    "source_type": "note",
+                    "source_id": "note-advanced-quiz",
+                    "text": "Source evidence for the shared advanced quiz examples.",
+                }
+            ]
+        ),
+    )
+    llm = AsyncMock()
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", llm)
+    questions: list[dict] = []
+    db = Mock()
+    db.create_quiz.return_value = 1
+    db.get_quiz.return_value = {"id": 1, "name": "Shared contract quiz"}
+    db.create_question.side_effect = lambda **question: questions.append(question)
+    db.list_questions.return_value = {"items": questions}
+    return db, llm
+
+
 def test_fixture_matrix_and_documentation_cover_every_available_profile() -> None:
+    """Require docs and shared catalog metadata for every available profile."""
     matrix = _load_fixture_matrix()
     catalog = {profile["id"]: profile for profile in get_quiz_generation_profiles() if profile["status"] == "available"}
     profile_ids = set(matrix["profiles"])
@@ -64,6 +98,7 @@ def test_fixture_matrix_and_documentation_cover_every_available_profile() -> Non
 
 @pytest.mark.parametrize("profile_id", sorted(_available_profile_ids()))
 def test_profile_example_requests_pass_api_schema_validation(profile_id: str) -> None:
+    """Validate each documented request with the public API request schema."""
     request = _load_fixture_matrix()["profiles"][profile_id]["request"]
 
     parsed = QuizGenerateRequest.model_validate(request)
@@ -72,24 +107,30 @@ def test_profile_example_requests_pass_api_schema_validation(profile_id: str) ->
 
 
 @pytest.mark.parametrize("profile_id", _available_question_profile_ids())
-def test_question_profile_examples_pass_runtime_validation(profile_id: str) -> None:
+@pytest.mark.asyncio
+async def test_question_profile_examples_pass_runtime_validation(
+    profile_id: str,
+    generation_dependencies: tuple[Mock, AsyncMock],
+) -> None:
+    """Generate and persist each valid fixture through the public service."""
     example = _load_fixture_matrix()["profiles"][profile_id]
-    questions = _normalize_questions(
-        deepcopy(example["output"]["questions"]),
-        default_source_type="note",
-        default_source_id="note-advanced-quiz",
-        generation_profile=profile_id,
+    db, llm = generation_dependencies
+    llm.return_value = deepcopy(example["output"])
+    result = await generate_quiz_from_sources(
+        db=db,
+        media_db=Mock(),
+        **example["request"],
     )
 
-    assert questions
-    assert len(questions) == example["request"]["num_questions"]
-    _validate_strict_provenance(
-        questions,
-        [{"source_type": "note", "source_id": "note-advanced-quiz"}],
-    )
+    assert result["output_kind"] == "questions"
+    assert len(result["questions"]) == example["request"]["num_questions"]
+    assert db.create_question.call_count == example["request"]["num_questions"]
+    if profile_id == "best_of_five":
+        assert result["questions"][0]["explanation"] == example["output"]["questions"][0]["explanation"]
 
 
 def test_osce_profile_example_passes_runtime_schema_validation() -> None:
+    """Resolve the valid OSCE fixture against its cited source evidence."""
     example = _load_fixture_matrix()["profiles"]["osce_scenario"]
     evidence = [
         {
@@ -110,6 +151,7 @@ def test_osce_profile_example_passes_runtime_schema_validation() -> None:
 
 
 def test_malformed_output_fixture_ids_cover_required_failure_classes() -> None:
+    """Keep required malformed-output failure classes represented in the matrix."""
     case_ids = {case["id"] for case in _load_fixture_matrix()["malformed_output_cases"]}
 
     assert {
@@ -120,6 +162,7 @@ def test_malformed_output_fixture_ids_cover_required_failure_classes() -> None:
         "best_of_five_too_many_options",
         "best_of_five_wrong_option_count",
         "best_of_five_invalid_answer",
+        "best_of_five_missing_explanation",
         "emq_incomplete_group",
         "emq_inconsistent_option_bank",
         "assertion_reasoning_missing_reason",
@@ -138,61 +181,58 @@ def test_malformed_output_fixture_ids_cover_required_failure_classes() -> None:
     if FIXTURE_PATH.exists()
     else [],
 )
-def test_malformed_output_fixtures_follow_runtime_contracts(case: dict) -> None:
+@pytest.mark.asyncio
+async def test_malformed_output_fixtures_follow_runtime_contracts(
+    case: dict,
+    generation_dependencies: tuple[Mock, AsyncMock],
+) -> None:
+    """Assert public errors before persistence or documented output normalization."""
     profile_id = case["profile"]
     mode = case["mode"]
     payload = deepcopy(case["output"])
-
-    if mode == "normalize_reject":
-        with pytest.raises(ValueError, match=case["error"]):
-            _normalize_questions(
-                payload["questions"],
-                default_source_type="note",
-                default_source_id="note-advanced-quiz",
-                generation_profile=profile_id,
-            )
-        return
-
-    if mode == "normalize_expect":
-        questions = _normalize_questions(
-            payload["questions"],
-            default_source_type="note",
-            default_source_id="note-advanced-quiz",
-            generation_profile=profile_id,
-        )
-        for field, expected_value in case["expected"].items():
-            assert questions[0].get(field) == expected_value
-        return
-
-    if mode == "assertion_schema_reject":
-        with pytest.raises(ValueError, match=case["error"]):
-            _validate_assertion_reasoning_questions(payload["questions"])
-        return
-
-    if mode == "planned_reject":
-        with pytest.raises(ValueError, match=case["error"]):
-            _normalize_planned_questions(
-                payload["questions"],
-                case["question_plan"],
-                default_source_type="note",
-                default_source_id="note-advanced-quiz",
-            )
-        return
-
-    if mode == "provenance_reject":
-        questions = _normalize_questions(
-            payload["questions"],
-            default_source_type="note",
-            default_source_id="note-advanced-quiz",
-            generation_profile=profile_id,
-        )
-        with pytest.raises(QuizProvenanceValidationError, match=case["error"]):
-            _validate_strict_provenance(questions, case["selected_sources"])
-        return
-
     if mode == "osce_schema_reject":
         with pytest.raises(ValidationError):
             OsceStationCreateContent.model_validate(payload["osce_stations"][0])
         return
 
-    pytest.fail(f"Unknown malformed fixture mode: {mode}")
+    db, llm = generation_dependencies
+    llm.return_value = payload
+    request = {
+        "generation_profile": profile_id,
+        "sources": case.get("selected_sources", [{"source_type": "note", "source_id": "note-advanced-quiz"}]),
+        "num_questions": max(1, len(payload["questions"])),
+    }
+    if mode == "planned_reject":
+        request["question_plan"] = case["question_plan"]
+        request["num_questions"] = sum(item["count"] for item in case["question_plan"])
+    if mode == "normalize_expect":
+        result = await generate_quiz_from_sources(db=db, media_db=Mock(), **request)
+        for field, expected_value in case["expected"].items():
+            assert result["questions"][0].get(field) == expected_value
+        return
+    if mode not in {"normalize_reject", "planned_reject", "provenance_reject"}:
+        pytest.fail(f"Unknown malformed fixture mode: {mode}")
+    error_type = QuizProvenanceValidationError if mode == "provenance_reject" else ValueError
+    if profile_id == "best_of_five":
+        error_type = QuizMalformedOutputError
+    with pytest.raises(error_type, match=case["error"]):
+        await generate_quiz_from_sources(db=db, media_db=Mock(), **request)
+    db.create_quiz.assert_not_called()
+    db.create_question.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explanation", [None, "", "   ", 42, True, [], {}])
+async def test_best_of_five_rejects_invalid_explanations_before_persistence(
+    explanation: object,
+    generation_dependencies: tuple[Mock, AsyncMock],
+) -> None:
+    """Reject absent, blank, or non-text rationales without creating a quiz."""
+    example = _load_fixture_matrix()["profiles"]["best_of_five"]
+    db, llm = generation_dependencies
+    payload = deepcopy(example["output"])
+    payload["questions"][0]["explanation"] = explanation
+    llm.return_value = payload
+    with pytest.raises(QuizMalformedOutputError, match="nonempty explanation"):
+        await generate_quiz_from_sources(db=db, media_db=Mock(), **example["request"])
+    db.create_quiz.assert_not_called()

--- a/tldw_Server_API/tests/Quizzes/test_advanced_quiz_generation_fixtures.py
+++ b/tldw_Server_API/tests/Quizzes/test_advanced_quiz_generation_fixtures.py
@@ -1,0 +1,198 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.osce import OsceStationCreateContent
+from tldw_Server_API.app.api.v1.schemas.quizzes import QuizGenerateRequest
+from tldw_Server_API.app.services.osce_generator import normalize_generated_station
+from tldw_Server_API.app.services.quiz_generator import (
+    QuizProvenanceValidationError,
+    _normalize_planned_questions,
+    _normalize_questions,
+    _validate_assertion_reasoning_questions,
+    _validate_strict_provenance,
+    get_quiz_generation_profiles,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "advanced_quiz_generation_profiles.json"
+DOC_PATH = Path(__file__).parents[3] / "Docs" / "API" / "Quizzes.md"
+
+
+def _load_fixture_matrix() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _available_profile_ids() -> set[str]:
+    return {profile["id"] for profile in get_quiz_generation_profiles() if profile["status"] == "available"}
+
+
+def _available_question_profile_ids() -> list[str]:
+    return sorted(
+        profile["id"]
+        for profile in get_quiz_generation_profiles()
+        if profile["status"] == "available" and profile["output_kind"] == "questions"
+    )
+
+
+def test_fixture_matrix_and_documentation_cover_every_available_profile() -> None:
+    matrix = _load_fixture_matrix()
+    catalog = {profile["id"]: profile for profile in get_quiz_generation_profiles() if profile["status"] == "available"}
+    profile_ids = set(matrix["profiles"])
+    validation_profile_ids = {case["profile"] for case in matrix["malformed_output_cases"]}
+    available_profile_ids = _available_profile_ids()
+    docs = DOC_PATH.read_text(encoding="utf-8")
+
+    assert profile_ids == available_profile_ids
+    assert validation_profile_ids == available_profile_ids
+    for profile_id in available_profile_ids:
+        profile = catalog[profile_id]
+        example = matrix["profiles"][profile_id]
+        table_row = next(line for line in docs.splitlines() if line.startswith(f"| `{profile_id}` |"))
+        assert f'<a id="profile-{profile_id}"></a>' in docs
+        assert example["catalog"] == profile
+        assert example["request"]["generation_profile"] == profile_id
+        assert example["request"]["difficulty"] == profile["default_difficulty"]
+        assert example["output"]["output_kind"] == profile["output_kind"]
+        default_size = profile["default_num_stations"] or profile["default_num_questions"]
+        assert f"| {default_size} " in table_row
+
+
+@pytest.mark.parametrize("profile_id", sorted(_available_profile_ids()))
+def test_profile_example_requests_pass_api_schema_validation(profile_id: str) -> None:
+    request = _load_fixture_matrix()["profiles"][profile_id]["request"]
+
+    parsed = QuizGenerateRequest.model_validate(request)
+
+    assert parsed.generation_profile.value == profile_id
+
+
+@pytest.mark.parametrize("profile_id", _available_question_profile_ids())
+def test_question_profile_examples_pass_runtime_validation(profile_id: str) -> None:
+    example = _load_fixture_matrix()["profiles"][profile_id]
+    questions = _normalize_questions(
+        deepcopy(example["output"]["questions"]),
+        default_source_type="note",
+        default_source_id="note-advanced-quiz",
+        generation_profile=profile_id,
+    )
+
+    assert questions
+    assert len(questions) == example["request"]["num_questions"]
+    _validate_strict_provenance(
+        questions,
+        [{"source_type": "note", "source_id": "note-advanced-quiz"}],
+    )
+
+
+def test_osce_profile_example_passes_runtime_schema_validation() -> None:
+    example = _load_fixture_matrix()["profiles"]["osce_scenario"]
+    evidence = [
+        {
+            "source_type": "note",
+            "source_id": "note-advanced-quiz",
+            "chunk_id": "chunk-anticoagulation",
+            "label": "Anticoagulation guide",
+            "text": (
+                "Warfarin is used for anticoagulation, requires regular monitoring, "
+                "and patients should seek help for important bleeding warning signs."
+            ),
+        }
+    ]
+
+    station = normalize_generated_station(example["output"]["osce_stations"][0], evidence)
+
+    assert station.schema_version == "osce.station.v1"
+
+
+def test_malformed_output_fixture_ids_cover_required_failure_classes() -> None:
+    case_ids = {case["id"] for case in _load_fixture_matrix()["malformed_output_cases"]}
+
+    assert {
+        "best_of_five_ambiguous_answer",
+        "best_of_five_duplicate_answer_label",
+        "best_of_five_duplicate_options_numeric_answer",
+        "best_of_five_non_multiple_choice",
+        "best_of_five_too_many_options",
+        "best_of_five_wrong_option_count",
+        "best_of_five_invalid_answer",
+        "emq_incomplete_group",
+        "emq_inconsistent_option_bank",
+        "assertion_reasoning_missing_reason",
+        "assertion_reasoning_noncanonical_options",
+        "assertion_reasoning_unlabeled_question_text",
+        "assertion_reasoning_invalid_answer",
+        "reserved_tag_leakage",
+        "invalid_citation",
+        "question_count_mismatch",
+    } <= case_ids
+
+
+@pytest.mark.parametrize(
+    "case",
+    [pytest.param(case, id=case["id"]) for case in _load_fixture_matrix()["malformed_output_cases"]]
+    if FIXTURE_PATH.exists()
+    else [],
+)
+def test_malformed_output_fixtures_follow_runtime_contracts(case: dict) -> None:
+    profile_id = case["profile"]
+    mode = case["mode"]
+    payload = deepcopy(case["output"])
+
+    if mode == "normalize_reject":
+        with pytest.raises(ValueError, match=case["error"]):
+            _normalize_questions(
+                payload["questions"],
+                default_source_type="note",
+                default_source_id="note-advanced-quiz",
+                generation_profile=profile_id,
+            )
+        return
+
+    if mode == "normalize_expect":
+        questions = _normalize_questions(
+            payload["questions"],
+            default_source_type="note",
+            default_source_id="note-advanced-quiz",
+            generation_profile=profile_id,
+        )
+        for field, expected_value in case["expected"].items():
+            assert questions[0].get(field) == expected_value
+        return
+
+    if mode == "assertion_schema_reject":
+        with pytest.raises(ValueError, match=case["error"]):
+            _validate_assertion_reasoning_questions(payload["questions"])
+        return
+
+    if mode == "planned_reject":
+        with pytest.raises(ValueError, match=case["error"]):
+            _normalize_planned_questions(
+                payload["questions"],
+                case["question_plan"],
+                default_source_type="note",
+                default_source_id="note-advanced-quiz",
+            )
+        return
+
+    if mode == "provenance_reject":
+        questions = _normalize_questions(
+            payload["questions"],
+            default_source_type="note",
+            default_source_id="note-advanced-quiz",
+            generation_profile=profile_id,
+        )
+        with pytest.raises(QuizProvenanceValidationError, match=case["error"]):
+            _validate_strict_provenance(questions, case["selected_sources"])
+        return
+
+    if mode == "osce_schema_reject":
+        with pytest.raises(ValidationError):
+            OsceStationCreateContent.model_validate(payload["osce_stations"][0])
+        return
+
+    pytest.fail(f"Unknown malformed fixture mode: {mode}")

--- a/tldw_Server_API/tests/Quizzes/test_quiz_generator_test_mode.py
+++ b/tldw_Server_API/tests/Quizzes/test_quiz_generator_test_mode.py
@@ -446,12 +446,14 @@ def test_normalize_questions_preserves_legacy_mcq_answer_fallback() -> None:
 def test_normalize_questions_clears_group_metadata_for_non_emq_profiles(
     generation_profile: str,
 ) -> None:
+    """Ungroup valid non-EMQ questions without altering their profile behavior."""
     options = ["A", "B", "C", "D", "E"] if generation_profile == "best_of_five" else ["A", "B"]
     questions = _normalize_questions(
         [
             {
                 "question_type": "multiple_choice",
                 "question_text": "Ordinary multiple choice question",
+                "explanation": "The first option is supported by the source.",
                 "group_id": "llm-supplied-group",
                 "group_prompt": "LLM-supplied group prompt",
                 "options": options,
@@ -517,11 +519,13 @@ def test_normalize_questions_marks_best_of_five_with_existing_tags() -> None:
 
 
 def test_normalize_questions_rejects_any_invalid_best_of_five_option_count() -> None:
+    """Reject a malformed option count even after a valid question in the batch."""
     valid_question = {
         "question_type": "multiple_choice",
         "question_text": "Which answer is best supported?",
         "options": ["A", "B", "C", "D", "E"],
         "correct_answer": 0,
+        "explanation": "The first option is supported by the source.",
     }
     invalid_question = {
         **valid_question,


### PR DESCRIPTION
## Summary

- What changed: Documented all six available advanced quiz generation profiles and added one shared JSON contract matrix consumed by backend and frontend tests. Hardened Best-of-Five normalization, validated OSCE examples through the production normalizer, and aligned the WebUI fallback profile catalog with the server.
- Why: Keep API documentation, generated-output validation, WebUI/browser-extension behavior, and fallback metadata synchronized while rejecting malformed advanced quiz output instead of guessing.

## Change summary (requester-authored)

This PR documents all six quiz generation profiles and adds shared test fixtures to keep the backend, WebUI, and browser extension aligned. It strengthens Best-of-Five validation to reject malformed questions, duplicate options, and invalid or ambiguous answers, validates OSCE examples through the actual generation pipeline, and synchronizes frontend profile defaults with the server. Verification includes 517 passing backend tests and 45 passing frontend tests.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)
- `python -m pytest tldw_Server_API/tests/Quizzes -q`: 525 passed, 4 skipped after Qodo remediation
- Eight new explanation regression cases reproduced the bug before the fix
- Focused Vitest quiz service, GenerateTab, and TakeQuizTab suites: 45 passed
- Ruff, compileall, JSON parsing, `git diff --check`, and production-scope Bandit passed
- Earlier repository-wide TypeScript output: 349 lines of pre-existing diagnostics outside touched files; none in touched files

## Review Remediation

- Added test module/function docstrings.
- Centralized malformed Best-of-Five output errors in a ValueError-compatible domain exception, preserving endpoint handling.
- Reject missing, blank, and non-string Best-of-Five explanations before persistence.
- Exercise shared question fixtures through the public generation service instead of directly calling private normalizers; assert rejected output creates no quiz or questions.
- Independent review found no remaining actionable issues.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (not applicable to this contract/docs change)
- [x] No listed AntD deprecations introduced in touched code
- [x] No `Maximum update depth exceeded` warnings introduced
- [x] No unresolved `{{...}}` placeholders introduced
- [x] WebUI/extension parity validated through the shared UI package fixtures
- [x] Flashcards-specific checks are not applicable

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Watchlists UI behavior was not changed

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Watchlists polling, notifications, and scale behavior were not changed

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to restore the prior docs, fixtures, fallback catalog metadata, and quiz normalization behavior.

Backlog: TASK-12102.3.6
