### PR TITLE
feat(quizzes): add generation observability metrics

### DIFF
--- a/Docs/API/Quizzes.md
+++ b/Docs/API/Quizzes.md
@@ -4,6 +4,53 @@ The Quiz API supports ordinary scored question quizzes and OSCE scenario
 practice. OSCE practice is self-marked study guidance. It does not calculate a
 score, percentage, passing threshold, or pass/fail result.
 
+## Generation Metrics
+
+The shared generation service records the following metric families in the
+existing metrics registry, available through the configured `/metrics`
+Prometheus scrape and `/api/v1/metrics` JSON endpoints:
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `quiz_generation_requests_total` | Counter | `profile`, `source_type` |
+| `quiz_generation_outcomes_total` | Counter | `profile`, `source_type`, `outcome` |
+| `quiz_generation_duration_seconds` | Histogram | `profile`, `source_type`, `outcome` |
+
+One invocation counts once, regardless of the number of questions or stations.
+All six profiles and the legacy media-only delegate share this boundary.
+Requests are counted before source resolution; attempts rejected during initial
+normalization are counted when rejected. HTTP/auth/schema rejections that never
+enter the service are covered by HTTP metrics, not these generation counters.
+
+- `profile`: one of the six profile IDs below, or `unknown` when profile
+  normalization fails. Accepted aliases use the canonical profile ID.
+- `source_type`: `media`, `note`, `flashcard_deck`, `flashcard_card`,
+  `quiz_attempt`, or `quiz_attempt_question`; `mixed` for multiple recognized
+  types; `unknown` for unsupported types or incomplete source normalization.
+  Multiple sources of the same type do not become `mixed`.
+- `outcome`: `success`, `validation_error`, `provider_error`, `runtime_error`,
+  or `cancelled`. Invalid, missing, or empty sources, rejected output, provenance,
+  and source-grounding verdicts count as validation errors. Provider/verifier
+  invocation failures (including OSCE's wrapped verifier failures) are separate
+  from database and persistence runtime failures.
+
+Latency measures monotonic elapsed seconds from service entry through response
+construction, including source resolution, generation, verification, and
+persistence. Failed and cancelled attempts are included. Histogram boundaries
+are 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, and 600 seconds, plus `+Inf`.
+
+For example, validation failures per profile over five minutes:
+
+```promql
+sum by (profile) (rate(quiz_generation_outcomes_total{outcome="validation_error"}[5m]))
+```
+
+Metrics are best-effort: telemetry outages cannot change a quiz response or
+exception, but can leave gaps in counters or latency samples. They contain no
+source content, IDs, user/workspace identifiers, model/provider names, or error
+messages. Existing metrics/export configuration applies; no new external
+telemetry destination is introduced.
+
 ## Generation Profiles
 
 `GET /api/v1/quizzes/generation-profiles` is the source of truth for profile

--- a/Docs/Design/Quiz_Generation_Observability.md
+++ b/Docs/Design/Quiz_Generation_Observability.md
@@ -1,0 +1,55 @@
+# Quiz Generation Observability
+
+Task: TASK-12102.3.7. Approved scope: backend-only, cross-profile generation
+counters and latency using the existing metrics registry. No new dashboard,
+frontend behavior, persistence schema, or telemetry destination.
+
+## Boundary
+
+`generate_quiz_from_sources` owns one observation per invocation. This covers
+all six profiles, the WebUI and extension's shared API, and the legacy
+`generate_quiz_from_media` delegate without double counting.
+
+A request-local observation starts a monotonic clock before normalization.
+Once profile and source types are normalized, it records the request before
+source resolution. An early normalization rejection is counted on exit, with
+unknown dimensions where normalization did not complete. Success is recorded
+only after persistence and response construction finish. Failures and
+cancellation also produce terminal outcomes and latency observations.
+
+## Classification And Privacy
+
+Internal phase markers distinguish validation from provider and persistence
+failures without changing or wrapping exceptions. OSCE's existing typed
+generation errors distinguish provider failures from invalid/unverified output;
+OSCE persistence failures remain runtime failures even though the existing
+service wraps them in `OsceVerificationError`. Within OSCE generation, a chained
+verification error identifies a verifier execution failure, while an unchained
+verification rejection remains a validation error. Source resolution uses its
+existing `ValueError` rejection contract for invalid, missing, or empty sources;
+database/operational exceptions remain runtime failures.
+
+Metric dimensions are allowlisted profile, source type, and outcome. Repeated
+sources of one type use that type; multiple recognized types use `mixed`;
+unsupported or unavailable types use `unknown`. Identifiers, content, prompts,
+model names, provider names, and exception messages are never metric labels.
+
+## Failure Isolation
+
+The observation never suppresses the generation exception or changes its
+identity. Registry lookup, registration, counter writes, histogram writes,
+clock reads, and fallback logging are best-effort. Each metric write is isolated
+so a failed counter does not prevent latency recording. A constant debug message
+reports telemetry failures without exposing the underlying exception.
+
+The three metric families are standard registry definitions, including explicit
+latency buckets, so registry resets preserve their contracts. Operator-facing
+names and examples are documented in [Quizzes API](../API/Quizzes.md#generation-metrics).
+
+## Verification
+
+Tests exercise the public generation service with real SQLite persistence and a
+real isolated metrics registry. Coverage includes every profile, mixed sources,
+early rejection, malformed output, provider and verification failures,
+persistence errors, cancellation, concurrent requests, legacy delegation,
+monotonic timing, registry reset/export, and unavailable observability components.

--- a/backlog/tasks/task-12102.3.7 - Add-advanced-quiz-generation-observability-metrics.md
+++ b/backlog/tasks/task-12102.3.7 - Add-advanced-quiz-generation-observability-metrics.md
@@ -4,7 +4,7 @@ title: Add advanced quiz generation observability metrics
 status: Done
 assignee: []
 created_date: '2026-07-10 05:39'
-updated_date: '2026-09-12 07:06'
+updated_date: '2026-09-12 07:21'
 labels:
   - quiz
   - observability
@@ -12,6 +12,7 @@ labels:
 dependencies: []
 references:
   - Docs/Product/Advanced_Quiz_Customization_PRD.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2948'
 documentation:
   - Docs/Design/Quiz_Generation_Observability.md
 parent_task_id: TASK-12102.3
@@ -42,6 +43,8 @@ Stage 1 complete: approved bounded design, isolated latest-dev worktree, and 52 
 
 <!-- SECTION:NOTES:BEGIN -->
 User approved backend-only bounded instrumentation on codex/advanced-quiz-generation-metrics from origin/dev f032ade9; unrelated main-checkout TTS work remains untouched. Tests first reproduced missing metric behavior. Independent review found wrapped OSCE verifier outages and invalid source selections misclassified; seven actual-path regression cases reproduced six failures, then all passed after fixes preserving exception behavior. Follow-up review found no remaining actionable issues. Final verification: 640 passed, 4 skipped, 4 warnings in 331.26s across tests/Quizzes and tests/Metrics; 100% statement coverage of quiz_generation_metrics.py. All four skips are existing PostgreSQL-backed OSCE tests because PostgreSQL was unreachable. Existing pytest temporary-directory cleanup warnings also remain; no tests disabled. Ruff, compileall, git diff --check, and touched-production Bandit passed; Bandit reported zero findings. Test log: /tmp/task_12102_3_7_final.log; security report: /tmp/bandit_12102_3_7.json. Backlog MCP became unresponsive during final review, so the supported CLI fallback was used.
+
+User selected push and PR creation. Implementation commit fdc8008f50 is pushed on codex/advanced-quiz-generation-metrics. PR #2948 targets dev: https://github.com/rmusser01/tldw_server/pull/2948. Worktree retained for review. Human-written Change summary is still required before merge; no merge has been requested or performed for this PR.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12102.3.7 - Add-advanced-quiz-generation-observability-metrics.md
+++ b/backlog/tasks/task-12102.3.7 - Add-advanced-quiz-generation-observability-metrics.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-12102.3.7
 title: Add advanced quiz generation observability metrics
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-10 05:39'
+updated_date: '2026-09-12 07:06'
 labels:
   - quiz
   - observability
@@ -11,6 +12,8 @@ labels:
 dependencies: []
 references:
   - Docs/Product/Advanced_Quiz_Customization_PRD.md
+documentation:
+  - Docs/Design/Quiz_Generation_Observability.md
 parent_task_id: TASK-12102.3
 priority: medium
 ---
@@ -23,18 +26,36 @@ Implement the cross-profile observability requirement from the Advanced Quiz Cus
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Quiz generation request/outcome counters and latency histograms are registered with bounded profile, source-type, and outcome labels.
-- [ ] #2 Validation failures are distinguishable from runtime/provider failures without logging source content or other high-cardinality values.
-- [ ] #3 Metrics instrumentation is fail-open and cannot change quiz generation success or error behavior when metrics are unavailable.
-- [ ] #4 Focused tests cover success, validation failure, runtime failure, mixed-source labeling, latency observation, and metrics-registry failure.
+- [x] #1 Quiz generation request/outcome counters and latency histograms are registered with bounded profile, source-type, and outcome labels.
+- [x] #2 Validation failures are distinguishable from runtime/provider failures without logging source content or other high-cardinality values.
+- [x] #3 Metrics instrumentation is fail-open and cannot change quiz generation success or error behavior when metrics are unavailable.
+- [x] #4 Focused tests cover success, validation failure, runtime failure, mixed-source labeling, latency observation, and metrics-registry failure.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1 complete: approved bounded design, isolated latest-dev worktree, and 52 passing baseline tests. Stage 2 complete: test-first standard registry counters/histogram and request-local fail-open observation across all six profiles. Stage 3 complete: API/design documentation, 53 focused metrics cases, full Quiz/Metrics regression suite, security checks, and independent review with both findings fixed and re-reviewed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+User approved backend-only bounded instrumentation on codex/advanced-quiz-generation-metrics from origin/dev f032ade9; unrelated main-checkout TTS work remains untouched. Tests first reproduced missing metric behavior. Independent review found wrapped OSCE verifier outages and invalid source selections misclassified; seven actual-path regression cases reproduced six failures, then all passed after fixes preserving exception behavior. Follow-up review found no remaining actionable issues. Final verification: 640 passed, 4 skipped, 4 warnings in 331.26s across tests/Quizzes and tests/Metrics; 100% statement coverage of quiz_generation_metrics.py. All four skips are existing PostgreSQL-backed OSCE tests because PostgreSQL was unreachable. Existing pytest temporary-directory cleanup warnings also remain; no tests disabled. Ruff, compileall, git diff --check, and touched-production Bandit passed; Bandit reported zero findings. Test log: /tmp/task_12102_3_7_final.log; security report: /tmp/bandit_12102_3_7.json. Backlog MCP became unresponsive during final review, so the supported CLI fallback was used.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added registered quiz generation request/outcome counters and end-to-end latency histogram shared by all six profiles and both clients. Allowlisted profile/source-type/outcome labels exclude content and identifiers; mixed sources count once. Phase-aware outcomes distinguish rejected generation and sources from provider/verifier/persistence failures and cancellation, while metrics outages preserve existing results and exceptions. Added operator documentation, design rationale, and 53 public-service regression cases. Implementation is complete and independently reviewed; branch is ready for the user to choose PR creation or local integration. No frontend or persistence-schema changes, new telemetry destinations, or unresolved implementation blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/Metrics/metrics_manager.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_manager.py
@@ -5,7 +5,6 @@ This module provides a unified interface for all metric operations,
 supporting both OpenTelemetry and fallback implementations.
 """
 
-import hashlib
 import hmac
 import os
 import re
@@ -21,8 +20,8 @@ from typing import Any, Callable, Optional
 
 from loguru import logger
 
-from .telemetry import OTEL_AVAILABLE, get_telemetry_manager
 from .stt_metrics import iter_stt_metric_definitions
+from .telemetry import OTEL_AVAILABLE, get_telemetry_manager
 
 if OTEL_AVAILABLE:
     from opentelemetry.metrics import CallbackOptions, Observation
@@ -1424,6 +1423,34 @@ class MetricsRegistry:
                 unit="s",
                 labels=["provider", "model"],
                 buckets=[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1]
+            )
+        )
+
+        # Quiz generation: bounded profile/source labels shared by every client.
+        self.register_metric(
+            MetricDefinition(
+                name="quiz_generation_requests_total",
+                type=MetricType.COUNTER,
+                description="Quiz generation attempts entering the shared generation service",
+                labels=["profile", "source_type"],
+            )
+        )
+        self.register_metric(
+            MetricDefinition(
+                name="quiz_generation_outcomes_total",
+                type=MetricType.COUNTER,
+                description="Completed quiz generation attempts by outcome",
+                labels=["profile", "source_type", "outcome"],
+            )
+        )
+        self.register_metric(
+            MetricDefinition(
+                name="quiz_generation_duration_seconds",
+                type=MetricType.HISTOGRAM,
+                description="End-to-end quiz generation duration including failed and cancelled attempts",
+                unit="s",
+                labels=["profile", "source_type", "outcome"],
+                buckets=[0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
             )
         )
 

--- a/tldw_Server_API/app/services/quiz_generation_metrics.py
+++ b/tldw_Server_API/app/services/quiz_generation_metrics.py
@@ -1,0 +1,119 @@
+"""Best-effort, bounded observability for one complete quiz generation attempt."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Literal
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.schemas.quizzes import QuizGenerationProfile, QuizSourceType
+from tldw_Server_API.app.core.exceptions import BadRequestError, OsceProviderError, OsceVerificationError
+from tldw_Server_API.app.core.Metrics import metrics_manager
+
+_PROFILES = frozenset(profile.value for profile in QuizGenerationProfile)
+_SOURCE_TYPES = frozenset(source.value for source in QuizSourceType)
+
+
+@contextlib.contextmanager
+def _optional_metrics() -> Iterator[None]:
+    """Isolate telemetry failures, including logging outages, from generation."""
+    try:
+        yield
+    except Exception:  # noqa: BLE001 - Observability must never replace a generation result or error.
+        with contextlib.suppress(Exception):
+            logger.debug("Quiz generation metrics unavailable")
+
+
+def _record(name: str, labels: dict[str, str], value: float = 1, *, histogram: bool = False) -> None:
+    """Isolate each registry write so one failed metric does not prevent another."""
+    with _optional_metrics():
+        registry = metrics_manager.get_metrics_registry()
+        if histogram:
+            registry.observe(name, value, labels=labels)
+        else:
+            registry.increment(name, value, labels=labels)
+
+
+@dataclass
+class QuizGenerationMetrics:
+    """Record one request/outcome pair, preserving returns, errors, and cancellation.
+
+    The caller supplies already-normalized profile and source types. Phase markers
+    distinguish provider/persistence exceptions from genuine validation failures;
+    neither phases nor exception messages become metric labels.
+    """
+
+    profile: str = "unknown"
+    phase: Literal["validation", "provider", "runtime", "osce"] = "validation"
+    _source_type: str = field(default="unknown", init=False)
+    _started_at: float | None = field(default=None, init=False)
+    _request_recorded: bool = field(default=False, init=False)
+
+    def __enter__(self) -> QuizGenerationMetrics:
+        """Start elapsed timing before source validation or resolution."""
+        with _optional_metrics():
+            self._started_at = time.perf_counter()
+        return self
+
+    def start(self, sources: Sequence[dict[str, str]]) -> None:
+        """Count normalized requests before I/O, collapsing duplicate and mixed types."""
+        with _optional_metrics():
+            source_types = {source["source_type"] for source in sources}
+            if source_types and source_types <= _SOURCE_TYPES:
+                self._source_type = next(iter(source_types)) if len(source_types) == 1 else "mixed"
+            self._record_request()
+
+    def _labels(self) -> dict[str, str]:
+        """Return only allowlisted dimensions; never retain source IDs or content."""
+        return {
+            "profile": self.profile if self.profile in _PROFILES else "unknown",
+            "source_type": self._source_type,
+        }
+
+    def _record_request(self) -> None:
+        """Attempt request recording once, including requests rejected before start."""
+        if not self._request_recorded:
+            self._request_recorded = True
+            _record("quiz_generation_requests_total", self._labels())
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        error: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
+        """Observe the terminal outcome without suppressing or replacing the error."""
+        with _optional_metrics():
+            if error is None:
+                outcome = "success"
+            elif isinstance(error, asyncio.CancelledError):
+                outcome = "cancelled"
+            elif self.phase == "provider" or (
+                self.phase == "osce"
+                and (
+                    isinstance(error, OsceProviderError)
+                    or (isinstance(error, OsceVerificationError) and error.__cause__ is not None)
+                )
+            ):
+                outcome = "provider_error"
+            elif self.phase != "runtime" and isinstance(error, (ValueError, BadRequestError)):
+                outcome = "validation_error"
+            else:
+                outcome = "runtime_error"
+            self._record_request()
+            labels = {**self._labels(), "outcome": outcome}
+            _record("quiz_generation_outcomes_total", labels)
+            if self._started_at is not None:
+                _record(
+                    "quiz_generation_duration_seconds",
+                    labels,
+                    max(0.0, time.perf_counter() - self._started_at),
+                    histogram=True,
+                )
+        return False

--- a/tldw_Server_API/app/services/quiz_generator.py
+++ b/tldw_Server_API/app/services/quiz_generator.py
@@ -31,6 +31,7 @@ from tldw_Server_API.app.services.osce_generator import (
     generate_osce_stations_from_sources,
 )
 from tldw_Server_API.app.services.osce_practice import utc_now
+from tldw_Server_API.app.services.quiz_generation_metrics import QuizGenerationMetrics
 from tldw_Server_API.app.services.quiz_source_resolver import resolve_quiz_sources
 
 if TYPE_CHECKING:
@@ -1790,123 +1791,220 @@ async def generate_quiz_from_sources(
     workspace_tag: str | None = None,
 ) -> dict[str, Any]:
     """Generate a quiz from mixed sources (media, notes, flashcard decks/cards)."""
-    normalized_profile = _normalize_generation_profile(generation_profile)
-    normalized_sources = _normalize_sources(sources)
-    evidence = await asyncio.to_thread(
-        resolve_quiz_sources,
-        normalized_sources,
-        db=db,
-        media_db=media_db,
-    )
-
-    plan = _coerce_generation_plan(
-        num_questions=num_questions,
-        question_types=question_types,
-        question_plan=question_plan,
-        generation_profile=normalized_profile,
-    )
-    normalized_types = [item["question_type"] for item in plan]
-    focus_instructions = [_build_generation_profile_instruction(normalized_profile)]
-    if focus_topics:
-        focus_instructions.append(f"- Focus on these topics: {', '.join(t for t in focus_topics if t)}")
-    focus_instruction = "\n".join(focus_instructions)
-    source_contract = _build_source_contract(normalized_sources)
-    primary_media_id = _resolve_primary_media_id(normalized_sources)
-    quiz_title, quiz_description = await asyncio.to_thread(
-        _resolve_generated_quiz_metadata,
-        media_db=media_db,
-        normalized_sources=normalized_sources,
-        primary_media_id=primary_media_id,
-    )
-
-    if normalized_profile == "osce_scenario":
-        bundle = await generate_osce_stations_from_sources(
-            evidence=evidence,
-            normalized_sources=normalized_sources,
-            num_stations=num_stations,
-            difficulty=difficulty,
-            focus_topics=focus_topics or [],
-            model=model,
-            api_provider=api_provider,
-            verification_provider=claims_verification_provider,
-            verification_model=claims_verification_model,
+    with QuizGenerationMetrics() as metrics:
+        normalized_profile = _normalize_generation_profile(generation_profile)
+        metrics.profile = normalized_profile
+        normalized_sources = _normalize_sources(sources)
+        metrics.start(normalized_sources)
+        evidence = await asyncio.to_thread(
+            resolve_quiz_sources,
+            normalized_sources,
+            db=db,
+            media_db=media_db,
         )
-        verification_timestamp = utc_now()
-        verification_units = build_osce_verification_units(bundle.stations)
-        station_rows = [
-            {
-                "content": station.model_dump(mode="json"),
-                "order_index": index,
-                "origin": "generated",
-                "provenance": bundle.provenance,
-                "source_bundle": normalized_sources,
-                "verification_state": "source_verified",
-                "verification_timestamp": verification_timestamp,
-                "verification_summary": (
-                    f"Verified {len(verification_units)} evidence units against "
-                    f"{len(normalized_sources)} canonical sources."
-                ),
-            }
-            for index, station in enumerate(bundle.stations)
-        ]
-        try:
-            quiz, persisted_stations = await asyncio.to_thread(
-                db.create_quiz_with_osce_stations_atomic,
-                {
-                    "name": f"OSCE: {quiz_title}" if quiz_title else "OSCE: Mixed Sources",
-                    "description": "Auto-generated source-backed OSCE practice stations",
-                    "workspace_id": workspace_id,
-                    "workspace_tag": workspace_tag,
-                    "media_id": primary_media_id,
-                    "source_bundle_json": normalized_sources,
-                    "activity_type": "osce",
-                    "generation_profile": normalized_profile,
-                },
-                station_rows,
-            )
-        except Exception as exc:
-            logger.warning(
-                "OSCE atomic persistence failed client={} exception={}",
-                str(db.client_id)[:128],
-                type(exc).__name__,
-            )
-            raise OsceVerificationError() from exc
-        projected_stations = [
-            OsceStationAuthoringResponse.model_validate(
-                {
-                    field_name: station[field_name]
-                    for field_name in OsceStationAuthoringResponse.model_fields
-                }
-            ).model_dump(mode="json")
-            for station in persisted_stations
-        ]
-        return {
-            "output_kind": "osce_stations",
-            "quiz": quiz,
-            "questions": [],
-            "osce_stations": projected_stations,
-            "claim_verification": bundle.verification_result.to_dict(),
-        }
 
-    if _should_use_deterministic_test_mode():
-        questions = _build_test_mode_questions(
-            evidence=evidence,
-            normalized_sources=normalized_sources,
+        metrics.phase = "validation"
+        plan = _coerce_generation_plan(
             num_questions=num_questions,
+            question_types=question_types,
+            question_plan=question_plan,
+            generation_profile=normalized_profile,
+        )
+        normalized_types = [item["question_type"] for item in plan]
+        focus_instructions = [_build_generation_profile_instruction(normalized_profile)]
+        if focus_topics:
+            focus_instructions.append(f"- Focus on these topics: {', '.join(t for t in focus_topics if t)}")
+        focus_instruction = "\n".join(focus_instructions)
+        source_contract = _build_source_contract(normalized_sources)
+        primary_media_id = _resolve_primary_media_id(normalized_sources)
+        metrics.phase = "runtime"
+        quiz_title, quiz_description = await asyncio.to_thread(
+            _resolve_generated_quiz_metadata,
+            media_db=media_db,
+            normalized_sources=normalized_sources,
+            primary_media_id=primary_media_id,
+        )
+
+        if normalized_profile == "osce_scenario":
+            metrics.phase = "osce"
+            bundle = await generate_osce_stations_from_sources(
+                evidence=evidence,
+                normalized_sources=normalized_sources,
+                num_stations=num_stations,
+                difficulty=difficulty,
+                focus_topics=focus_topics or [],
+                model=model,
+                api_provider=api_provider,
+                verification_provider=claims_verification_provider,
+                verification_model=claims_verification_model,
+            )
+            metrics.phase = "runtime"
+            verification_timestamp = utc_now()
+            verification_units = build_osce_verification_units(bundle.stations)
+            station_rows = [
+                {
+                    "content": station.model_dump(mode="json"),
+                    "order_index": index,
+                    "origin": "generated",
+                    "provenance": bundle.provenance,
+                    "source_bundle": normalized_sources,
+                    "verification_state": "source_verified",
+                    "verification_timestamp": verification_timestamp,
+                    "verification_summary": (
+                        f"Verified {len(verification_units)} evidence units against "
+                        f"{len(normalized_sources)} canonical sources."
+                    ),
+                }
+                for index, station in enumerate(bundle.stations)
+            ]
+            try:
+                quiz, persisted_stations = await asyncio.to_thread(
+                    db.create_quiz_with_osce_stations_atomic,
+                    {
+                        "name": f"OSCE: {quiz_title}" if quiz_title else "OSCE: Mixed Sources",
+                        "description": "Auto-generated source-backed OSCE practice stations",
+                        "workspace_id": workspace_id,
+                        "workspace_tag": workspace_tag,
+                        "media_id": primary_media_id,
+                        "source_bundle_json": normalized_sources,
+                        "activity_type": "osce",
+                        "generation_profile": normalized_profile,
+                    },
+                    station_rows,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "OSCE atomic persistence failed client={} exception={}",
+                    str(db.client_id)[:128],
+                    type(exc).__name__,
+                )
+                raise OsceVerificationError() from exc
+            projected_stations = [
+                OsceStationAuthoringResponse.model_validate(
+                    {
+                        field_name: station[field_name]
+                        for field_name in OsceStationAuthoringResponse.model_fields
+                    }
+                ).model_dump(mode="json")
+                for station in persisted_stations
+            ]
+            return {
+                "output_kind": "osce_stations",
+                "quiz": quiz,
+                "questions": [],
+                "osce_stations": projected_stations,
+                "claim_verification": bundle.verification_result.to_dict(),
+            }
+
+        metrics.phase = "validation"
+        if _should_use_deterministic_test_mode():
+            questions = _build_test_mode_questions(
+                evidence=evidence,
+                normalized_sources=normalized_sources,
+                num_questions=num_questions,
+                question_types=normalized_types,
+                question_plan=plan if question_plan else None,
+                generation_profile=normalized_profile,
+            )
+            questions = _limit_questions_by_profile(
+                questions,
+                num_questions=num_questions,
+                generation_profile=normalized_profile,
+            )
+            if normalized_profile == "emq":
+                _validate_emq_groups(questions)
+            _validate_strict_provenance(questions, normalized_sources)
+            if normalized_profile == ASSERTION_REASONING_TAG:
+                _validate_assertion_reasoning_questions(questions)
+            metrics.phase = "provider"
+            claim_verification = await _verify_quiz_questions_against_sources(
+                questions=questions,
+                evidence=evidence,
+                generation_provider=api_provider or DEFAULT_LLM_PROVIDER,
+                generation_model=model,
+                verification_provider=claims_verification_provider,
+                verification_model=claims_verification_model,
+            )
+            metrics.phase = "validation"
+            claim_verification_payload = claim_verification.to_dict()
+            if claim_verification.verdict != "grounded":
+                raise QuizClaimVerificationError(claim_verification_payload)
+            metrics.phase = "runtime"
+            result = await asyncio.to_thread(
+                _persist_generated_quiz,
+                db=db,
+                normalized_sources=normalized_sources,
+                questions=questions,
+                quiz_title=quiz_title,
+                quiz_description=quiz_description,
+                primary_media_id=primary_media_id,
+                workspace_id=workspace_id,
+                workspace_tag=workspace_tag,
+            )
+            result["claim_verification"] = claim_verification_payload
+            result["output_kind"] = "questions"
+            result["osce_stations"] = []
+            return result
+
+        content = _build_content_from_evidence(evidence)
+
+        prompt_question_count = max(2, num_questions) if normalized_profile == "emq" else num_questions
+        prompt = _format_quiz_generation_prompt(
+            num_questions=prompt_question_count,
+            content=content,
+            difficulty=difficulty,
             question_types=normalized_types,
+            focus_instruction=focus_instruction,
+            source_contract=source_contract,
             question_plan=plan if question_plan else None,
             generation_profile=normalized_profile,
         )
-        questions = _limit_questions_by_profile(
-            questions,
-            num_questions=num_questions,
-            generation_profile=normalized_profile,
-        )
+
+        llm_kwargs: dict[str, Any] = {
+            "prompt": prompt,
+            "model": model,
+            "max_tokens": min(8000, max(2000, num_questions * 220)),
+        }
+        if api_provider:
+            llm_kwargs["api_provider"] = api_provider
+        metrics.phase = "provider"
+        raw_response = await _call_quiz_generation_llm(**llm_kwargs)
+        metrics.phase = "validation"
+        content_text = extract_response_content(raw_response)
+        payload = _extract_json_payload(content_text if content_text is not None else raw_response)
+        raw_questions = payload.get("questions") if isinstance(payload, dict) else payload
+        if not isinstance(raw_questions, list):
+            raise ValueError("LLM response did not include a questions list")
+
+        default_source = normalized_sources[0]
+        if question_plan and normalized_profile in {"standard_recall", "mixed_assessment"}:
+            questions = _normalize_planned_questions(
+                raw_questions,
+                plan,
+                default_source_type=default_source["source_type"],
+                default_source_id=default_source["source_id"],
+            )
+        else:
+            questions = _normalize_questions(
+                raw_questions,
+                default_source_type=default_source["source_type"],
+                default_source_id=default_source["source_id"],
+                generation_profile=normalized_profile,
+            )
+            questions = _limit_questions_by_profile(
+                questions,
+                num_questions=num_questions,
+                generation_profile=normalized_profile,
+            )
+        if not questions:
+            raise ValueError("No valid questions generated")
         if normalized_profile == "emq":
             _validate_emq_groups(questions)
         _validate_strict_provenance(questions, normalized_sources)
         if normalized_profile == ASSERTION_REASONING_TAG:
             _validate_assertion_reasoning_questions(questions)
+
+        metrics.phase = "provider"
         claim_verification = await _verify_quiz_questions_against_sources(
             questions=questions,
             evidence=evidence,
@@ -1915,9 +2013,12 @@ async def generate_quiz_from_sources(
             verification_provider=claims_verification_provider,
             verification_model=claims_verification_model,
         )
+        metrics.phase = "validation"
         claim_verification_payload = claim_verification.to_dict()
         if claim_verification.verdict != "grounded":
             raise QuizClaimVerificationError(claim_verification_payload)
+
+        metrics.phase = "runtime"
         result = await asyncio.to_thread(
             _persist_generated_quiz,
             db=db,
@@ -1933,90 +2034,6 @@ async def generate_quiz_from_sources(
         result["output_kind"] = "questions"
         result["osce_stations"] = []
         return result
-
-    content = _build_content_from_evidence(evidence)
-
-    prompt_question_count = max(2, num_questions) if normalized_profile == "emq" else num_questions
-    prompt = _format_quiz_generation_prompt(
-        num_questions=prompt_question_count,
-        content=content,
-        difficulty=difficulty,
-        question_types=normalized_types,
-        focus_instruction=focus_instruction,
-        source_contract=source_contract,
-        question_plan=plan if question_plan else None,
-        generation_profile=normalized_profile,
-    )
-
-    llm_kwargs: dict[str, Any] = {
-        "prompt": prompt,
-        "model": model,
-        "max_tokens": min(8000, max(2000, num_questions * 220)),
-    }
-    if api_provider:
-        llm_kwargs["api_provider"] = api_provider
-    raw_response = await _call_quiz_generation_llm(**llm_kwargs)
-    content_text = extract_response_content(raw_response)
-    payload = _extract_json_payload(content_text if content_text is not None else raw_response)
-    raw_questions = payload.get("questions") if isinstance(payload, dict) else payload
-    if not isinstance(raw_questions, list):
-        raise ValueError("LLM response did not include a questions list")
-
-    default_source = normalized_sources[0]
-    if question_plan and normalized_profile in {"standard_recall", "mixed_assessment"}:
-        questions = _normalize_planned_questions(
-            raw_questions,
-            plan,
-            default_source_type=default_source["source_type"],
-            default_source_id=default_source["source_id"],
-        )
-    else:
-        questions = _normalize_questions(
-            raw_questions,
-            default_source_type=default_source["source_type"],
-            default_source_id=default_source["source_id"],
-            generation_profile=normalized_profile,
-        )
-        questions = _limit_questions_by_profile(
-            questions,
-            num_questions=num_questions,
-            generation_profile=normalized_profile,
-        )
-    if not questions:
-        raise ValueError("No valid questions generated")
-    if normalized_profile == "emq":
-        _validate_emq_groups(questions)
-    _validate_strict_provenance(questions, normalized_sources)
-    if normalized_profile == ASSERTION_REASONING_TAG:
-        _validate_assertion_reasoning_questions(questions)
-
-    claim_verification = await _verify_quiz_questions_against_sources(
-        questions=questions,
-        evidence=evidence,
-        generation_provider=api_provider or DEFAULT_LLM_PROVIDER,
-        generation_model=model,
-        verification_provider=claims_verification_provider,
-        verification_model=claims_verification_model,
-    )
-    claim_verification_payload = claim_verification.to_dict()
-    if claim_verification.verdict != "grounded":
-        raise QuizClaimVerificationError(claim_verification_payload)
-
-    result = await asyncio.to_thread(
-        _persist_generated_quiz,
-        db=db,
-        normalized_sources=normalized_sources,
-        questions=questions,
-        quiz_title=quiz_title,
-        quiz_description=quiz_description,
-        primary_media_id=primary_media_id,
-        workspace_id=workspace_id,
-        workspace_tag=workspace_tag,
-    )
-    result["claim_verification"] = claim_verification_payload
-    result["output_kind"] = "questions"
-    result["osce_stations"] = []
-    return result
 
 
 async def generate_quiz_from_media(

--- a/tldw_Server_API/tests/Quizzes/test_quiz_generation_metrics.py
+++ b/tldw_Server_API/tests/Quizzes/test_quiz_generation_metrics.py
@@ -1,0 +1,682 @@
+"""Exercise generation observability through the public service and real registry."""
+
+import asyncio
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tldw_Server_API.app.core.Claims_Extraction.artifact_verification import ArtifactVerificationResult
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
+from tldw_Server_API.app.core.exceptions import (
+    BadRequestError,
+    OsceCitationError,
+    OsceProviderError,
+    OsceVerificationError,
+    QuizMalformedOutputError,
+)
+from tldw_Server_API.app.core.Metrics import metrics_manager
+from tldw_Server_API.app.core.Metrics.metrics_manager import MetricsRegistry
+from tldw_Server_API.app.services import osce_generator, quiz_generation_metrics, quiz_generator
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def registry(monkeypatch: pytest.MonkeyPatch) -> MetricsRegistry:
+    """Use an isolated real registry without changing other tests' singleton."""
+    value = MetricsRegistry()
+    monkeypatch.setattr(metrics_manager, "_metrics_registry", value)
+    return value
+
+
+@pytest.fixture
+def generation_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[dict]:
+    """Provide real SQLite persistence and a deterministic source-backed generator."""
+    monkeypatch.setenv("TEST_MODE", "1")
+    db = CharactersRAGDB(str(tmp_path / "quizzes.db"), client_id="metrics-test")
+    media_db = MediaDatabase(str(tmp_path / "media.db"), client_id="metrics-test")
+    note_id = db.add_note(
+        title="Private source title",
+        content="Warfarin requires INR monitoring and review of important bleeding warning signs.",
+    )
+    try:
+        yield {
+            "db": db,
+            "media_db": media_db,
+            "sources": [{"source_type": "note", "source_id": str(note_id)}],
+            "num_questions": 2,
+        }
+    finally:
+        db.close_connection()
+        media_db.close_connection()
+
+
+@pytest.mark.parametrize(
+    "profile",
+    ["standard_recall", "mixed_assessment", "best_of_five", "emq", "assertion_reasoning", "osce_scenario"],
+)
+async def test_success_records_one_generation_for_every_profile(
+    profile: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Count one request, one successful outcome, and one duration across all profiles."""
+    result = await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile=profile)
+
+    assert result["quiz"]["id"]
+    labels = {"profile": profile, "source_type": "note"}
+    assert registry.get_cumulative_counter("quiz_generation_requests_total", labels) == 1
+    outcome = {**labels, "outcome": "success"}
+    assert registry.get_cumulative_counter("quiz_generation_outcomes_total", outcome) == 1
+    stats = registry.get_metric_stats("quiz_generation_duration_seconds", labels=outcome)
+    assert stats["count"] == 1
+    assert stats["latest"] >= 0
+
+
+async def test_request_is_counted_while_generation_is_in_flight(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expose started work before a provider has produced its final outcome."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def provider(**kwargs: object) -> dict:
+        """Hold generation open until the test releases the provider."""
+        entered.set()
+        await release.wait()
+        return {"questions": []}
+
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", provider)
+    task = asyncio.create_task(quiz_generator.generate_quiz_from_sources(**generation_args))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        assert (
+            registry.get_cumulative_counter(
+                "quiz_generation_requests_total",
+                {"profile": "standard_recall", "source_type": "note"},
+            )
+            == 1
+        )
+        assert registry.get_cumulative_counter_total("quiz_generation_outcomes_total") == 0
+    finally:
+        release.set()
+        with pytest.raises(ValueError, match="No valid questions"):
+            await task
+
+
+@pytest.mark.parametrize("duplicate", [False, True])
+async def test_source_labels_collapse_mixed_types_but_not_duplicate_notes(
+    duplicate: bool,
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Count a mixed-source invocation once, independent of source count or identifiers."""
+    if duplicate:
+        generation_args["sources"].append(dict(generation_args["sources"][0]))
+    else:
+        card_id = generation_args["db"].add_flashcard({"front": "Warfarin", "back": "Regular INR monitoring."})
+        generation_args["sources"].append({"source_type": "flashcard_card", "source_id": str(card_id)})
+
+    await quiz_generator.generate_quiz_from_sources(**generation_args)
+
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_requests_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "note" if duplicate else "mixed",
+            },
+        )
+        == 1
+    )
+    assert registry.get_cumulative_counter_total("quiz_generation_requests_total") == 1
+
+
+@pytest.mark.parametrize("raw_response", ["not valid JSON", {"questions": []}])
+async def test_malformed_output_is_validation_failure(
+    raw_response: object,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Differentiate rejected generated output from a failed provider invocation."""
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", AsyncMock(return_value=raw_response))
+    with pytest.raises(ValueError):
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "note",
+                "outcome": "validation_error",
+            },
+        )
+        == 1
+    )
+    assert generation_args["db"].list_quizzes()["count"] == 0
+
+
+@pytest.mark.parametrize("error_type", [ValueError, RuntimeError, TimeoutError])
+async def test_provider_errors_preserve_exception_and_are_not_validation_failures(
+    error_type: type[Exception],
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classify by the failing phase, not just a provider's exception base class."""
+    error = error_type("private provider response")
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", AsyncMock(side_effect=error))
+    with pytest.raises(error_type) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert caught.value is error
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "note",
+                "outcome": "provider_error",
+            },
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize("profile", ["standard_recall", "osce_scenario"])
+async def test_persistence_error_is_runtime_failure_even_when_wrapped_by_osce(
+    profile: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not mislabel OSCE persistence's existing verification error as invalid output."""
+    method = "create_quiz_with_osce_stations_atomic" if profile == "osce_scenario" else "create_quiz"
+    error = ValueError("private database detail")
+    monkeypatch.setattr(generation_args["db"], method, Mock(side_effect=error))
+    with pytest.raises(OsceVerificationError if profile == "osce_scenario" else ValueError) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile=profile)
+    assert (caught.value.__cause__ if profile == "osce_scenario" else caught.value) is error
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": profile,
+                "source_type": "note",
+                "outcome": "runtime_error",
+            },
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    ("error_type", "outcome"),
+    [
+        (OsceCitationError, "validation_error"),
+        (OsceVerificationError, "validation_error"),
+        (OsceProviderError, "provider_error"),
+    ],
+)
+async def test_osce_generation_errors_keep_their_public_identity(
+    error_type: type[Exception],
+    outcome: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use OSCE's typed pre-persistence errors without exposing private details."""
+    error = error_type("private detail")
+    monkeypatch.setattr(quiz_generator, "generate_osce_stations_from_sources", AsyncMock(side_effect=error))
+    with pytest.raises(error_type) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile="osce_scenario")
+    assert caught.value is error
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "osce_scenario",
+                "source_type": "note",
+                "outcome": outcome,
+            },
+        )
+        == 1
+    )
+
+
+async def test_cancellation_is_preserved_and_observed(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Record cancellation once without swallowing or replacing CancelledError."""
+    error = asyncio.CancelledError()
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", AsyncMock(side_effect=error))
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert caught.value is error
+    labels = {"profile": "standard_recall", "source_type": "note", "outcome": "cancelled"}
+    assert registry.get_cumulative_counter("quiz_generation_outcomes_total", labels) == 1
+    assert registry.get_metric_stats("quiz_generation_duration_seconds", labels=labels)["count"] == 1
+
+
+async def test_unknown_profile_is_bounded_and_still_counted(
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Never put an arbitrary rejected profile name into metric labels."""
+    with pytest.raises(BadRequestError):
+        await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile="private-user-profile")
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "unknown",
+                "source_type": "unknown",
+                "outcome": "validation_error",
+            },
+        )
+        == 1
+    )
+    assert registry.get_cumulative_counter_total("quiz_generation_requests_total") == 1
+    assert "private-user-profile" not in registry.export_prometheus_format()
+
+
+@pytest.mark.parametrize("fail_generation", [False, True])
+@pytest.mark.parametrize("failure_point", ["lookup", "registration", "increment", "observe"])
+async def test_metrics_failures_do_not_change_generation_results_or_errors(
+    fail_generation: bool,
+    failure_point: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registry outages at each write boundary must not affect the underlying operation."""
+    error = QuizMalformedOutputError("original private error")
+    if fail_generation:
+        monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", AsyncMock(side_effect=error))
+
+    def unavailable(*args: object, **kwargs: object) -> None:
+        """Simulate an unavailable metrics registry without changing application dependencies."""
+        raise RuntimeError("private metrics backend detail")
+
+    if failure_point == "lookup":
+        monkeypatch.setattr(metrics_manager, "get_metrics_registry", unavailable)
+    elif failure_point == "registration":
+        monkeypatch.setattr(metrics_manager, "_metrics_registry", None)
+        monkeypatch.setattr(MetricsRegistry, "_register_standard_metrics", unavailable)
+    else:
+        monkeypatch.setattr(registry, failure_point, unavailable)
+    if fail_generation:
+        with pytest.raises(QuizMalformedOutputError) as caught:
+            await quiz_generator.generate_quiz_from_sources(**generation_args)
+        assert caught.value is error
+    else:
+        result = await quiz_generator.generate_quiz_from_sources(**generation_args)
+        assert len(result["questions"]) == 2
+    if failure_point == "increment":
+        assert registry.get_metric_stats("quiz_generation_duration_seconds")["count"] == 1
+    elif failure_point == "observe":
+        assert registry.get_cumulative_counter_total("quiz_generation_outcomes_total") == 1
+
+
+async def test_metric_definitions_survive_registry_reset_and_export_histogram(
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Export a registered histogram with explicit buckets after a registry reset."""
+    registry.reset()
+    await quiz_generator.generate_quiz_from_sources(**generation_args)
+    exported = registry.export_prometheus_format()
+    assert "# TYPE quiz_generation_requests_total counter" in exported
+    assert "# TYPE quiz_generation_outcomes_total counter" in exported
+    assert "# TYPE quiz_generation_duration_seconds histogram" in exported
+    assert any(
+        line.startswith("quiz_generation_duration_seconds_bucket{") and 'le="60"' in line
+        for line in exported.splitlines()
+    )
+    assert "Private source title" not in exported
+    assert generation_args["sources"][0]["source_id"] not in exported
+
+
+async def test_duration_uses_monotonic_elapsed_time_even_for_failed_generation(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Observe the whole failed attempt rather than wall-clock timestamps or success only."""
+    clock = Mock(return_value=100.0)
+    monkeypatch.setattr(time, "perf_counter", clock)
+
+    async def provider(**kwargs: object) -> dict:
+        """Advance a deterministic elapsed clock before returning invalid output."""
+        clock.return_value = 102.5
+        return {"questions": []}
+
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", provider)
+    with pytest.raises(ValueError, match="No valid questions"):
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    stats = registry.get_metric_stats(
+        "quiz_generation_duration_seconds",
+        labels={
+            "profile": "standard_recall",
+            "source_type": "note",
+            "outcome": "validation_error",
+        },
+    )
+    assert stats["latest"] == 2.5
+
+
+@pytest.mark.parametrize(
+    ("source_type", "label"),
+    [
+        ("media", "media"),
+        ("note", "note"),
+        ("flashcard_deck", "flashcard_deck"),
+        ("flashcard_card", "flashcard_card"),
+        ("quiz_attempt", "quiz_attempt"),
+        ("quiz_attempt_question", "quiz_attempt_question"),
+        ("private-source-type", "unknown"),
+    ],
+)
+async def test_source_resolution_failures_keep_only_allowlisted_type_labels(
+    source_type: str,
+    label: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep source labels bounded even when resolution fails before generation begins."""
+    generation_args["sources"] = [{"source_type": source_type, "source_id": "private-source-id"}]
+    monkeypatch.setattr(
+        quiz_generator, "resolve_quiz_sources", Mock(side_effect=RuntimeError("private source content"))
+    )
+    with pytest.raises(RuntimeError):
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": label,
+                "outcome": "runtime_error",
+            },
+        )
+        == 1
+    )
+    assert "private" not in registry.export_prometheus_format()
+
+
+async def test_invalid_sources_record_known_profile_without_resolving_sources(
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Count attempts rejected before source resolution without losing the normalized profile."""
+    generation_args["sources"] = []
+    with pytest.raises(ValueError, match="At least one source"):
+        await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile="bof")
+    labels = {"profile": "best_of_five", "source_type": "unknown"}
+    assert registry.get_cumulative_counter("quiz_generation_requests_total", labels) == 1
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                **labels,
+                "outcome": "validation_error",
+            },
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize("failure", ["failed", "needs_revision", "provider"])
+async def test_verification_rejection_is_distinct_from_verifier_failure(
+    failure: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed source-grounding verdict is validation, while a verifier outage is operational."""
+    monkeypatch.setenv("TEST_MODE", "0")
+    monkeypatch.setattr(
+        quiz_generator,
+        "_call_quiz_generation_llm",
+        AsyncMock(
+            return_value={
+                "questions": [
+                    {
+                        "question_type": "multiple_choice",
+                        "question_text": "Which test monitors warfarin?",
+                        "options": ["INR", "HbA1c", "CRP", "Sodium"],
+                        "correct_answer": 0,
+                        "source_citations": [generation_args["sources"][0]],
+                    }
+                ]
+            }
+        ),
+    )
+    error = ValueError("private verifier response")
+    verifier = (
+        AsyncMock(side_effect=error)
+        if failure == "provider"
+        else AsyncMock(
+            return_value=ArtifactVerificationResult(
+                verdict=failure,
+                report={},
+                unit_results=[],
+                metadata={},
+            )
+        )
+    )
+    monkeypatch.setattr(quiz_generator, "verify_generated_artifact_against_sources", verifier)
+    with pytest.raises(ValueError) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    if failure == "provider":
+        assert caught.value is error
+    else:
+        assert isinstance(caught.value, quiz_generator.QuizClaimVerificationError)
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "note",
+                "outcome": "provider_error" if failure == "provider" else "validation_error",
+            },
+        )
+        == 1
+    )
+
+
+async def test_legacy_media_wrapper_does_not_double_count(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy entry point delegates to the same single observation boundary."""
+    monkeypatch.setattr(
+        quiz_generator,
+        "resolve_quiz_sources",
+        Mock(
+            return_value=[
+                {
+                    "source_type": "media",
+                    "source_id": "42",
+                    "text": "Warfarin requires INR monitoring.",
+                }
+            ]
+        ),
+    )
+    await quiz_generator.generate_quiz_from_media(
+        db=generation_args["db"],
+        media_db=generation_args["media_db"],
+        media_id=42,
+        num_questions=1,
+    )
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_requests_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "media",
+            },
+        )
+        == 1
+    )
+    assert registry.get_cumulative_counter_total("quiz_generation_outcomes_total") == 1
+
+
+async def test_concurrent_attempts_do_not_share_phase_or_profile_labels(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interleaved provider and validation failures retain independent per-request state."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def provider(**kwargs: object) -> dict:
+        """Interleave two different profiles at the provider boundary."""
+        if kwargs.get("model") == "blocked-provider":
+            entered.set()
+            await release.wait()
+            raise ValueError("provider failure")
+        return {"questions": []}
+
+    monkeypatch.setattr(quiz_generator, "_call_quiz_generation_llm", provider)
+    blocked = asyncio.create_task(
+        quiz_generator.generate_quiz_from_sources(
+            **generation_args,
+            generation_profile="best_of_five",
+            model="blocked-provider",
+        )
+    )
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        with pytest.raises(ValueError, match="No valid questions"):
+            await quiz_generator.generate_quiz_from_sources(**generation_args)
+    finally:
+        release.set()
+        with pytest.raises(ValueError, match="provider failure"):
+            await blocked
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "best_of_five",
+                "source_type": "note",
+                "outcome": "provider_error",
+            },
+        )
+        == 1
+    )
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "note",
+                "outcome": "validation_error",
+            },
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize("failure_point", ["clock", "logging"])
+async def test_secondary_observability_failures_cannot_break_generation(
+    failure_point: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clock or fallback-logger failures must not turn successful generation into an error."""
+    broken = Mock(side_effect=RuntimeError("private metrics failure"))
+    if failure_point == "clock":
+        monkeypatch.setattr(quiz_generation_metrics, "time", SimpleNamespace(perf_counter=broken))
+    else:
+        monkeypatch.setattr(metrics_manager, "get_metrics_registry", broken)
+        monkeypatch.setattr(quiz_generation_metrics, "logger", SimpleNamespace(debug=broken))
+    result = await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert len(result["questions"]) == 2
+    if failure_point == "clock":
+        assert registry.get_cumulative_counter_total("quiz_generation_outcomes_total") == 1
+
+
+@pytest.mark.parametrize("error_type", [TimeoutError, ValueError])
+async def test_osce_verifier_outage_is_operational_after_wrapping(
+    error_type: type[Exception],
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the real OSCE verifier boundary, including its public error wrapper."""
+    error = error_type("private verification service failure")
+    monkeypatch.setattr(osce_generator, "verify_generated_artifact_against_sources", AsyncMock(side_effect=error))
+    with pytest.raises(OsceVerificationError) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args, generation_profile="osce_scenario")
+    assert caught.value.__cause__ is error
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {"profile": "osce_scenario", "source_type": "note", "outcome": "provider_error"},
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize("source_case", ["unsupported", "malformed_id", "missing", "empty"])
+async def test_real_source_rejections_are_validation_failures(
+    source_case: str,
+    generation_args: dict,
+    registry: MetricsRegistry,
+) -> None:
+    """Reject invalid selections without reporting a database or provider outage."""
+    source = {"source_type": "note", "source_id": "missing-private-note"}
+    if source_case == "unsupported":
+        source["source_type"] = "untrusted-private-type"
+    elif source_case == "malformed_id":
+        source = {"source_type": "media", "source_id": "not-an-integer"}
+    elif source_case == "empty":
+        source["source_id"] = generation_args["db"].add_note(title="Empty", content="")
+    generation_args["sources"] = [source]
+    with pytest.raises(ValueError):
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {
+                "profile": "standard_recall",
+                "source_type": "unknown" if source_case == "unsupported" else source["source_type"],
+                "outcome": "validation_error",
+            },
+        )
+        == 1
+    )
+
+
+async def test_source_database_outage_remains_runtime_failure(
+    generation_args: dict,
+    registry: MetricsRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolver's database exception must not become a source validation rejection."""
+    error = RuntimeError("private database connection failure")
+    monkeypatch.setattr(generation_args["db"], "get_note_by_id", Mock(side_effect=error))
+    with pytest.raises(RuntimeError) as caught:
+        await quiz_generator.generate_quiz_from_sources(**generation_args)
+    assert caught.value is error
+    assert (
+        registry.get_cumulative_counter(
+            "quiz_generation_outcomes_total",
+            {"profile": "standard_recall", "source_type": "note", "outcome": "runtime_error"},
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary

- What changed: Implement TASK-12102.3.7 with registered quiz generation request/outcome counters and an end-to-end latency histogram across all six profiles, including OSCE and the legacy media delegate.
- Why: Instrument the shared backend service and existing registry so the WebUI and extension receive consistent coverage without frontend changes, a new telemetry destination, or duplicated counting. Allowlisted labels exclude content and identifiers; best-effort recording preserves generation results, exceptions, and cancellation.
- Distinguish invalid sources/output and rejected grounding verdicts from provider/verifier outages and persistence failures. Independent review found two classification gaps; both were fixed with actual-path regression tests and re-reviewed without remaining findings.

## Change summary

This PR adds privacy-conscious observability across all six quiz generation profiles, tracking requests, outcomes, and end-to-end latency through the shared backend used by the WebUI and browser extension. It distinguishes validation failures from provider and runtime errors without recording source content or identifiers, and metrics failures cannot disrupt quiz generation. Verification included 640 passing tests and 100% statement coverage of the new metrics helper.

## Validation

- [x] Tests added/updated for behavior changes: 53 public-service metrics cases.
- [x] Relevant unit/integration tests pass locally: 640 passed, 4 skipped across tests/Quizzes and tests/Metrics.
- [x] Docs updated: API metric contracts and design rationale.
- New metrics helper: 100% statement coverage.
- Ruff, compileall, git diff --check, and touched-production Bandit pass; Bandit reports zero findings.
- Four existing PostgreSQL-backed OSCE tests skipped because PostgreSQL was unreachable. Existing pytest warnings and unrelated temporary-directory cleanup warnings remain; no tests disabled.

## UX Audit Checklist (v2 Stage 5)

Not applicable: no frontend behavior, UI, or asset changes. Both clients use the instrumented shared backend service; browser smoke tests were not rerun.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

Not applicable: no Watchlists changes.

## Watchlists Scale Checklist (Group 10 Stage 5)

Not applicable: no Watchlists or polling changes.

## Risk & Rollback

- Risk level: Low. Instrumentation is fail-open and labels are bounded; no response or persistence-schema changes. Registry outages can leave gaps in metric samples.
- Rollback plan: revert this change; no database migration or client deployment is required.

Task: TASK-12102.3.7
Design: Docs/Design/Quiz_Generation_Observability.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded, best-effort observability to the shared quiz generation service: request/outcome counters and a latency histogram for all six profiles, with no new telemetry destination or frontend changes.

Outcomes distinguish validation failures (invalid sources, rejected grounding) from provider/verifier outages and persistence failures. Metrics are fail-open and never include content or identifiers; existing exceptions and results are preserved.

<sup>Written for commit a0b15861486a483847308f1abcc32b1752811921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

